### PR TITLE
Handle ungraceful disconnects from AA server

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
@@ -551,7 +551,7 @@ class CommManager(
      * For a caller that has run out of patience rather than out of hope: a Self Mode launch that has
      * not reported in yet may still be in flight, and the server it will arrive on, plus the dummy
      * VPN it was handed, both have to stay up for that to happen. See
-     * [com.andrerinas.openheadunit.aap.SelfLaunchTimeoutPolicy.mayDisconnect].
+     * [com.andrerinas.openheadunit.connection.self.SelfLaunchTimeoutPolicy.mayDisconnect].
      */
     suspend fun reportError(msg: String) {
         _connectionState.emit(ConnectionState.Error(msg))

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/projection/SocketProjectionConnection.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/projection/SocketProjectionConnection.kt
@@ -16,6 +16,7 @@ import java.io.OutputStream
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Socket
+import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -29,6 +30,9 @@ class SocketProjectionConnection(
     private var output: OutputStream? = null
     private var input: DataInputStream? = null
     private var transport: Socket
+    // Socket#isConnected might return true, even if server has closed the connection
+    // Only way to capture it is to check for exceptions, E.g. "SocketException: Broken pipe"
+    private var transportBroken: Boolean = false
     // Only true for genuine Nearby tunnels, where the handshake's AA-16.4+ settle delay
     // and stale-byte drain must be skipped because every byte from the start matters.
     // Regular WirelessServer-accepted sockets (Hotspot/WiFi Direct/Headunit Server) and
@@ -57,7 +61,7 @@ class SocketProjectionConnection(
     override val type = ProjectionConnection.Type.WIFI
 
     override val isConnected: Boolean
-        get() = transport.isConnected
+        get() = transport.isConnected && !transportBroken
 
     override val isSingleMessage: Boolean
         get() = singleMessage
@@ -207,10 +211,14 @@ class SocketProjectionConnection(
 
     override fun sendBlocking(buf: ByteArray, length: Int, timeout: Int): Int {
         val out = output ?: return -1
+
         return try {
             out.write(buf, 0, length)
             out.flush()
             length
+        } catch (e: SocketException) {
+            handleBrokenTransport(e)
+            -1
         } catch (e: IOException) {
             AppLog.e(e)
             -1
@@ -229,13 +237,31 @@ class SocketProjectionConnection(
             } else {
                 inp.read(buf, 0, length)
             }
-        } catch (e: SocketTimeoutException) {
+        } catch (_: SocketTimeoutException) {
             // With raw DataInputStream (no BufferedInputStream), timeout during
             // small reads (4-byte header) virtually never causes partial consumption.
             // Let the caller decide if this is fatal based on context.
             0
-        } catch (e: IOException) {
+        } catch (e: SocketException) {
+            handleBrokenTransport(e)
             -1
+        } catch (_: IOException) {
+            -1
+        }
+    }
+
+    private fun handleBrokenTransport(e: SocketException) {
+        AppLog.w("Socket broken (server disconnected ungracefully?)", e)
+        transportBroken = true
+
+        // Force close the stream/socket so the OS frees the file descriptor
+        // If you don't do this, you will eventually cause a memory/handle leak
+        try {
+            output?.close()
+        } catch (_: IOException) {
+        } finally {
+            input = null
+            output = null
         }
     }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/projection/SocketProjectionConnection.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/projection/SocketProjectionConnection.kt
@@ -251,7 +251,7 @@ class SocketProjectionConnection(
     }
 
     private fun handleBrokenTransport(e: SocketException) {
-        AppLog.w("Socket broken (server disconnected ungracefully?)", e)
+        AppLog.e("Socket broken (server disconnected ungracefully?)", e)
         transportBroken = true
 
         // Force close the stream/socket so the OS frees the file descriptor

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/self/AAPermissionTrampolineActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/self/AAPermissionTrampolineActivity.kt
@@ -11,25 +11,28 @@ import com.andrerinas.openheadunit.utils.AppLog
  * Shows Android Auto's own permission check, to find out whether missing permissions are why Self
  * Mode did not start.
  *
- * AA's activity closes immediately when everything is already granted, so a fast return is the
- * success case, not a failure. It used to be read the other way round - anything under a second
- * counted as failed - which fired a "Failed to start Android Auto" toast on every healthy start.
+ * AA's activity closes immediately (within [IMMEDIATE_THRESHOLD_MS]) when everything is already granted.
+ * If the duration is below [IMMEDIATE_THRESHOLD_MS] (or if starting the activity failed), the user already
+ * had all permissions (or check failed), so the cause must be something else (e.g. system app status).
  *
- * The only failure this can actually observe is not being able to start the activity at all.
+ * If the duration is at or above [IMMEDIATE_THRESHOLD_MS], AA's permission activity was displayed to request
+ * missing permissions.
  */
 class PermissionTrampolineActivity : Activity() {
 
     companion object {
         private const val REQUEST_CODE_AA = 1001
+        private const val IMMEDIATE_THRESHOLD_MS = 1000L
 
-        private var onResultCallback: ((permissionCheckRan: Boolean) -> Unit)? = null
+        private var onResultCallback: ((hadMissingPermissions: Boolean) -> Unit)? = null
 
         /**
-         * @param onResult `true` when AA's permission activity ran and returned, whether it closed
-         *   at once or the user worked through it - either way permissions are not the problem.
-         *   `false` when it could not be started, which is the caller's cue to work out why.
+         * @param onResult `true` when AA's permission activity was displayed for missing permissions
+         *   (duration >= [IMMEDIATE_THRESHOLD_MS]).
+         *   `false` when duration was below [IMMEDIATE_THRESHOLD_MS] (permissions already granted)
+         *   or when the permission activity could not be started at all.
          */
-        fun launch(context: Context, onResult: (permissionCheckRan: Boolean) -> Unit) {
+        fun launch(context: Context, onResult: (hadMissingPermissions: Boolean) -> Unit) {
             onResultCallback = onResult
             val intent = Intent(context, PermissionTrampolineActivity::class.java).apply {
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
@@ -55,7 +58,7 @@ class PermissionTrampolineActivity : Activity() {
             startActivityForResult(intent, REQUEST_CODE_AA)
         } catch (e: Exception) {
             AppLog.w("SelfMode: could not start AA's permission activity: ${e.message}")
-            finishWith(permissionCheckRan = false)
+            finishWith(hadMissingPermissions = false)
         }
     }
 
@@ -64,14 +67,15 @@ class PermissionTrampolineActivity : Activity() {
         if (requestCode == REQUEST_CODE_AA) {
             val durationMs = SystemClock.elapsedRealtime() - launchTimestamp
             AppLog.i("SelfMode: AA permissions request took $durationMs ms")
-            finishWith(permissionCheckRan = true)
+            val hadMissingPermissions = durationMs >= IMMEDIATE_THRESHOLD_MS
+            finishWith(hadMissingPermissions = hadMissingPermissions)
         }
     }
 
-    private fun finishWith(permissionCheckRan: Boolean) {
+    private fun finishWith(hadMissingPermissions: Boolean) {
         val callback = onResultCallback
         cleanup()
-        callback?.invoke(permissionCheckRan)
+        callback?.invoke(hadMissingPermissions)
         finish()
     }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/self/SelfLaunchResolveHelper.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/self/SelfLaunchResolveHelper.kt
@@ -16,24 +16,25 @@ class SelfLaunchResolveHelper(private val service: AapService) {
     }
 
     private fun openPermissionsCheck() {
-        PermissionTrampolineActivity.launch(service) { permissionCheckRan ->
-            if (permissionCheckRan) {
-                // AA's own permission screen ran and came back, so permissions are not why Self
-                // Mode timed out. Nothing more specific is knowable from here.
-                AppLog.w("SelfMode: AA's permissions are in order; the launch timed out for another reason.")
+        PermissionTrampolineActivity.launch(service) { hadMissingPermissions ->
+            if (!hadMissingPermissions) {
+                // Duration was below threshold (permissions already granted) or activity could not be started.
+                // Since permissions are not the issue, check for other failure causes (e.g., system app).
+                AppLog.w("SelfMode: AA permissions were already granted or activity failed to start; checking other causes.")
+                onPermissionsCheckFailed()
+            } else {
+                // AA's permission screen ran to request missing permissions.
+                AppLog.i("SelfMode: AA's permission screen was shown for missing permissions.")
                 ToastUtils.showToast(
                     service,
                     service.getString(R.string.failed_start_android_auto),
                     Toast.LENGTH_LONG
                 )
-            } else {
-                AppLog.e("SelfMode: AA's permission activity could not be started.")
-                onPermissionsCheckFailed()
             }
         }
     }
 
-    /** Why AA's own permission screen would not open. Only reachable when it did not run at all. */
+    /** Called when permissions were already granted or activity failed to start, to check other causes. */
     private fun onPermissionsCheckFailed() {
         // is AA even installed?
         if (!isAAInstalled()) {

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/self/SelfLaunchTimeoutPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/self/SelfLaunchTimeoutPolicy.kt
@@ -1,4 +1,4 @@
-package com.andrerinas.openheadunit.aap
+package com.andrerinas.openheadunit.connection.self
 
 /** Which of Self Mode's two bring-up routes a launch attempt took. */
 enum class SelfLaunchPath {

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/self/SelfLauncherManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/self/SelfLauncherManager.kt
@@ -6,8 +6,6 @@ import android.net.Uri
 import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.aap.AapService
 import com.andrerinas.openheadunit.aap.DummyVpnPolicy
-import com.andrerinas.openheadunit.aap.SelfLaunchPath
-import com.andrerinas.openheadunit.aap.SelfLaunchTimeoutPolicy
 import com.andrerinas.openheadunit.connection.self.launchers.SelfLauncherBTDiscovery
 import com.andrerinas.openheadunit.connection.self.launchers.SelfLauncherBroadcast
 import com.andrerinas.openheadunit.connection.self.launchers.SelfLauncherLegacy

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/SelfLaunchTimeoutPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/SelfLaunchTimeoutPolicyTest.kt
@@ -1,5 +1,7 @@
 package com.andrerinas.openheadunit.aap
 
+import com.andrerinas.openheadunit.connection.self.SelfLaunchPath
+import com.andrerinas.openheadunit.connection.self.SelfLaunchTimeoutPolicy
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue


### PR DESCRIPTION
- The AA server could be ungracefully disconnect from our socket connection, making it believe we're still connected, but write/read attempts resulting a long lasting loop of Exceptions
- Undo some of #898 's changes regarding SelfLaunchResolveHelper, as that caused the "is it a systems app" check to never be called