### PR TITLE
Self Mode: stop a launch still in flight being treated as a failure, and stop probing the ROM for logcat on every app launch

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/SelfLaunchTimeoutPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/SelfLaunchTimeoutPolicy.kt
@@ -1,0 +1,56 @@
+package com.andrerinas.openheadunit.aap
+
+/** Which of Self Mode's two bring-up routes a launch attempt took. */
+enum class SelfLaunchPath {
+    /** AA < 17.4: fire `WirelessStartupActivity` and wait for Gearhead to dial our port 5288. */
+    LEGACY,
+
+    /** AA >= 17.4: dial Android Auto's own head unit server on `127.0.0.1:5277` ourselves. */
+    HEADUNIT_SERVER,
+}
+
+/**
+ * How long a Self Mode launch may take before the user is told it did not work, and what may be
+ * torn down when that happens.
+ *
+ * The deadline used to be 2500 ms for both routes, and expiring it called `CommManager.emitError`,
+ * which disconnects. On [SelfLaunchPath.LEGACY] that is self-defeating twice over: the disconnect
+ * takes down the dummy VPN whose `Network` we just handed Gearhead as `PARAM_SERVICE_WIFI_NETWORK`,
+ * and it closes the port 5288 server that is the only way the phone can arrive. Gearhead needs 15
+ * to 20 s on that route, so the deadline expired every time and killed sessions that were working.
+ *
+ * Hence the two rules here. A deadline the slower route can actually meet, and a timeout that
+ * reports without tearing anything down - the launch may still be in flight, and on the head unit
+ * server route a connection dropped before the AAP version exchange leaves that server deaf until
+ * the user restarts it by hand.
+ */
+object SelfLaunchTimeoutPolicy {
+
+    /**
+     * Gearhead has to start `WirelessStartupActivity`, pick up the network it was handed and dial
+     * back over loopback. Measured at 15 to 20 s on a UNISOC head unit, so the deadline is set
+     * clear of that rather than at it.
+     */
+    const val LEGACY_DEADLINE_MS = 30_000L
+
+    /**
+     * Nothing to wait for: `CommManager.connect` is synchronous on this route and has already
+     * reported its own failure by the time the deadline is armed. This only covers a connection
+     * that came up and then lost the AAP handshake.
+     */
+    const val HEADUNIT_SERVER_DEADLINE_MS = 10_000L
+
+    fun deadlineMs(path: SelfLaunchPath): Long = when (path) {
+        SelfLaunchPath.LEGACY -> LEGACY_DEADLINE_MS
+        SelfLaunchPath.HEADUNIT_SERVER -> HEADUNIT_SERVER_DEADLINE_MS
+    }
+
+    /**
+     * Never, on either route, and a test holds that. A timeout means "we have not heard yet", which
+     * is not the same as "nothing is coming" - the answer is to say so, not to remove the things the
+     * answer would arrive on. A route that ever needs a teardown here should justify it in this
+     * function rather than reaching for a disconnect at the call site.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    fun mayDisconnect(path: SelfLaunchPath): Boolean = false
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
@@ -539,9 +539,22 @@ class CommManager(
         }
     }
 
+    /** Reports a failure and tears the connection down with it. */
     suspend fun emitError(msg: String) {
         _connectionState.emit(ConnectionState.Error(msg))
         disconnect()
+    }
+
+    /**
+     * Reports a failure without touching the connection.
+     *
+     * For a caller that has run out of patience rather than out of hope: a Self Mode launch that has
+     * not reported in yet may still be in flight, and the server it will arrive on, plus the dummy
+     * VPN it was handed, both have to stay up for that to happen. See
+     * [com.andrerinas.openheadunit.aap.SelfLaunchTimeoutPolicy.mayDisconnect].
+     */
+    suspend fun reportError(msg: String) {
+        _connectionState.emit(ConnectionState.Error(msg))
     }
 
     /**

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/self/AAPermissionTrampolineActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/self/AAPermissionTrampolineActivity.kt
@@ -7,18 +7,30 @@ import android.os.Bundle
 import android.os.SystemClock
 import com.andrerinas.openheadunit.utils.AppLog
 
-// Display android auto's built-in activity that checks for missing permissions
-// It immediately closes if all needed ones are granted
+/**
+ * Shows Android Auto's own permission check, to find out whether missing permissions are why Self
+ * Mode did not start.
+ *
+ * AA's activity closes immediately when everything is already granted, so a fast return is the
+ * success case, not a failure. It used to be read the other way round - anything under a second
+ * counted as failed - which fired a "Failed to start Android Auto" toast on every healthy start.
+ *
+ * The only failure this can actually observe is not being able to start the activity at all.
+ */
 class PermissionTrampolineActivity : Activity() {
 
     companion object {
         private const val REQUEST_CODE_AA = 1001
-        private const val IMMEDIATE_THRESHOLD_MS = 1000L
 
-        private var onFailCallback: (() -> Unit)? = null
+        private var onResultCallback: ((permissionCheckRan: Boolean) -> Unit)? = null
 
-        fun launch(context: Context, onFail: () -> Unit) {
-            onFailCallback = onFail
+        /**
+         * @param onResult `true` when AA's permission activity ran and returned, whether it closed
+         *   at once or the user worked through it - either way permissions are not the problem.
+         *   `false` when it could not be started, which is the caller's cue to work out why.
+         */
+        fun launch(context: Context, onResult: (permissionCheckRan: Boolean) -> Unit) {
+            onResultCallback = onResult
             val intent = Intent(context, PermissionTrampolineActivity::class.java).apply {
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             }
@@ -41,8 +53,9 @@ class PermissionTrampolineActivity : Activity() {
 
         try {
             startActivityForResult(intent, REQUEST_CODE_AA)
-        } catch (_: Exception) {
-            triggerFail()
+        } catch (e: Exception) {
+            AppLog.w("SelfMode: could not start AA's permission activity: ${e.message}")
+            finishWith(permissionCheckRan = false)
         }
     }
 
@@ -50,26 +63,20 @@ class PermissionTrampolineActivity : Activity() {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == REQUEST_CODE_AA) {
             val durationMs = SystemClock.elapsedRealtime() - launchTimestamp
-
             AppLog.i("SelfMode: AA permissions request took $durationMs ms")
-
-            if (durationMs < IMMEDIATE_THRESHOLD_MS) {
-                triggerFail()
-            } else {
-                cleanup()
-                finish()
-            }
+            finishWith(permissionCheckRan = true)
         }
     }
 
-    private fun triggerFail() {
-        onFailCallback?.invoke()
+    private fun finishWith(permissionCheckRan: Boolean) {
+        val callback = onResultCallback
         cleanup()
+        callback?.invoke(permissionCheckRan)
         finish()
     }
 
     private fun cleanup() {
-        onFailCallback = null
+        onResultCallback = null
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/self/SelfLaunchResolveHelper.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/self/SelfLaunchResolveHelper.kt
@@ -16,12 +16,24 @@ class SelfLaunchResolveHelper(private val service: AapService) {
     }
 
     private fun openPermissionsCheck() {
-        PermissionTrampolineActivity.launch(service) {
-            AppLog.e("SelfMode: Permission activity closed immediately or failed.")
-            onPermissionsCheckFailed()
+        PermissionTrampolineActivity.launch(service) { permissionCheckRan ->
+            if (permissionCheckRan) {
+                // AA's own permission screen ran and came back, so permissions are not why Self
+                // Mode timed out. Nothing more specific is knowable from here.
+                AppLog.w("SelfMode: AA's permissions are in order; the launch timed out for another reason.")
+                ToastUtils.showToast(
+                    service,
+                    service.getString(R.string.failed_start_android_auto),
+                    Toast.LENGTH_LONG
+                )
+            } else {
+                AppLog.e("SelfMode: AA's permission activity could not be started.")
+                onPermissionsCheckFailed()
+            }
         }
     }
 
+    /** Why AA's own permission screen would not open. Only reachable when it did not run at all. */
     private fun onPermissionsCheckFailed() {
         // is AA even installed?
         if (!isAAInstalled()) {

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/self/SelfLauncherManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/self/SelfLauncherManager.kt
@@ -6,6 +6,8 @@ import android.net.Uri
 import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.aap.AapService
 import com.andrerinas.openheadunit.aap.DummyVpnPolicy
+import com.andrerinas.openheadunit.aap.SelfLaunchPath
+import com.andrerinas.openheadunit.aap.SelfLaunchTimeoutPolicy
 import com.andrerinas.openheadunit.connection.self.launchers.SelfLauncherBTDiscovery
 import com.andrerinas.openheadunit.connection.self.launchers.SelfLauncherBroadcast
 import com.andrerinas.openheadunit.connection.self.launchers.SelfLauncherLegacy
@@ -95,14 +97,18 @@ class SelfLauncherManager(
             val services = SelfLauncherServices(service, wifiLauncherManager)
             val launchers: Array<SelfLauncher>
 
+            val path: SelfLaunchPath
+
             if (isAaVersion174OrHigher()) {
                 AppLog.i("SelfMode: AA 17.4+ detected. Connecting directly to Headunit Server on 127.0.0.1:5277...")
+                path = SelfLaunchPath.HEADUNIT_SERVER
                 launchers = arrayOf(
                     SelfLauncherV17_4(this@SelfLauncherManager, services)
                 )
 
             } else {
                 AppLog.i("SelfMode: AA < 17.4 detected. Starting WirelessServer on 5288 and running legacy triggers...")
+                path = SelfLaunchPath.LEGACY
                 launchers = arrayOf(
                     SelfLauncherLegacy(this@SelfLauncherManager, services),
                     SelfLauncherBroadcast(this@SelfLauncherManager, services), // fallback #1
@@ -134,13 +140,20 @@ class SelfLauncherManager(
                 return@launch
             }
 
-            // run a timer to make sure it actually succeeded
+            // Report a launch that has not connected yet, without taking anything down: the
+            // wireless server and the dummy VPN are what the phone still has to arrive on. See
+            // SelfLaunchTimeoutPolicy.
+            val deadlineMs = SelfLaunchTimeoutPolicy.deadlineMs(path)
             service.serviceScope.launch {
-                delay(2500L)
+                delay(deadlineMs)
 
                 if (!commManager.isConnected && isActive) {
-                    AppLog.e("SelfMode: All launchers failed (timeout)")
-                    commManager.emitError("No launch method succeeded (timeout") // hide "connecting" overlay
+                    AppLog.e("SelfMode: nothing connected within ${deadlineMs}ms of the launch")
+                    if (SelfLaunchTimeoutPolicy.mayDisconnect(path)) {
+                        commManager.emitError("No launch method succeeded (timeout)")
+                    } else {
+                        commManager.reportError("No launch method succeeded (timeout)")
+                    }
 
                     handleNeverConnect()
                 }

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/LogExporter.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/LogExporter.kt
@@ -29,29 +29,6 @@ object LogExporter {
     private var captureRestarts = 0
     private const val MAX_RESTARTS = 5
 
-    @Volatile
-    private var cachedLogcatSupported: Boolean? = null
-
-    /**
-     * Checks whether the current process is able to read logcat output.
-     * On older Android versions (e.g. 5.1/7.1) or restricted ROMs without READ_LOGS permission,
-     * logcat exits immediately with 'Permission denied' or empty output.
-     */
-    fun isLogcatSupported(): Boolean {
-        cachedLogcatSupported?.let { return it }
-        return try {
-            val process = Runtime.getRuntime().exec(arrayOf("logcat", "-d", "-t", "1"))
-            val exitCode = process.waitFor()
-            val hasOutput = process.inputStream.bufferedReader().use { it.readLine() != null }
-            val isSupported = exitCode == 0 && hasOutput
-            cachedLogcatSupported = isSupported
-            isSupported
-        } catch (_: Throwable) {
-            cachedLogcatSupported = false
-            false
-        }
-    }
-
     /**
      * Ceiling for one capture file. Sits under [LogFilesHelper]'s 50 MB budget for the whole
      * directory, so a single runaway capture cannot consume it.
@@ -71,15 +48,6 @@ object LogExporter {
      */
     fun startCapture(context: Context, verbosity: LogLevel) {
         val settings = Settings(context)
-
-        // If LOGCAT is selected but logcat is restricted on this device, automatically switch to APPLOG_FILE
-        if (settings.logSource == Settings.LogSource.LOGCAT && !isLogcatSupported()) {
-            AppLog.w("LogExporter: Logcat is not accessible on this device (permission denied/restricted). Automatically switching log source to Direct to file (APPLOG_FILE).")
-            settings.logSource = Settings.LogSource.APPLOG_FILE
-            settings.exporterCaptureEnabled = true
-            AppLog.init(settings, context.applicationContext)
-            return
-        }
 
         if (AppLog.logSource == Settings.LogSource.APPLOG_FILE) {
             AppLog.w("LogExporter: log source is APPLOG_FILE; logcat capture is disabled")
@@ -208,13 +176,18 @@ object LogExporter {
                     try { Thread.sleep(2000) } catch (_: InterruptedException) { return@Thread }
                     launchLogcatPipe(file, verbosity, context)
                 } else if (captureProcess === process && file.length() == 0L) {
+                    // The only reliable test for a ROM that refuses logcat: the capture the user
+                    // asked for ran and produced nothing. Asking beforehand meant spawning logcat
+                    // speculatively, which on Android 13+ raises the system consent dialog.
+                    // exporterCaptureEnabled is deliberately not touched - this branch is only
+                    // reachable from a capture that is already enabled, and the source is the only
+                    // thing being corrected.
                     val err = try { process.errorStream.bufferedReader().readText().trim() } catch (_: Exception) { "" }
                     AppLog.w("LogExporter: Logcat capture produced 0 bytes ($err). Automatically switching to Direct to file (APPLOG_FILE).")
                     file.delete()
                     captureFile = null
                     val settings = Settings(context)
                     settings.logSource = Settings.LogSource.APPLOG_FILE
-                    settings.exporterCaptureEnabled = true
                     AppLog.init(settings, context.applicationContext)
                 }
             }.also { it.isDaemon = true; it.start() }
@@ -260,11 +233,6 @@ object LogExporter {
         AppLog.w(sessionBanner(context))
 
         val settings = Settings(context)
-
-        if (settings.logSource == Settings.LogSource.LOGCAT && !isLogcatSupported()) {
-            AppLog.w("LogExporter: Logcat is not accessible on this device. Switching log source to Direct to file (APPLOG_FILE).")
-            settings.logSource = Settings.LogSource.APPLOG_FILE
-        }
 
         if (AppLog.logSource == Settings.LogSource.APPLOG_FILE) {
             return (AppLog.currentLogFile ?: AppLog.lastLogFile)

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -182,11 +182,18 @@ class Settings(private val context: Context) {
         DOWNLOADS
     }
 
+    /**
+     * Where captured logs come from. Read on every [com.andrerinas.openheadunit.utils.AppLog.init],
+     * including the one in `App.onCreate`, so this getter must not do any work.
+     *
+     * It used to resolve its default by spawning `logcat` to see whether the ROM allows it. That ran
+     * on the main thread at every process start, even when the preference below already answered the
+     * question, and on Android 13+ each spawn raises the system log-access consent dialog. A
+     * restricted ROM is now detected from the capture that actually runs, in [LogExporter]'s
+     * zero-byte branch.
+     */
     var logSource: LogSource
-        get() {
-            val defaultSource = if (LogExporter.isLogcatSupported()) LogSource.LOGCAT else LogSource.APPLOG_FILE
-            return LogSource.entries.getOrElse(prefs.getInt(KEY_LOG_SOURCE, defaultSource.ordinal)) { defaultSource }
-        }
+        get() = LogSource.entries.getOrElse(prefs.getInt(KEY_LOG_SOURCE, LogSource.LOGCAT.ordinal)) { LogSource.LOGCAT }
         set(value) { prefs.edit().putInt(KEY_LOG_SOURCE, value.ordinal).apply() }
 
     var logLocation: LogLocation

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/SelfLaunchTimeoutPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/SelfLaunchTimeoutPolicyTest.kt
@@ -1,0 +1,59 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SelfLaunchTimeoutPolicyTest {
+
+    @Test
+    fun `no route may tear the session down when it runs out of patience`() {
+        // The defect this replaces: the timeout disconnected, which took down the dummy VPN handed
+        // to Gearhead and closed the port 5288 server the phone still had to arrive on.
+        for (path in SelfLaunchPath.values()) {
+            assertFalse(path.name, SelfLaunchTimeoutPolicy.mayDisconnect(path))
+        }
+    }
+
+    @Test
+    fun `every route gets a deadline, and none of them is the old 2500ms`() {
+        for (path in SelfLaunchPath.values()) {
+            val deadline = SelfLaunchTimeoutPolicy.deadlineMs(path)
+            assertTrue("${path.name} deadline is not positive: $deadline", deadline > 0)
+            assertTrue(
+                "${path.name} kept a deadline Gearhead cannot meet: $deadline",
+                deadline > 2_500L
+            )
+        }
+    }
+
+    @Test
+    fun `the legacy route waits longer than the one that dials out itself`() {
+        // Legacy hands Gearhead a network and waits to be called back; the head unit server route
+        // connects synchronously and has already reported its own failure by this point.
+        assertTrue(
+            SelfLaunchTimeoutPolicy.deadlineMs(SelfLaunchPath.LEGACY) >
+                SelfLaunchTimeoutPolicy.deadlineMs(SelfLaunchPath.HEADUNIT_SERVER)
+        )
+    }
+
+    @Test
+    fun `the legacy deadline clears the measured bring-up time`() {
+        // 15 to 20 s measured on a UNISOC head unit. A deadline at that figure would expire on a
+        // run that was merely slow, which is the failure being fixed.
+        assertTrue(SelfLaunchTimeoutPolicy.deadlineMs(SelfLaunchPath.LEGACY) >= 20_000L)
+    }
+
+    @Test
+    fun `the deadlines are the named constants`() {
+        assertEquals(
+            SelfLaunchTimeoutPolicy.LEGACY_DEADLINE_MS,
+            SelfLaunchTimeoutPolicy.deadlineMs(SelfLaunchPath.LEGACY)
+        )
+        assertEquals(
+            SelfLaunchTimeoutPolicy.HEADUNIT_SERVER_DEADLINE_MS,
+            SelfLaunchTimeoutPolicy.deadlineMs(SelfLaunchPath.HEADUNIT_SERVER)
+        )
+    }
+}


### PR DESCRIPTION
## Why

Two regressions that landed after 3.3.0-beta1, in different subsystems, both reported as Self Mode breaking on units where beta1 worked.

The first is a logcat probe. `Settings.logSource` resolved its default by spawning `logcat` and blocking in `waitFor()`. The default was computed before `getOrElse`, so it ran even when the stored preference already answered the question, and `App.onCreate` reaches it through `AppLog.init`, which put it on the main thread at every process start. On Android 13+ each spawn raises the system log-access consent dialog, and `pm grant READ_LOGS` does not suppress it. A test rig measured it firing 55 times across scripted relaunches on one device, once taking SystemUI down with it and once leaving the app alive with no log output for 90 seconds.

The second is a 2500 ms launch watchdog added with the launcher refactor, which called `emitError` and therefore disconnected. On the AA < 17.4 route that removed the two things the phone still had to arrive on: `onDisconnected` takes the dummy VPN down, and that VPN's `Network` is what we hand Gearhead as `PARAM_SERVICE_WIFI_NETWORK`, while `scheduleReconnectIfNeeded` stops the wifi launcher and closes the port 5288 server. Gearhead needs 15 to 20 seconds on that route, and `SelfLauncherLegacy.runWifiLauncher` already spends up to one of them waiting for the VPN to become the active network, so the deadline expired on every attempt and killed sessions that were working. The reporter saw this as Self Mode failing with VPN errors.

A third defect sat downstream of the second and always fired after it. `AAPermissionTrampolineActivity.onActivityResult` treated any return under a second as a failure, even though its own comment says AA's permission activity closes at once when everything is already granted, so a healthy permission check produced "Failed to start Android Auto" every time.

## What changed

| Layer | Change |
|---|---|
| `utils/Settings.kt` | `logSource` goes back to a plain prefs read. The getter documents that it runs on every `AppLog.init` and must not do work. |
| `utils/LogExporter.kt` | `isLogcatSupported()` and its two remaining call sites are removed. The useful half of the original change does not need a probe: `launchLogcatPipe` already detects a ROM that refuses logcat from the capture that actually ran, and that auto-switch stays. The auto-switch no longer writes `exporterCaptureEnabled = true` beside the source change, which was redundant on a branch only reachable from a capture the user already enabled. |
| `aap/SelfLaunchTimeoutPolicy.kt` (new) | A pure policy object holding the two rules: a per-route deadline (30 s legacy, 10 s head unit server) and `mayDisconnect` returning false on both routes. Follows the repo's existing extract-and-unit-test convention for anything decidable without Android. |
| `connection/CommManager.kt` | Adds `reportError`, which says what `emitError` says without the teardown. |
| `connection/self/SelfLauncherManager.kt`, `SelfLaunchResolveHelper.kt` | Take their deadline from the policy and report rather than disconnect on expiry. |
| `connection/self/AAPermissionTrampolineActivity.kt` | A returned result now means permissions are not the problem, whatever it cost. The only failure the trampoline can observe is being unable to start the activity, and that is the one case that still runs the installed / system-app diagnosis. |
| `test/.../SelfLaunchTimeoutPolicyTest.kt` (new) | 5 cases over the deadline table and the no-disconnect rule. |

A phone that arrives after the deadline still connects, because `connect(socket)` guards on `Connecting` and not on `Error`.

The dummy VPN is deliberately untouched. It is how Self Mode gets a non-null `activeNetwork` for our own process, which is why `DummyVpnPolicy.Owner.SELF_MODE` exists.

## Where to focus review

`SelfLaunchTimeoutPolicy.mayDisconnect` returning false unconditionally is the load-bearing rule, and the reason it is a function rather than a constant is so a route that ever needs a teardown has to justify it there instead of reaching for a disconnect at the call site.

The `HEADUNIT_SERVER_DEADLINE_MS` of 10 s covers only a connection that came up and then lost the AAP handshake. `CommManager.connect` is synchronous on that route and has already reported its own failure by the time the deadline is armed. This matters because a connection to AA's head unit server dropped before the AAP version exchange leaves that server deaf until the user restarts it by hand.

The trampoline change inverts a condition. It is worth confirming that losing the sub-second-return signal costs nothing, which is the argument that a returned result at all means the activity ran.

## Verification

Two hardware rounds against `origin/main`, on three devices: a UNISOC MT50 head unit (Android 14, Gearhead 17.3), a POCO X3 (Android 15, Gearhead 17.5) and a Motorola edge 30 neo (Android 14, Gearhead 17.3).

Build and unit tests, `assembleGithubDebug` and `testGithubDebugUnitTest`: candidate 770 tests / 0 failures, baseline 765 / 0. The delta of 5 is `SelfLaunchTimeoutPolicyTest`.

The log probe. The candidate spawns zero app-owned `logcat` on all three devices with capture off, and `MainActivity` resumes in about 1 second on each. The baseline reproduces the consent dialog on the head unit, where it held the foreground for the entire poll unattended and `MainActivity` never resumed. Log capture still works on the candidate: an 81 KB `HUR_Log` carrying the session banner, and the AA session formed while the consent dialog was still on screen, which is the direct evidence that `onCreate` is no longer blocked.

The launch watchdog. Legacy Self Mode forms in 1352 ms and 2033 ms on the two AA-17.3 devices with no teardown, no timeout report and no toast. The AA 17.4+ route on the third device forms and holds a 90 second session unchanged. With a genuine failure forced, the deadline reports at +30.09 s rather than 2.5 s, and neither `releasing the dummy VPN` nor `Self Mode disconnected. Not restarting.` appears anywhere in the capture.

The trampoline. The same forced-failure run shows the corrected reading: `AA permissions request took 316 ms` followed by `AA's permissions are in order; the launch timed out for another reason.` rather than the old `could not be started`.

One thing to be explicit about: the disconnect-on-timeout itself could not be reproduced on the test rig. Self Mode runs over loopback there and connects in 1.2 to 2.0 seconds on all three devices, so the baseline never trips its own 2.5 second deadline and the teardown never fires. That rule is covered by `SelfLaunchTimeoutPolicyTest` and by the candidate's observable behaviour above.

## Risks

The `logSource` default changes from probe-derived to `LOGCAT`. On a ROM that refuses logcat, a user with no stored preference now gets one capture that produces zero bytes before the existing auto-switch moves them to `APPLOG_FILE`, where previously the probe would have chosen that up front. That is one wasted capture, and it is the trade for not spawning `logcat` on every process start.

Raising the legacy deadline from 2.5 s to 30 s means a Self Mode launch that genuinely will not work now takes 30 seconds to say so. That is deliberate: the previous behaviour said so in 2.5 seconds and was wrong nearly every time.
