### PR TITLE
Self Mode: the projection stays in front of a call, and the Android Auto keyboard stays up

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapAudio.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapAudio.kt
@@ -1,6 +1,5 @@
 package com.andrerinas.openheadunit.aap
 
-import android.content.Context
 import android.media.AudioAttributes
 import android.media.AudioFocusRequest
 import android.media.AudioManager
@@ -14,14 +13,12 @@ import com.andrerinas.openheadunit.aap.protocol.proto.Control
 import com.andrerinas.openheadunit.decoder.audio.AudioDecoder
 import com.andrerinas.openheadunit.decoder.audio.PlaybackFocusPolicy
 import com.andrerinas.openheadunit.utils.AppLog
-import com.andrerinas.openheadunit.utils.BluetoothHelper
 import com.andrerinas.openheadunit.utils.Settings
 
 internal class AapAudio(
         private val audioDecoder: AudioDecoder,
         private val audioManager: AudioManager,
-        private val settings: Settings,
-        private val context: Context) {
+        private val settings: Settings) {
 
     private val staticAudioFocus = settings.staticAudioFocus
     private val separateAudioStreams = settings.separateAudioStreams
@@ -52,7 +49,8 @@ internal class AapAudio(
     //
     // Whether we take it at all is PlaybackFocusPolicy's call: on a head unit that is also the
     // phone's Bluetooth A2DP sink, the focus grab makes the sink service AVRCP-pause that same
-    // phone, silencing the stream we are playing.
+    // phone, silencing the stream we are playing. AUTO finds that out by trying and watching, and
+    // the answer is remembered in settings so the trial happens once per head unit.
     private val activeAudioChannels = mutableSetOf<Int>()
     private val playbackFocusListener = AudioManager.OnAudioFocusChangeListener {
         AppLog.i("AapAudio: playback audio focus changed: $it")
@@ -65,7 +63,7 @@ internal class AapAudio(
     @Volatile
     private var selfDefeatingStops = 0
     @Volatile
-    private var selfDefeatingLatched = false
+    private var selfDefeatingLatched = settings.playbackFocusSelfDefeating
 
     @Volatile
     private var isDucked = false
@@ -102,6 +100,14 @@ internal class AapAudio(
         return (1.0f + (mediaVolumeOffset / 100.0f)).coerceIn(0.0f, 2.0f)
     }
 
+    /** Which of the gates said no, so a reporter log names it instead of leaving it to be inferred. */
+    private fun declineReason(): String = when {
+        staticAudioFocus -> "static audio focus holds it instead"
+        !enableAudioSink -> "the audio sink is off"
+        selfDefeatingLatched -> "taking it stops this phone's own playback (mode=$playbackFocusMode, learned)"
+        else -> "mode=$playbackFocusMode"
+    }
+
     /**
      * Whether a focus request the phone asked for over the protocol should reach the system.
      *
@@ -114,14 +120,13 @@ internal class AapAudio(
      * RELEASE is never gated: abandoning focus must always work, or a grab from before the link
      * came up would be stranded for the rest of the session.
      *
-     * The latch does not extend here — it is armed in [onAudioPlaybackStopped], which only runs
-     * while the playback path holds focus. On a unit whose Bluetooth probe reads nothing, this path
-     * has no automatic backstop and needs the mode set to NEVER by hand.
+     * The latch gates this path but is never armed by it: arming happens in [onAudioPlaybackStopped],
+     * which only runs while the playback path holds focus. So this path follows what that one
+     * learned rather than learning anything itself.
      */
     fun shouldHonourProtocolFocusRequest(isRelease: Boolean): Boolean {
         if (isRelease) return true
 
-        val btMediaLinkActive = BluetoothHelper.isA2dpMediaLinkActive(context)
         // isAudioChannel: the notification arrives on the control channel, but the question being
         // asked is about audio focus. The flag means "this is an audio-focus decision", not "this
         // message came in on an audio channel".
@@ -130,12 +135,11 @@ internal class AapAudio(
                 staticAudioFocus = staticAudioFocus,
                 audioSinkEnabled = enableAudioSink,
                 isAudioChannel = true,
-                btMediaLinkActive = btMediaLinkActive,
                 selfDefeatingLatched = selfDefeatingLatched)
 
         if (!honour) {
             AppLog.i("AapAudio: phone asked for audio focus - leaving system audio focus alone " +
-                    "(mode=$playbackFocusMode, bluetoothMedia=$btMediaLinkActive, latched=$selfDefeatingLatched)")
+                    "(${declineReason()})")
         }
         return honour
     }
@@ -245,12 +249,13 @@ internal class AapAudio(
     fun releaseAllFocus() {
         AppLog.i("AapAudio: Releasing all audio focus.")
         synchronized(activeAudioChannels) { activeAudioChannels.clear() }
-        // The latch is a property of one connection, not of the head unit: re-arm it so a session
-        // that reconnects with Bluetooth off gets the car-radio behaviour back.
+        // The latch is a property of the head unit, so it comes back from settings rather than
+        // clearing: a unit that pauses the phone when we take focus does it on every connection,
+        // and re-running the trial each time would cost the user the same interrupted tracks again.
         holdingPlaybackFocus = false
         focusAcquiredAtMs = 0L
         selfDefeatingStops = 0
-        selfDefeatingLatched = false
+        selfDefeatingLatched = settings.playbackFocusSelfDefeating
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             audioFocusRequest?.let { audioManager.abandonAudioFocusRequest(it) }
             audioFocusRequest = null
@@ -321,18 +326,16 @@ internal class AapAudio(
         }
         if (!wasEmpty) return
 
-        val btMediaLinkActive = BluetoothHelper.isA2dpMediaLinkActive(context)
         val acquire = PlaybackFocusPolicy.shouldAcquire(
                 mode = playbackFocusMode,
                 staticAudioFocus = staticAudioFocus,
                 audioSinkEnabled = enableAudioSink,
                 isAudioChannel = true,
-                btMediaLinkActive = btMediaLinkActive,
                 selfDefeatingLatched = selfDefeatingLatched)
 
         if (!acquire) {
             AppLog.i("AapAudio: AA audio started (${Channel.name(channel)}) - leaving system audio focus alone " +
-                    "(mode=$playbackFocusMode, bluetoothMedia=$btMediaLinkActive, latched=$selfDefeatingLatched)")
+                    "(${declineReason()})")
             return
         }
 
@@ -341,7 +344,7 @@ internal class AapAudio(
         // abandon focus. TRANSIENT sends AUDIOFOCUS_LOSS_TRANSIENT so they pause and resume
         // once AA audio stops and we release focus.
         AppLog.i("AapAudio: AA audio started (${Channel.name(channel)}) - acquiring transient system audio focus " +
-                "(mode=$playbackFocusMode, bluetoothMedia=$btMediaLinkActive)")
+                "(mode=$playbackFocusMode)")
         focusAcquiredAtMs = SystemClock.elapsedRealtime()
         holdingPlaybackFocus = true
         requestPlaybackFocus()
@@ -368,10 +371,12 @@ internal class AapAudio(
     }
 
     /**
-     * Watches for the pathology the Bluetooth probe is meant to pre-empt, for the units where it
-     * cannot see the link: the media channel closing again almost as soon as we took focus, because
-     * the phone stopped its own playback in response. Two of those in a row and we stop asking for
-     * focus, so the session settles instead of cycling every few seconds.
+     * Watches for the pathology AUTO is trying out: the media channel closing again almost as soon
+     * as we took focus, because the phone stopped its own playback in response. Two of those in a
+     * row and we stop asking for focus, so the session settles instead of cycling every few seconds.
+     *
+     * The answer is written to settings because it describes the head unit, not this connection.
+     * Re-picking the focus mode clears it, which is the way back if the two stops were a coincidence.
      */
     private fun noteStopWhileHoldingFocus(channel: Int) {
         if (selfDefeatingLatched || focusAcquiredAtMs == 0L) return
@@ -387,8 +392,10 @@ internal class AapAudio(
                 "($selfDefeatingStops/${PlaybackFocusPolicy.SELF_DEFEATING_LIMIT})")
         if (selfDefeatingStops >= PlaybackFocusPolicy.SELF_DEFEATING_LIMIT) {
             selfDefeatingLatched = true
+            settings.playbackFocusSelfDefeating = true
             AppLog.w("AapAudio: taking system audio focus is stopping the phone's own playback " +
-                    "(the head unit is most likely its Bluetooth audio sink) - not acquiring it again this session")
+                    "(the head unit is most likely its Bluetooth audio sink) - not acquiring it again, " +
+                    "on this or a later connection, until the focus mode is re-picked")
         }
     }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
@@ -35,11 +35,14 @@ import com.andrerinas.openheadunit.decoder.video.WarmRelaunchKeyframePolicy
 import com.andrerinas.openheadunit.input.ProjectionKeyPolicy
 import com.andrerinas.openheadunit.input.TouchCoordinateMapper
 import kotlinx.coroutines.launch
+import com.andrerinas.openheadunit.decoder.audio.MicRecorder
 import com.andrerinas.openheadunit.decoder.video.DecoderStopPolicy
 import com.andrerinas.openheadunit.decoder.video.SoftwareYuvFrameSink
 import com.andrerinas.openheadunit.decoder.video.VideoDecoder
 import com.andrerinas.openheadunit.decoder.video.VideoDimensionsListener
 import com.andrerinas.openheadunit.utils.AppLog
+import com.andrerinas.openheadunit.connection.self.SelfModeCallRaisePolicy
+import com.andrerinas.openheadunit.decoder.audio.CallState
 import com.andrerinas.openheadunit.utils.IntentFilters
 import com.andrerinas.openheadunit.view.IProjectionView
 import com.andrerinas.openheadunit.view.GlProjectionView
@@ -78,6 +81,22 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
     private var isSurfaceSet = false
     private var overlayState = OverlayState.STARTING
     private val watchdogHandler = android.os.Handler(android.os.Looper.getMainLooper())
+
+    /**
+     * True when the user themselves left the projection (Home, Recents), which fires
+     * onUserLeaveHint just before onPause. An activity launching over us does not, and that is
+     * what separates a call screen covering the projection from the user walking away from it.
+     */
+    private var userLeftDeliberately = false
+
+    /** The open call-raise episode, or null when the projection is not covered by a call. */
+    private var callRaiseEpisode: SelfModeCallRaisePolicy.Episode? = null
+
+    /** What the last episode spent, so a call screen that relaunches cannot keep buying more. */
+    private var lastCallRaiseAttempts = 0
+    private var lastCallRaiseAtMs = 0L
+
+    private val callRaiseTick = Runnable { tickCallRaise() }
 
     /**
      * Ken Burns scale animation applied to a static image loading screen.
@@ -980,11 +999,15 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
             LocalBroadcastManager.getInstance(this).unregisterReceiver(settingsReceiver)
             isSettingsReceiverRegistered = false
         }
+        // After the removeCallbacks above, never before: the tick posts on the same handler.
+        maybeOpenCallRaiseEpisode()
     }
 
     override fun onResume() {
         super.onResume()
         isForeground = true
+        userLeftDeliberately = false
+        closeCallRaiseEpisode("the projection is back in front")
         AppLog.i("AapProjectionActivity: onResume")
         // Show the one-time rename notice even here, on top of an active projection.
         RenameNotice.maybeShow(this, App.provide(this).settings)
@@ -1476,10 +1499,98 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         }
     }
 
+    /**
+     * Opens a call-raise episode when something covered the projection during a call, in Self Mode.
+     *
+     * Self Mode is the only place this can happen: everywhere else the call screen lands on the
+     * phone and the projection is on the head unit.
+     */
+    private fun maybeOpenCallRaiseEpisode() {
+        closeCallRaiseEpisode("covered again")
+        if (userLeftDeliberately || AapService.instance?.isSelfModeActive() != true || App.isPiPActive) return
+        if (!settings.raiseProjectionDuringCall) return
+
+        val audioMode = audioModeOrNormal()
+        val callActive = CallState.isCallActive(audioMode, MicRecorder.holdsCommunicationMode)
+        if (!callActive && !CallState.isCallStarting(audioMode)) return
+
+        val nowMs = SystemClock.elapsedRealtime()
+        val carried = SelfModeCallRaisePolicy.carriedAttempts(lastCallRaiseAttempts, lastCallRaiseAtMs, nowMs)
+        AppLog.i("AapProjectionActivity: covered during a call, will raise the projection ($carried attempts already spent)")
+        callRaiseEpisode = SelfModeCallRaisePolicy.Episode(
+            startedAtMs = nowMs,
+            sawCallActive = callActive,
+            attempts = carried,
+            lastAttemptAtMs = if (carried > 0) lastCallRaiseAtMs else 0L,
+        )
+        watchdogHandler.postDelayed(callRaiseTick, SelfModeCallRaisePolicy.TICK_MS)
+    }
+
+    /**
+     * Ends an open episode. The reason is logged only when there was one, because a successful raise
+     * ends the episode from onResume before the tick that would otherwise have reported it can run.
+     */
+    private fun closeCallRaiseEpisode(reason: String) {
+        if (callRaiseEpisode != null) {
+            AppLog.i("AapProjectionActivity: call raise finished - $reason")
+        }
+        callRaiseEpisode = null
+        watchdogHandler.removeCallbacks(callRaiseTick)
+    }
+
+    private fun tickCallRaise() {
+        val episode = callRaiseEpisode ?: return
+        val nowMs = SystemClock.elapsedRealtime()
+        val callActive = CallState.isCallActive(audioModeOrNormal(), MicRecorder.holdsCommunicationMode)
+        val observed = SelfModeCallRaisePolicy.observe(episode, nowMs, callActive)
+        val action = SelfModeCallRaisePolicy.decide(
+            nowMs = nowMs,
+            episode = observed,
+            callActive = callActive,
+            isForeground = isForeground,
+            pipActive = App.isPiPActive,
+        )
+        val reason = SelfModeCallRaisePolicy.describe(action, observed, callActive, isForeground)
+
+        val next = when (action) {
+            SelfModeCallRaisePolicy.Action.DONE -> {
+                AppLog.i("AapProjectionActivity: call raise finished - $reason")
+                callRaiseEpisode = null
+                return
+            }
+            SelfModeCallRaisePolicy.Action.RAISE -> {
+                AppLog.i("AapProjectionActivity: raising the projection - $reason")
+                requestProjectionRaise()
+                SelfModeCallRaisePolicy.onRaised(observed, nowMs, callActive).also {
+                    lastCallRaiseAttempts = it.attempts
+                    lastCallRaiseAtMs = nowMs
+                }
+            }
+            SelfModeCallRaisePolicy.Action.WAIT -> observed
+        }
+        callRaiseEpisode = next
+        watchdogHandler.postDelayed(callRaiseTick, SelfModeCallRaisePolicy.nextTickDelayMs(next))
+    }
+
+    /** The service owns the overlay trampoline, and a paused activity cannot start itself. */
+    private fun requestProjectionRaise() {
+        sendBroadcast(Intent(AapService.ACTION_RAISE_PROJECTION).apply { setPackage(packageName) })
+    }
+
+    private fun audioModeOrNormal(): Int = try {
+        (getSystemService(Context.AUDIO_SERVICE) as android.media.AudioManager).mode
+    } catch (e: Exception) {
+        AppLog.w("AapProjectionActivity: Could not read the audio mode: ${e.message}")
+        android.media.AudioManager.MODE_NORMAL
+    }
+
     override fun onUserLeaveHint() {
         // Optional: Auto-enter PiP if user presses home
 
         // For now, we only enter via dialog as requested.
+        // Also the one signal that the next onPause is the user's own doing, so the call raise
+        // below never argues with someone who chose to leave.
+        userLeftDeliberately = true
         super.onUserLeaveHint()
     }
 
@@ -1814,6 +1925,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
 
     override fun onDestroy() {
         super.onDestroy()
+        closeCallRaiseEpisode("the projection is going away")
         if (isFinishReceiverRegistered) {
             unregisterReceiver(finishReceiver)
             isFinishReceiverRegistered = false

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
@@ -166,7 +166,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
             if (!ProjectionWatchdogPolicy.shouldNudgeForFirstFrame(
                     sessionLive = ProjectionWatchdogPolicy.isSessionLive(commManager.connectionState.value),
                     surfaceSet = isSurfaceSet,
-                    renderedSinceSurfaceSet = rendered,
+                    crediblePictureOnSurface = videoDecoder.hasCrediblePicture,
                     warmRelaunchCycleSpent = warmRelaunchCycleSpent,
                 )
             ) return
@@ -189,15 +189,15 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
             if (!ProjectionWatchdogPolicy.isSessionLive(commManager.connectionState.value)) {
                 return
             }
+            // Every tick, not only before the first frame: a codec rebuilt with cached parameter
+            // sets renders gray P-frame output, so lastFrameRenderedMs is set while there is still
+            // no picture, and gating this on it left the 850 ms check as the only attempt.
+            maybeRecoverWarmRelaunch()
             val lastFrame = videoDecoder.lastFrameRenderedMs
             if (lastFrame == 0L) {
                 // First frame hasn't arrived yet — handled by the starting overlay. If the phone is
                 // streaming video but nothing draws, offer to switch renderer (issue #767).
                 maybeOfferRendererConfirm()
-                // A relaunch lands here too, and used to get nothing else: the overlay is already
-                // hidden (the previous instance had rendered), so its keyframe watchdog never
-                // re-arms, and maybeRequestVideoFocus below is never reached.
-                maybeRecoverWarmRelaunch()
                 watchdogHandler.postDelayed(this, ProjectionWatchdogPolicy.WATCHDOG_TICK_MS)
                 return
             }
@@ -237,8 +237,14 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
 
     // Age and escalation state of the surface the decoder currently renders to. Reset together in
     // onSurfaceChanged, so each relaunch gets exactly one focus cycle.
+    /** When a touch of ours last completed, for [VideoFocusReleasePolicy.coverFollowsTouch]. */
+    private var lastProjectionTouchMs = 0L
+
     private var lastSurfaceSetMs = 0L
     private var warmRelaunchCycleSpent = false
+
+    /** One line per surface, not per tick: the gray-P-frame case is worth naming exactly once. */
+    private var loggedKeyframelessPicture = false
 
     /**
      * A relaunch handed the decoder a fresh surface and no picture has followed it.
@@ -256,9 +262,18 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
     private fun maybeRecoverWarmRelaunch() {
         if (lastSurfaceSetMs == 0L) return
         val now = SystemClock.elapsedRealtime()
+        if (!loggedKeyframelessPicture &&
+            videoDecoder.lastFrameRenderedMs != 0L && !videoDecoder.hasCrediblePicture
+        ) {
+            loggedKeyframelessPicture = true
+            AppLog.w(
+                "AapProjectionActivity: frames are rendering but no keyframe has decoded since the " +
+                    "codec started - counting this surface as having no picture"
+            )
+        }
         val action = WarmRelaunchKeyframePolicy.decide(
             sessionHasRendered = videoDecoder.hasRenderedThisSession,
-            renderedSinceSurfaceSet = videoDecoder.lastFrameRenderedMs != 0L,
+            crediblePictureOnSurface = videoDecoder.hasCrediblePicture,
             transportStarted = commManager.connectionState.value is CommManager.ConnectionState.TransportStarted,
             msSinceSurfaceSet = now - lastSurfaceSetMs,
             // The link, not the video channel. An idle Android Auto screen sends no video for
@@ -1654,6 +1669,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         settleFocusCycle()
         lastSurfaceSetMs = SystemClock.elapsedRealtime()
         warmRelaunchCycleSpent = false
+        loggedKeyframelessPicture = false
         watchdogHandler.removeCallbacks(warmRelaunchCheckRunnable)
         watchdogHandler.postDelayed(
             warmRelaunchCheckRunnable,
@@ -1754,7 +1770,22 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         }
         AppLog.i("SurfaceCallback: onSurfaceDestroyed. Surface: $surface")
         isSurfaceSet = false
-        commManager.send(VideoFocusEvent(gain = false, unsolicited = false))
+        val nowMs = SystemClock.elapsedRealtime()
+        if (VideoFocusReleasePolicy.shouldReleaseOnSurfaceLost(
+                coverFollowsTouch = VideoFocusReleasePolicy.coverFollowsTouch(lastProjectionTouchMs, nowMs),
+                sessionConnected = commManager.isConnected,
+                activityEnding = isFinishing || isChangingConfigurations,
+                pipActive = App.isPiPActive,
+                focusCycleInFlight = focusCycleGainPending,
+            )
+        ) {
+            commManager.send(VideoFocusEvent(gain = false, unsolicited = false))
+        } else {
+            AppLog.i(
+                "AapProjectionActivity: the surface went away ${nowMs - lastProjectionTouchMs}ms after " +
+                    "a touch - holding video focus so Android Auto keeps its keyboard up"
+            )
+        }
         videoDecoder.stopIfCurrentSurface(surface, DecoderStopPolicy.REASON_SURFACE_DESTROYED)
     }
 
@@ -1874,6 +1905,11 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         }
 
         commManager.send(TouchEvent(ts, action, event.actionIndex, pointerData))
+        // ACTION_UP only: a swipe-up-home or edge-back gesture ends in ACTION_CANCEL, and neither
+        // must look like the text-field tap that opens Android Auto's phone keyboard.
+        if (event.actionMasked == MotionEvent.ACTION_UP) {
+            lastProjectionTouchMs = ts
+        }
     }
 
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -473,6 +473,16 @@ class AapService : Service() {
         }
     }
 
+    // Receives ACTION_RAISE_PROJECTION, sent by the projection activity when a call screen has
+    // covered it in Self Mode. The activity is paused at that point, so the launch has to come from
+    // here, where the overlay trampoline lives.
+    private val raiseProjectionReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            if (intent.action != ACTION_RAISE_PROJECTION) return
+            launchAapProjectionActivity(allowNotificationFallback = false)
+        }
+    }
+
     // -------------------------------------------------------------------------
     // Wake detection for hibernate/quick boot head units
     // -------------------------------------------------------------------------
@@ -1041,7 +1051,12 @@ class AapService : Service() {
         serviceScope.launch { commManager.startHandshake() }
     }
 
-    private fun launchAapProjectionActivity() {
+    /**
+     * @param allowNotificationFallback whether a full-screen-intent notification may stand in when
+     *   there is no overlay permission. False on the call path, where it would compete with the
+     *   call screen's own full-screen intent.
+     */
+    private fun launchAapProjectionActivity(allowNotificationFallback: Boolean = true) {
         if (App.isPiPActive) {
             AppLog.i("AapService: Skipping projection launch because PiP is active")
             return
@@ -1065,7 +1080,9 @@ class AapService : Service() {
                     catch (e: Exception) { AppLog.e("Projection direct fallback failed: ${e.message}") }
                 }
             }
-            ActivityLaunchPolicy.LaunchStrategy.NOTIFICATION -> launchProjectionViaNotification(intent)
+            ActivityLaunchPolicy.LaunchStrategy.NOTIFICATION ->
+                if (allowNotificationFallback) launchProjectionViaNotification(intent)
+                else AppLog.w("AapService: No overlay permission, not raising the projection")
         }
     }
 
@@ -1411,6 +1428,11 @@ class AapService : Service() {
         ContextCompat.registerReceiver(
             this, sensorRefreshReceiver,
             IntentFilter(ACTION_REFRESH_SENSORS).apply { addAction(ACTION_RESTART_AUDIO) },
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
+        ContextCompat.registerReceiver(
+            this, raiseProjectionReceiver,
+            IntentFilter(ACTION_RAISE_PROJECTION),
             ContextCompat.RECEIVER_NOT_EXPORTED
         )
         // Runtime-registered MEDIA_BUTTON receiver.
@@ -1808,6 +1830,8 @@ class AapService : Service() {
     override fun onDestroy() {
         AppLog.i("AapService destroying... (wakeLock held=${bootWakeLock?.isHeld == true})")
         isDestroying = true
+        // Nothing else clears it here, and the manager outlives the service instance.
+        selfLauncherManager.isActive = false
         mediaMetadataDecodeJob?.cancel()
         cachedAaAlbumArtBitmap = null
         mediaNotification.cancel()
@@ -1853,6 +1877,7 @@ class AapService : Service() {
         try {
             unregisterReceiver(nightModeUpdateReceiver)
             unregisterReceiver(sensorRefreshReceiver)
+            unregisterReceiver(raiseProjectionReceiver)
         } catch (_: Exception) {}
         usbLauncherManager.unregister()
         try { unregisterReceiver(mediaButtonReceiver) } catch (_: Exception) {}
@@ -2367,6 +2392,7 @@ class AapService : Service() {
         const val ACTION_ORIENTATION_CHANGED     = "com.andrerinas.openheadunit.ACTION_ORIENTATION_CHANGED"
         const val ACTION_REFRESH_SENSORS         = "com.andrerinas.openheadunit.aap.action.REFRESH_SENSORS"
         const val ACTION_RESTART_AUDIO           = "com.andrerinas.openheadunit.aap.action.RESTART_AUDIO"
+        const val ACTION_RAISE_PROJECTION        = "com.andrerinas.openheadunit.aap.action.RAISE_PROJECTION"
         /**
          * Sent after the caller has already invoked [CommManager.connect(socket)].
          * The [observeConnectionState] flow observer handles the result — [onStartCommand]

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
@@ -520,7 +520,7 @@ class AapTransport(
 
     init {
         micRecorder.listener = this
-        aapAudio = AapAudio(audioDecoder, audioManager, settings, context)
+        aapAudio = AapAudio(audioDecoder, audioManager, settings)
         // A corrupt access unit is the one fault the phone cannot heal for us inside a GOP, and
         // hasRenderedThisSession is the gate that keeps this clear of the warm-up window
         // [WarmRelaunchKeyframePolicy] owns - the same gate VideoDecoder.notifyFrameDropped uses.

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/ProjectionWatchdogPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/ProjectionWatchdogPolicy.kt
@@ -197,12 +197,13 @@ object ProjectionWatchdogPolicy {
      *
      * @param sessionLive see [isSessionLive].
      * @param surfaceSet whether the decoder has been handed a surface at all yet.
-     * @param renderedSinceSurfaceSet whether any frame has reached the screen on that surface.
+     * @param crediblePictureOnSurface whether that surface is showing a picture a keyframe accounts
+     *   for. A codec rebuilt with cached parameter sets renders gray P-frame output, which is not one.
      */
     fun shouldNudgeForFirstFrame(
         sessionLive: Boolean,
         surfaceSet: Boolean,
-        renderedSinceSurfaceSet: Boolean,
+        crediblePictureOnSurface: Boolean,
         warmRelaunchCycleSpent: Boolean,
-    ): Boolean = sessionLive && surfaceSet && !renderedSinceSurfaceSet && !warmRelaunchCycleSpent
+    ): Boolean = sessionLive && surfaceSet && !crediblePictureOnSurface && !warmRelaunchCycleSpent
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/VideoFocusReleasePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/VideoFocusReleasePolicy.kt
@@ -1,0 +1,60 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Whether losing the projection surface should tell the phone we gave up video focus.
+ *
+ * The framework destroys a SurfaceView's surface whenever an opaque window covers the app, and the
+ * teardown has always answered with VIDEO_FOCUS_NATIVE. Android Auto reads that as the projection
+ * being over and tears the session down, which takes its phone keyboard with it: the keyboard opens
+ * over the projection when a text field is tapped, our release goes out, and Gearhead detaches it
+ * tens of milliseconds later. The user is left with no keyboard at all. The TextureView and GLES
+ * backends never lose their surface to a cover, never send the release, and keep the keyboard - the
+ * difference two reporters found by switching backends.
+ *
+ * The release is not removable in general. It is what makes the phone re-run sink setup, and the
+ * picture comes back in 42-96 ms with it against seconds without. So it is withheld only for the one
+ * cover shaped like the keyboard - opaque, on a live session, arriving within [TOUCH_WINDOW_MS] of a
+ * touch we forwarded - and the return is left to the warm-relaunch focus cycle, measured at
+ * 3.04-3.20 s. Everything else keeps the fast path.
+ *
+ * Withheld, never deferred. A release posted to fire later can land after a keyframe cycle has
+ * completed, leaving the phone released with nothing pending to take focus back - a black screen
+ * with audio still playing.
+ */
+object VideoFocusReleasePolicy {
+
+    /**
+     * How long after a touch of ours a cover still counts as that touch's doing.
+     *
+     * Android Auto's phone keyboard opens a fraction of a second after the field is tapped. An
+     * alarm, a notification-launched app or a Home press arrives with no forwarded touch behind it.
+     */
+    const val TOUCH_WINDOW_MS = 3_000L
+
+    /** Whether a cover this close behind a touch of ours is that touch's doing. */
+    fun coverFollowsTouch(lastTouchAtMs: Long, coveredAtMs: Long): Boolean =
+        lastTouchAtMs > 0L && coveredAtMs - lastTouchAtMs <= TOUCH_WINDOW_MS
+
+    /**
+     * @param coverFollowsTouch see [coverFollowsTouch]. The only signal that separates the keyboard
+     *   from every other coverer: its identity cannot be read without permissions, and
+     *   onUserLeaveHint fires for it exactly as for a Home press.
+     * @param sessionConnected whether there is a live session whose keyboard is worth protecting.
+     * @param activityEnding whether the projection activity is finishing or being recreated, in
+     *   which case the surface is not coming back and the phone should be told.
+     * @param pipActive whether picture-in-picture owns the screen, where being covered is the point.
+     * @param focusCycleInFlight whether a keyframe cycle already has focus released. Withholding
+     *   here would change nothing and the cycle owns the regain.
+     */
+    fun shouldReleaseOnSurfaceLost(
+        coverFollowsTouch: Boolean,
+        sessionConnected: Boolean,
+        activityEnding: Boolean,
+        pipActive: Boolean,
+        focusCycleInFlight: Boolean,
+    ): Boolean {
+        if (!coverFollowsTouch) return true
+        if (!sessionConnected || activityEnding || pipActive || focusCycleInFlight) return true
+        return false
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/self/SelfLauncherManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/self/SelfLauncherManager.kt
@@ -188,6 +188,10 @@ class SelfLauncherManager(
                         commManager.reportError("No launch method succeeded (timeout)")
                     }
 
+                    // The report is deliberately not a disconnect, so no Disconnected transition
+                    // arrives to clear this. Left true, it poisons the next session in this
+                    // process: ServiceDiscoveryResponse drops the media and speech audio sinks.
+                    isActive = false
                     handleNeverConnect()
                 }
             }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/self/SelfModeCallRaisePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/self/SelfModeCallRaisePolicy.kt
@@ -1,0 +1,171 @@
+package com.andrerinas.openheadunit.connection.self
+
+/**
+ * Whether the projection should be put back on top of the phone's call screen, in Self Mode.
+ *
+ * Android Auto never enables its car-mode in-call service on Android 13+, so Telecom's swap - the
+ * only thing that suppresses the Dialer during projection - cannot fire, and the Dialer covers the
+ * projection. Android Auto's own call UI is live underneath it the whole time, so raising our
+ * activity gives the user the call screen they wanted.
+ *
+ * Bounded on purpose: a few attempts and then silence, so a user who deliberately wants the Dialer
+ * gets it, and one last attempt after the call in case Android's own back-stack restore does not
+ * happen.
+ */
+object SelfModeCallRaisePolicy {
+
+    /** How long to let the call screen settle before the first attempt. */
+    const val FIRST_ATTEMPT_DELAY_MS = 600L
+
+    /** Spacing between attempts while the call is up. */
+    const val RETRY_INTERVAL_MS = 1_200L
+
+    /**
+     * Attempts allowed per call.
+     *
+     * The limit is what keeps this from becoming a fight. Once it is spent we stop pushing for the
+     * rest of the call, so switching to the Dialer by hand sticks.
+     */
+    const val MAX_ATTEMPTS_PER_CALL = 3
+
+    /**
+     * How long after the call ends to wait before the final attempt.
+     *
+     * Android normally reveals the still-paused projection the instant the call screen finishes
+     * itself, measured at 17 ms. This window lets that happen on its own; the attempt is only for
+     * the devices where it does not.
+     */
+    const val POST_CALL_SETTLE_MS = 1_000L
+
+    /**
+     * How long an episode may wait for the audio mode to report a call.
+     *
+     * The cover and the mode change race, so an episode can open a moment before the call registers.
+     * If no call shows up in this window, something else covered us and we leave it alone.
+     */
+    const val CALL_CONFIRM_WINDOW_MS = 2_000L
+
+    /**
+     * How long an attempt keeps counting after the projection came back.
+     *
+     * A call screen that relaunches itself over us would otherwise get a fresh budget each time it
+     * did, which is the one way this could turn into a loop.
+     */
+    const val ATTEMPT_CARRY_WINDOW_MS = 5_000L
+
+    /** Tick spacing while attempts remain. */
+    const val TICK_MS = 400L
+
+    /** Tick spacing once the attempts are spent and the only thing left to notice is the call ending. */
+    const val IDLE_TICK_MS = 2_000L
+
+    enum class Action {
+        /** Nothing to do yet. Keep ticking. */
+        WAIT,
+
+        /** Put the projection back on top. */
+        RAISE,
+
+        /** We are back, or there is nothing here to fix. Stop ticking. */
+        DONE,
+    }
+
+    /**
+     * What the caller carries between ticks.
+     *
+     * @param startedAtMs when the projection was covered.
+     * @param sawCallActive whether a call has been observed at all during this episode.
+     * @param attempts attempts made while the call was up.
+     * @param lastAttemptAtMs when the last attempt was made, or 0 if none.
+     * @param callEndedAtMs when the call was first observed to have ended, or 0 while it is up.
+     * @param postCallAttemptUsed whether the one attempt after the call has been made.
+     */
+    data class Episode(
+        val startedAtMs: Long,
+        val sawCallActive: Boolean = false,
+        val attempts: Int = 0,
+        val lastAttemptAtMs: Long = 0L,
+        val callEndedAtMs: Long = 0L,
+        val postCallAttemptUsed: Boolean = false,
+    )
+
+    /** Folds this tick's observation of the call into [episode]. Call before [decide]. */
+    fun observe(episode: Episode, nowMs: Long, callActive: Boolean): Episode = when {
+        callActive -> episode.copy(sawCallActive = true, callEndedAtMs = 0L)
+        episode.sawCallActive && episode.callEndedAtMs == 0L -> episode.copy(callEndedAtMs = nowMs)
+        else -> episode
+    }
+
+    /**
+     * @param nowMs monotonic clock, `SystemClock.elapsedRealtime()` at the call site.
+     * @param isForeground whether the projection activity is resumed again.
+     * @param pipActive whether picture-in-picture owns the screen, in which case being covered is
+     *   the point.
+     */
+    fun decide(
+        nowMs: Long,
+        episode: Episode,
+        callActive: Boolean,
+        isForeground: Boolean,
+        pipActive: Boolean,
+    ): Action {
+        if (isForeground || pipActive) return Action.DONE
+
+        if (callActive) {
+            if (episode.attempts >= MAX_ATTEMPTS_PER_CALL) return Action.WAIT
+            val dueAtMs = if (episode.attempts == 0) {
+                episode.startedAtMs + FIRST_ATTEMPT_DELAY_MS
+            } else {
+                episode.lastAttemptAtMs + RETRY_INTERVAL_MS
+            }
+            return if (nowMs >= dueAtMs) Action.RAISE else Action.WAIT
+        }
+
+        if (!episode.sawCallActive) {
+            return if (nowMs - episode.startedAtMs >= CALL_CONFIRM_WINDOW_MS) Action.DONE else Action.WAIT
+        }
+
+        if (episode.postCallAttemptUsed) return Action.DONE
+        val endedAtMs = if (episode.callEndedAtMs > 0L) episode.callEndedAtMs else nowMs
+        return if (nowMs - endedAtMs >= POST_CALL_SETTLE_MS) Action.RAISE else Action.WAIT
+    }
+
+    /** The episode to carry forward after an attempt at [nowMs]. */
+    fun onRaised(episode: Episode, nowMs: Long, callActive: Boolean): Episode = episode.copy(
+        attempts = if (callActive) episode.attempts + 1 else episode.attempts,
+        lastAttemptAtMs = nowMs,
+        postCallAttemptUsed = episode.postCallAttemptUsed || !callActive,
+    )
+
+    /**
+     * Attempts to start a new episode with, given what the last one spent.
+     *
+     * Zero once the window has passed, so a call an hour later is never talked out of trying.
+     */
+    fun carriedAttempts(previousAttempts: Int, lastAttemptAtMs: Long, nowMs: Long): Int =
+        if (lastAttemptAtMs > 0L && nowMs - lastAttemptAtMs <= ATTEMPT_CARRY_WINDOW_MS) previousAttempts else 0
+
+    /** How long until the next tick. */
+    fun nextTickDelayMs(episode: Episode): Long =
+        if (episode.attempts >= MAX_ATTEMPTS_PER_CALL && episode.callEndedAtMs == 0L) IDLE_TICK_MS else TICK_MS
+
+    /** Why a decision came out the way it did, for the log. */
+    fun describe(action: Action, episode: Episode, callActive: Boolean, isForeground: Boolean): String =
+        when (action) {
+            Action.WAIT -> when {
+                callActive && episode.attempts >= MAX_ATTEMPTS_PER_CALL ->
+                    "attempts spent, leaving the call screen alone"
+                callActive -> "waiting for the next attempt"
+                !episode.sawCallActive -> "no call yet"
+                else -> "waiting for the call screen to close on its own"
+            }
+            Action.RAISE ->
+                if (callActive) "attempt ${episode.attempts + 1} of $MAX_ATTEMPTS_PER_CALL during the call"
+                else "the call ended and the projection is still covered"
+            Action.DONE -> when {
+                isForeground -> "the projection is back in front"
+                !episode.sawCallActive -> "whatever covered the projection was not a call"
+                else -> "nothing left to do"
+            }
+        }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/CallState.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/CallState.kt
@@ -1,0 +1,31 @@
+package com.andrerinas.openheadunit.decoder.audio
+
+import android.media.AudioManager
+
+/**
+ * Whether a phone call is up, read from the audio mode.
+ *
+ * The app has no telephony listener and `READ_PHONE_STATE` would cost a runtime prompt, while
+ * `AudioManager.getMode()` needs no permission and covers VoIP as well as cellular. The one false
+ * positive is our own microphone uplink, which sets `MODE_IN_COMMUNICATION` to force SCO routing.
+ */
+object CallState {
+
+    /**
+     * @param appHoldsCommunicationMode whether our own microphone path is the one holding
+     *   `MODE_IN_COMMUNICATION`, in which case the mode says nothing about a call.
+     */
+    fun isCallActive(audioMode: Int, appHoldsCommunicationMode: Boolean): Boolean = when (audioMode) {
+        AudioManager.MODE_IN_CALL -> true
+        AudioManager.MODE_IN_COMMUNICATION -> !appHoldsCommunicationMode
+        else -> false
+    }
+
+    /**
+     * A call is ringing but has not been answered.
+     *
+     * Deliberately not part of [isCallActive]: the call screen takes over at answer, not at ring,
+     * so this only exists to let an episode open a moment early and wait for the mode to catch up.
+     */
+    fun isCallStarting(audioMode: Int): Boolean = audioMode == AudioManager.MODE_RINGTONE
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/MicRecorder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/MicRecorder.kt
@@ -59,6 +59,16 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
     companion object {
         // Sentinel value stored in settings to indicate Bluetooth SCO mode
         const val SOURCE_BLUETOOTH_SCO = 100
+
+        /**
+         * True while the uplink is the one holding MODE_IN_COMMUNICATION for SCO routing.
+         *
+         * Read by anything that infers a phone call from the audio mode, so our own microphone
+         * does not look like one.
+         */
+        @Volatile
+        var holdsCommunicationMode = false
+            private set
     }
 
     interface Listener {
@@ -96,6 +106,7 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
         if (bluetoothScoStarted) {
             cleanupSco()
         }
+        holdsCommunicationMode = false
     }
 
     private fun cleanupSco() {
@@ -189,6 +200,7 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
         // Set audio mode to MODE_IN_COMMUNICATION to force SCO routing
         try {
             audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+            holdsCommunicationMode = true
         } catch (e: Exception) {
             AppLog.e("MicRecorder: Failed to set audio mode to MODE_IN_COMMUNICATION", e)
         }

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/PlaybackFocusPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/PlaybackFocusPolicy.kt
@@ -13,6 +13,13 @@ package com.andrerinas.openheadunit.decoder.audio
  * resumes, and the whole thing repeats every few seconds. Nothing in the focus API distinguishes
  * the two cases, so this decides it from context instead.
  *
+ * The dynamic path decides it by trying. A connected A2DP link used to veto the grab outright, but
+ * plenty of units have one connected and idle while AA audio arrives over USB, and a factory head
+ * unit that routes its amplifier from audio focus then plays nothing at all. So [shouldAcquire]
+ * takes focus and lets the self-defeating detector — the thing that observes the harm instead of
+ * guessing at it — stop us after two cycles. The veto stays on the static path, which has no
+ * detector.
+ *
  * The two entry points are exact complements on the `staticAudioFocus` axis: whichever route is
  * live, the other declines, so they can never both hold focus. A test asserts it.
  *
@@ -22,10 +29,10 @@ object PlaybackFocusPolicy {
 
     /** User override for the automatic behaviour. Stored as an ordinal in settings. */
     enum class Mode(val value: Int) {
-        /** Take focus only when nothing suggests it will silence the phone we are projecting. */
+        /** Take focus until we observe it silencing the phone we are projecting. */
         AUTO(0),
 
-        /** Always take focus. For units where the Bluetooth probe answers wrongly. */
+        /** Always take focus. For units where the automatic answer comes out wrong. */
         ALWAYS(1),
 
         /** Never take focus. */
@@ -41,19 +48,14 @@ object PlaybackFocusPolicy {
      * @param isAudioChannel   the channel is one of AUDIO / AUDIO1 / AUDIO2.
      * @param staticAudioFocus static mode holds focus permanently and manages it elsewhere, so the
      *                         dynamic path must keep its hands off entirely.
-     * @param btMediaLinkActive a Bluetooth media (A2DP) link to this head unit is up, so the
-     *                          "other player" we would silence is very likely the phone itself.
-     *                          Callers that cannot tell should pass `true`: a car radio playing over
-     *                          AA is an annoyance, silence is a broken app.
      * @param selfDefeatingLatched we already observed the phone cut its own audio right after we
-     *                          took focus, more than once this session.
+     *                          took focus, more than once. This is the answer that decides AUTO.
      */
     fun shouldAcquire(
         mode: Mode,
         staticAudioFocus: Boolean,
         audioSinkEnabled: Boolean,
         isAudioChannel: Boolean,
-        btMediaLinkActive: Boolean,
         selfDefeatingLatched: Boolean
     ): Boolean {
         // Pre-existing gates, unchanged: these decide whether the dynamic path runs at all.
@@ -62,7 +64,7 @@ object PlaybackFocusPolicy {
         return when (mode) {
             Mode.NEVER -> false
             Mode.ALWAYS -> true
-            Mode.AUTO -> !btMediaLinkActive && !selfDefeatingLatched
+            Mode.AUTO -> !selfDefeatingLatched
         }
     }
 
@@ -71,15 +73,15 @@ object PlaybackFocusPolicy {
      * `AUDIOFOCUS_GAIN` that static mode holds for a whole session, grabbed at connect time before
      * any audio exists.
      *
-     * Same trigger as the dynamic path — an A2DP sink answers our focus loss by pausing the phone we
+     * Same harm as the dynamic path — an A2DP sink answers our focus loss by pausing the phone we
      * project — but a permanent `AUDIOFOCUS_LOSS` is not a `LOSS_TRANSIENT`: the sink pauses once and
      * does not resume when we abandon focus, so the failure is a session that starts silent rather
      * than one that cycles.
      *
-     * There is no latch parameter because there is nothing here for the latch to observe. It counts
-     * media channels closing shortly after a grab, and static mode grabs once, outside any channel's
-     * lifetime. The Bluetooth probe is the only signal available on this path, which is why a unit
-     * whose probe reads nothing needs [Mode.NEVER] set by hand.
+     * That is why this path still refuses on a connected Bluetooth media link where the dynamic path
+     * now tries: there is nothing here for the latch to observe. It counts media channels closing
+     * shortly after a grab, and static mode grabs once, outside any channel's lifetime. A unit whose
+     * probe reads nothing therefore needs [Mode.NEVER] set by hand.
      */
     fun shouldAcquirePermanent(
         mode: Mode,
@@ -109,7 +111,8 @@ object PlaybackFocusPolicy {
     fun countsAsSelfDefeating(isMediaChannel: Boolean, msSinceAcquire: Long): Boolean =
         isMediaChannel && msSinceAcquire in 0L until SELF_DEFEATING_WINDOW_MS
 
-    /** Consecutive self-defeating stops before we stop taking focus for the rest of the session. */
+    /** Consecutive self-defeating stops before we stop taking focus. Remembered across sessions, so
+     *  a unit that behaves this way pays for the trial once rather than at every connect. */
     const val SELF_DEFEATING_LIMIT = 2
 
     const val SELF_DEFEATING_WINDOW_MS = 5_000L

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/video/PictureCredibilityPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/video/PictureCredibilityPolicy.kt
@@ -1,0 +1,50 @@
+package com.andrerinas.openheadunit.decoder.video
+
+/**
+ * Whether frames reaching the screen amount to a picture, or only to output.
+ *
+ * A codec rebuilt against a new surface keeps its cached parameter sets, so it configures and starts
+ * on a P-frame and some components emit output from it - gray, but rendered. Every recovery gate that
+ * asks "has a frame rendered on this surface" then reads that as a working picture and stands down,
+ * and the screen stays gray until the phone's next natural keyframe, up to a full GOP away.
+ *
+ * The question those gates need answered is whether a keyframe accounts for what is on screen.
+ * [KeyframeRepairTracker] already tracks that per codec instance; this turns it into the one boolean
+ * the gates read.
+ */
+object PictureCredibilityPolicy {
+
+    /**
+     * How long a fed keyframe may still be working its way to the output before the picture stops
+     * counting as credible.
+     *
+     * Twice [KeyframeRepairTracker.RENDERS_BEFORE_TIMESTAMPS_DISBELIEVED] frames' worth at the lowest
+     * plausible rate, so a component whose timestamps cannot be used is never called incredible on a
+     * stream that is fine.
+     */
+    const val PENDING_KEYFRAME_GRACE_MS = 2_000L
+
+    /**
+     * @param renderedSinceCodecStart whether any frame has reached the surface since this codec
+     *   started.
+     * @param keyframeAccountingAvailable whether keyframes are tracked at all on this path. The
+     *   bundled software HEVC decoder does not feed [KeyframeRepairTracker], so a rendered frame is
+     *   the only evidence there is and asking for more would starve it forever.
+     * @param keyframeDecodedSinceCodecStart whether a keyframe has produced output.
+     * @param msSincePendingKeyframeFed age of the keyframe still waiting at the output, or
+     *   [Long.MAX_VALUE] when none is pending.
+     */
+    fun hasCrediblePicture(
+        renderedSinceCodecStart: Boolean,
+        keyframeAccountingAvailable: Boolean,
+        keyframeDecodedSinceCodecStart: Boolean,
+        msSincePendingKeyframeFed: Long,
+    ): Boolean {
+        if (!renderedSinceCodecStart) return false
+        if (!keyframeAccountingAvailable) return true
+        if (keyframeDecodedSinceCodecStart) return true
+        // A keyframe is in the pipe and the repair is already under way. Past the grace it has
+        // demonstrably produced nothing, which is a holed keyframe, not a picture.
+        return msSincePendingKeyframeFed < PENDING_KEYFRAME_GRACE_MS
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/video/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/video/VideoDecoder.kt
@@ -427,6 +427,10 @@ class VideoDecoder(
     // it is fed like any other and decodes to nothing. See [KeyframeRepairTracker].
     private val keyframeRepair = KeyframeRepairTracker()
 
+    /** When the newest keyframe was queued, for the grace in [PictureCredibilityPolicy]. */
+    @Volatile
+    private var lastKeyframeFedMs = 0L
+
     // --- Corruption concealment - see CorruptionConcealmentPolicy for the design and its bounds.
 
     /**
@@ -578,6 +582,24 @@ class VideoDecoder(
      */
     val hasRenderedThisSession: Boolean get() = renderedThisSession
 
+    /**
+     * Whether what is on the surface is a picture a keyframe accounts for, rather than output
+     * decoded from P-frames alone. See [PictureCredibilityPolicy].
+     */
+    val hasCrediblePicture: Boolean
+        get() = PictureCredibilityPolicy.hasCrediblePicture(
+            renderedSinceCodecStart = lastFrameRenderedMs != 0L,
+            keyframeAccountingAvailable = !usingBundledSoftwareHevc,
+            keyframeDecodedSinceCodecStart = keyframeRepair.keyframeDecoded,
+            msSincePendingKeyframeFed = pendingKeyframeAgeMs(),
+        )
+
+    private fun pendingKeyframeAgeMs(): Long {
+        val fedAtMs = lastKeyframeFedMs
+        if (!keyframeRepair.awaitingOutput || fedAtMs == 0L) return Long.MAX_VALUE
+        return SystemClock.elapsedRealtime() - fedAtMs
+    }
+
     enum class CodecType(val mimeType: String, val displayName: String, val settingsValue: String) {
         H264("video/avc", "H.264/AVC", "H.264"),
         H265("video/hevc", "H.265/HEVC", "H.265")
@@ -660,6 +682,7 @@ class VideoDecoder(
             mSurface = surface
             lastFrameRenderedMs = 0L
             keyframeRepair.reset()
+            lastKeyframeFedMs = 0L
             resetConcealment()
         }
     }
@@ -784,6 +807,7 @@ class VideoDecoder(
             // pending here would be confirmed by the new codec's very first frame. The same restart
             // is why the latency samples go: they were measured against the old session clock.
             keyframeRepair.reset()
+            lastKeyframeFedMs = 0L
             decodeLatency.reset()
             resetConcealment()
             lastKeyframeStarvedAskMs = 0L
@@ -2000,6 +2024,7 @@ class VideoDecoder(
                 // Fed, not yet repaired. The picture counts as repaired at the output side, where
                 // a keyframe that arrived holed is told apart from one that decodes.
                 keyframeRepair.onKeyframeFed(pts)
+                lastKeyframeFedMs = SystemClock.elapsedRealtime()
                 AppLog.i("VideoDecoder: keyframe reached the codec (${inputBuffer.limit()} bytes)")
             }
             return FeedResult.FED
@@ -2284,7 +2309,14 @@ class VideoDecoder(
                         // worth timing are exactly the ones where it might not be.
                         if (!loggedFirstHardwareFrame) {
                             loggedFirstHardwareFrame = true
-                            AppLog.i("First frame rendered (hardware decode)")
+                            // The flag resets per codec instance, so on a warm rebuild this first
+                            // frame can be gray output decoded from a P-frame rather than a picture.
+                            // Say which, keeping the prefix that marks the landmark.
+                            AppLog.i(
+                                if (keyframeRepair.keyframeDecoded) "First frame rendered (hardware decode)"
+                                else "First frame rendered (hardware decode) - no keyframe has decoded " +
+                                    "yet, so this is output, not a picture"
+                            )
                         }
                         onFirstFrameListener?.let { it(); onFirstFrameListener = null }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/video/WarmRelaunchKeyframePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/video/WarmRelaunchKeyframePolicy.kt
@@ -112,7 +112,10 @@ object WarmRelaunchKeyframePolicy {
      * @param sessionHasRendered whether any frame of this session ever reached the screen. False on
      *   a cold start, where the phone is already running sink setup of its own accord and a focus
      *   cycle would interrupt it.
-     * @param renderedSinceSurfaceSet whether the current surface has shown a frame yet.
+     * @param crediblePictureOnSurface whether the current surface is showing a picture a keyframe
+     *   accounts for. Not merely whether a frame rendered: a codec rebuilt with cached parameter
+     *   sets emits gray output from P-frames, and reading that as a picture is what left a live
+     *   view-mode switch gray for a whole GOP. See [PictureCredibilityPolicy].
      * @param transportStarted whether the AAP session is in its steady state. Nothing can be sent
      *   otherwise, and a handshake in progress will produce sink setup on its own.
      * @param msSinceSurfaceSet age of the current surface.
@@ -124,7 +127,7 @@ object WarmRelaunchKeyframePolicy {
      */
     fun decide(
         sessionHasRendered: Boolean,
-        renderedSinceSurfaceSet: Boolean,
+        crediblePictureOnSurface: Boolean,
         transportStarted: Boolean,
         msSinceSurfaceSet: Long,
         msSinceLinkActivity: Long,
@@ -134,7 +137,7 @@ object WarmRelaunchKeyframePolicy {
     ): Action {
         if (!transportStarted) return Action.NONE
         // A picture is on screen. Nothing to ask for, and asking is what costs a stream.
-        if (renderedSinceSurfaceSet) return Action.NONE
+        if (crediblePictureOnSurface) return Action.NONE
         // A cold start has never rendered, so there is no "was working a moment ago" to restore.
         if (!sessionHasRendered) return Action.NONE
         // The phone is gone. Nothing to ask, and the reconnecting overlay owns that case.

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -177,6 +177,7 @@ class SettingsFragment : Fragment() {
     private var pendingUseMeasuredTouchSurface: Boolean? = null
 
     private var pendingKillOnDisconnect: Boolean? = null
+    private var pendingRaiseProjectionDuringCall: Boolean? = null
 
     // Custom Insets
     private var pendingInsetLeft: Int? = null
@@ -306,6 +307,7 @@ class SettingsFragment : Fragment() {
         pendingUseMeasuredTouchSurface = settings.useMeasuredTouchSurface
 
         pendingKillOnDisconnect = settings.killOnDisconnect
+        pendingRaiseProjectionDuringCall = settings.raiseProjectionDuringCall
         pendingAutoEnableHotspot = settings.autoEnableHotspot
         pendingFakeSpeed = settings.fakeSpeed
         pendingUseLibusb = settings.useLibusb
@@ -421,6 +423,7 @@ class SettingsFragment : Fragment() {
         pendingHudMirroring = settings.hudMirroring
         pendingUseMeasuredTouchSurface = settings.useMeasuredTouchSurface
         pendingKillOnDisconnect = settings.killOnDisconnect
+        pendingRaiseProjectionDuringCall = settings.raiseProjectionDuringCall
         pendingAutoEnableHotspot = settings.autoEnableHotspot
         pendingFakeSpeed = settings.fakeSpeed
         pendingUseLibusb = settings.useLibusb
@@ -566,6 +569,7 @@ class SettingsFragment : Fragment() {
         pendingUseMeasuredTouchSurface?.let { settings.useMeasuredTouchSurface = it }
 
         pendingKillOnDisconnect?.let { settings.killOnDisconnect = it }
+        pendingRaiseProjectionDuringCall?.let { settings.raiseProjectionDuringCall = it }
         pendingAutoEnableHotspot?.let { settings.autoEnableHotspot = it }
         pendingFakeSpeed?.let { settings.fakeSpeed = it }
         pendingUseLibusb?.let { settings.useLibusb = it }
@@ -687,6 +691,7 @@ class SettingsFragment : Fragment() {
                         pendingAssistantVolumeOffset != settings.assistantVolumeOffset ||
                         pendingNavigationVolumeOffset != settings.navigationVolumeOffset ||
                         pendingKillOnDisconnect != settings.killOnDisconnect ||
+                        pendingRaiseProjectionDuringCall != settings.raiseProjectionDuringCall ||
                         pendingAutoEnableHotspot != settings.autoEnableHotspot ||
                         pendingFakeSpeed != settings.fakeSpeed ||
                         pendingWifiConnectionMode != settings.wifiConnectionMode ||
@@ -1330,6 +1335,22 @@ class SettingsFragment : Fragment() {
                 }
             }
         ))
+
+        // Self Mode is the only mode where the phone's call screen and the projection share a
+        // screen, so it is the only mode this can do anything in.
+        if (settings.showsSelf()) {
+            items.add(SettingItem.ToggleSettingEntry(
+                stableId = "raiseProjectionDuringCall",
+                nameResId = R.string.raise_projection_during_call,
+                descriptionResId = R.string.raise_projection_during_call_description,
+                isChecked = pendingRaiseProjectionDuringCall!!,
+                onCheckedChanged = { isChecked ->
+                    pendingRaiseProjectionDuringCall = isChecked
+                    checkChanges()
+                    updateSettingsList()
+                }
+            ))
+        }
 
         // --- Navigation Settings ---
         items.add(SettingItem.CategoryHeader("navigation", R.string.category_navigation))

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -532,7 +532,12 @@ class SettingsFragment : Fragment() {
         pendingBluetoothAddress?.let { settings.bluetoothAddress = it }
         pendingEnableAudioSink?.let { settings.enableAudioSink = it }
         pendingStaticAudioFocus?.let { settings.staticAudioFocus = it }
+        // Re-picking the focus mode is the way back from a wrong verdict: AUTO learns that taking
+        // system audio focus stops the phone's own playback and then stops asking for it, and two
+        // tracks that happened to end quickly can teach it that wrongly.
+        val focusModeChanged = pendingPlaybackFocusMode != null && pendingPlaybackFocusMode != settings.playbackFocusMode
         pendingPlaybackFocusMode?.let { settings.playbackFocusMode = it }
+        if (focusModeChanged) settings.playbackFocusSelfDefeating = false
         pendingSeparateAudioStreams?.let { settings.separateAudioStreams = it }
         pendingUseAacAudio?.let { settings.useAacAudio = it }
         pendingAttachHwDspEqualizer?.let { settings.attachHwDspEqualizer = it }

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -685,14 +685,22 @@ class Settings(private val context: Context) {
         set(value) { prefs.edit().putBoolean("static-audio-focus", value).apply() }
 
     // Whether AA playback takes system audio focus, so another local player (typically the car
-    // radio) pauses while it runs. AUTO skips it when a Bluetooth media link is up, because the
-    // A2DP sink answers our focus grab by pausing the phone that is feeding us. See
+    // radio) pauses while it runs. AUTO takes it until the phone is seen cutting its own audio in
+    // response, which is what happens when this head unit is its Bluetooth A2DP sink. See
     // PlaybackFocusPolicy for the whole story; ALWAYS and NEVER are the manual overrides.
     var playbackFocusMode: PlaybackFocusPolicy.Mode
         get() = PlaybackFocusPolicy.Mode.fromInt(
             prefs.getInt("playback-focus-mode", PlaybackFocusPolicy.Mode.AUTO.value)
         )
         set(value) { prefs.edit().putInt("playback-focus-mode", value.value).apply() }
+
+    // What AUTO learned: taking system audio focus stops the phone's own playback on this head
+    // unit, so stop asking for it. Remembered because the trial that finds it out costs the user a
+    // couple of interrupted tracks, and there is no reason to pay that at every connect. Re-picking
+    // the focus mode clears it, which is the way back from a false positive.
+    var playbackFocusSelfDefeating: Boolean
+        get() = prefs.getBoolean("playback-focus-self-defeating", false)
+        set(value) { prefs.edit().putBoolean("playback-focus-self-defeating", value).apply() }
 
     // Whether the physical media buttons reach Android Auto, or are left to the Bluetooth side that
     // may already act on the same press — two consumers of one button skip two tracks. See

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -131,6 +131,19 @@ class Settings(private val context: Context) {
             prefs.edit().putBoolean(KEY_SYNC_MEDIA_SESSION_AA_METADATA, value).apply()
         }
 
+    /**
+     * In Self Mode, put the projection back on top when a call covers it.
+     *
+     * Android Auto's own call UI is already on the projected surface, so the phone's call screen
+     * only hides it. Self Mode only: anywhere else the call screen is on the phone, not on the
+     * head unit.
+     */
+    var raiseProjectionDuringCall: Boolean
+        get() = prefs.getBoolean("raise-projection-during-call", true)
+        set(value) {
+            prefs.edit().putBoolean("raise-projection-during-call", value).apply()
+        }
+
     var nightMode: NightMode
         get() {
             val value = prefs.getInt("night-mode", 0)
@@ -643,6 +656,9 @@ class Settings(private val context: Context) {
     fun showsWifi(): Boolean = connectionModes.isEmpty() || ConnectionMode.WIFI in connectionModes
     /** The external-GPS choice only applies when a phone is connected; false only for Self-only. */
     fun showsExternalGps(): Boolean = showsUsb() || showsWifi()
+
+    /** Whether Self Mode settings should be shown (empty selection shows everything). */
+    fun showsSelf(): Boolean = connectionModes.isEmpty() || ConnectionMode.SELF in connectionModes
 
     var autoConnectLastSession: Boolean
         get() = prefs.getBoolean("auto-connect-last-session", false)

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -952,4 +952,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (تأخير %2$dث)</string>
     <string name="failed_aa_not_system">فشل: أندرويد أوتو غير مثبت كتطبيق نظام!</string>
     <string name="failed_aa_not_installed">فشل: أندرويد أوتو غير مثبت!</string>
+    <string name="raise_projection_during_call">البقاء في Android Auto أثناء المكالمات</string>
+    <string name="raise_projection_during_call_description">الوضع الذاتي فقط. يُعيد العرض فوق شاشة اتصال الهاتف بحيث يتم الرد على المكالمات وإنهاؤها من واجهة Android Auto</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -954,4 +954,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (zpoždění %2$ds)</string>
     <string name="failed_aa_not_system">Selhalo: Android Auto není nainstalováno jako systémová aplikace!</string>
     <string name="failed_aa_not_installed">Selhalo: Android Auto není nainstalováno!</string>
+    <string name="raise_projection_during_call">Zůstat v Android Auto během hovorů</string>
+    <string name="raise_projection_during_call_description">Pouze Self Mode. Vrátí projekci nad obrazovku hovoru telefonu, takže se hovory přijímají a ukončují v rozhraní Android Auto</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -955,4 +955,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (%2$ds Verzögerung)</string>
     <string name="failed_aa_not_system">Fehlgeschlagen: Android Auto ist nicht als System-App installiert!</string>
     <string name="failed_aa_not_installed">Fehlgeschlagen: Android Auto ist nicht installiert!</string>
+    <string name="raise_projection_during_call">Während Anrufen in Android Auto bleiben</string>
+    <string name="raise_projection_during_call_description">Nur Self Mode. Holt die Projektion über den Anrufbildschirm des Telefons zurück, sodass Anrufe in der Android-Auto-Oberfläche angenommen und beendet werden</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -963,4 +963,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (%2$ds de retardo)</string>
     <string name="failed_aa_not_system">Error: ¡Android Auto no está instalado como aplicación del sistema!</string>
     <string name="failed_aa_not_installed">Error: ¡Android Auto no está instalado!</string>
+    <string name="raise_projection_during_call">Permanecer en Android Auto durante las llamadas</string>
+    <string name="raise_projection_during_call_description">Solo Modo autónomo. Devuelve la proyección sobre la pantalla de llamada del teléfono para contestar y colgar las llamadas desde la interfaz de Android Auto</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -962,4 +962,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (%2$ds de retardo)</string>
     <string name="failed_aa_not_system">Error: ¡Android Auto no está instalado como aplicación del sistema!</string>
     <string name="failed_aa_not_installed">Error: ¡Android Auto no está instalado!</string>
+    <string name="raise_projection_during_call">Permanecer en Android Auto durante las llamadas</string>
+    <string name="raise_projection_during_call_description">Solo Modo Autónomo. Devuelve la proyección sobre la pantalla de llamada del teléfono para contestar y colgar las llamadas desde la interfaz de Android Auto</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1003,4 +1003,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (%2$ds de délai)</string>
     <string name="failed_aa_not_system">Échec : Android Auto n\'est pas installé en tant qu\'application système !</string>
     <string name="failed_aa_not_installed">Échec : Android Auto n\'est pas installé !</string>
+    <string name="raise_projection_during_call">Rester dans Android Auto pendant les appels</string>
+    <string name="raise_projection_during_call_description">Self Mode uniquement. Ramène la projection au-dessus de l\'écran d\'appel du téléphone pour répondre et raccrocher depuis l\'interface Android Auto</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -950,4 +950,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (%2$d mp késleltetés)</string>
     <string name="failed_aa_not_system">Sikertelen: Az Android Auto nincs rendszeralkalmazásként telepítve!</string>
     <string name="failed_aa_not_installed">Sikertelen: Az Android Auto nincs telepítve!</string>
+    <string name="raise_projection_during_call">Maradás az Android Autóban hívások alatt</string>
+    <string name="raise_projection_during_call_description">Csak Önálló mód. Visszahozza a kivetítést a telefon hívásképernyője fölé, így a hívások az Android Auto felületén fogadhatók és fejezhetők be</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -957,4 +957,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (ritardo di %2$ds)</string>
     <string name="failed_aa_not_system">Operazione non riuscita: Android Auto non è installato come app di sistema!</string>
     <string name="failed_aa_not_installed">Operazione non riuscita: Android Auto non è installato!</string>
+    <string name="raise_projection_during_call">Resta in Android Auto durante le chiamate</string>
+    <string name="raise_projection_during_call_description">Solo Modalità Self. Riporta la proiezione sopra la schermata di chiamata del telefono, così le chiamate si rispondono e si chiudono nell\'interfaccia di Android Auto</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -958,4 +958,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (%2$d秒の遅延)</string>
     <string name="failed_aa_not_system">失敗: Android Auto がシステムアプリとしてインストールされていません！</string>
     <string name="failed_aa_not_installed">失敗: Android Auto がインストールされていません！</string>
+    <string name="raise_projection_during_call">通話中もAndroid Autoに留まる</string>
+    <string name="raise_projection_during_call_description">セルフモードのみ。電話の通話画面の上に投影を戻し、Android Autoの画面で通話の応答と終了ができるようにします</string>
 </resources>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -935,4 +935,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (%2$dწმ დაყოვნება)</string>
     <string name="failed_aa_not_system">ვერ მოხერხდა: Android Auto არ არის დაინსტალირებული როგორც სისტემური აპი!</string>
     <string name="failed_aa_not_installed">ვერ მოხერხდა: Android Auto არ არის დაინსტალირებული!</string>
+    <string name="raise_projection_during_call">ზარების დროს Android Auto-ში დარჩენა</string>
+    <string name="raise_projection_during_call_description">მხოლოდ ავტონომიური რეჟიმი. აბრუნებს პროექციას ტელეფონის ზარის ეკრანის ზემოთ, ასე რომ ზარებზე პასუხი და დასრულება Android Auto-ს ინტერფეისში ხდება</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -951,4 +951,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (%2$d초 지연)</string>
     <string name="failed_aa_not_system">실패: Android Auto가 시스템 앱으로 설치되어 있지 않습니다!</string>
     <string name="failed_aa_not_installed">실패: Android Auto가 설치되어 있지 않습니다!</string>
+    <string name="raise_projection_during_call">통화 중에도 Android Auto에 머무르기</string>
+    <string name="raise_projection_during_call_description">단독 모드 전용. 전화의 통화 화면 위로 프로젝션을 다시 가져와 Android Auto 화면에서 통화를 받고 끊을 수 있게 합니다</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -954,4 +954,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (%2$ds vertraging)</string>
     <string name="failed_aa_not_system">Mislukt: Android Auto is niet geïnstalleerd als systeem-app!</string>
     <string name="failed_aa_not_installed">Mislukt: Android Auto is niet geïnstalleerd!</string>
+    <string name="raise_projection_during_call">In Android Auto blijven tijdens gesprekken</string>
+    <string name="raise_projection_during_call_description">Alleen Self Mode. Haalt de projectie terug over het belscherm van de telefoon, zodat gesprekken in de Android Auto-interface worden aangenomen en beëindigd</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -953,4 +953,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (%2$ds opóźnienia)</string>
     <string name="failed_aa_not_system">Błąd: Android Auto nie jest zainstalowany jako aplikacja systemowa!</string>
     <string name="failed_aa_not_installed">Błąd: Android Auto nie jest zainstalowane!</string>
+    <string name="raise_projection_during_call">Pozostań w Android Auto podczas połączeń</string>
+    <string name="raise_projection_during_call_description">Tylko Tryb samodzielny. Przywraca projekcję nad ekran połączenia telefonu, dzięki czemu połączenia odbiera się i kończy w interfejsie Android Auto</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -955,4 +955,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (%2$ds de atraso)</string>
     <string name="failed_aa_not_system">Falha: O Android Auto não está instalado como aplicativo do sistema!</string>
     <string name="failed_aa_not_installed">Falha: O Android Auto não está instalado!</string>
+    <string name="raise_projection_during_call">Permanecer no Android Auto durante chamadas</string>
+    <string name="raise_projection_during_call_description">Somente Self Mode. Traz a projeção de volta sobre a tela de chamada do telefone, para atender e encerrar as chamadas na interface do Android Auto</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -951,4 +951,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (întârziere %2$ds)</string>
     <string name="failed_aa_not_system">Eșuat: Android Auto nu este instalat ca aplicație de sistem!</string>
     <string name="failed_aa_not_installed">Eșuat: Android Auto nu este instalat!</string>
+    <string name="raise_projection_during_call">Rămâi în Android Auto în timpul apelurilor</string>
+    <string name="raise_projection_during_call_description">Doar Mod local. Readuce proiecția peste ecranul de apel al telefonului, astfel încât apelurile se răspund și se închid din interfața Android Auto</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -953,4 +953,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (задержка %2$dс)</string>
     <string name="failed_aa_not_system">Ошибка: Android Auto не установлен как системное приложение!</string>
     <string name="failed_aa_not_installed">Ошибка: Android Auto не установлен!</string>
+    <string name="raise_projection_during_call">Оставаться в Android Auto во время звонков</string>
+    <string name="raise_projection_during_call_description">Только Автономный режим. Возвращает проекцию поверх экрана вызова телефона, чтобы отвечать на звонки и завершать их в интерфейсе Android Auto</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -949,4 +949,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (%2$d sn gecikme)</string>
     <string name="failed_aa_not_system">Başarısız: Android Auto bir sistem uygulaması olarak yüklü değil!</string>
     <string name="failed_aa_not_installed">Başarısız: Android Auto yüklü değil!</string>
+    <string name="raise_projection_during_call">Aramalar sırasında Android Auto\'da kal</string>
+    <string name="raise_projection_during_call_description">Yalnızca Dahili Mod. Yansıtmayı telefonun arama ekranının üzerine geri getirir, böylece aramalar Android Auto arayüzünden yanıtlanır ve sonlandırılır</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -955,4 +955,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (затримка %2$dс)</string>
     <string name="failed_aa_not_system">Помилка: Android Auto не встановлено як системний додаток!</string>
     <string name="failed_aa_not_installed">Помилка: Android Auto не встановлено!</string>
+    <string name="raise_projection_during_call">Залишатися в Android Auto під час дзвінків</string>
+    <string name="raise_projection_during_call_description">Лише Самостійний режим. Повертає проєкцію поверх екрана виклику телефону, щоб відповідати на дзвінки та завершувати їх в інтерфейсі Android Auto</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -957,4 +957,6 @@
     <string name="auto_connect_delay_summary_format">%1$s (trễ %2$d giây)</string>
     <string name="failed_aa_not_system">Thất bại: Android Auto không được cài đặt dưới dạng ứng dụng hệ thống!</string>
     <string name="failed_aa_not_installed">Thất bại: Android Auto chưa được cài đặt!</string>
+    <string name="raise_projection_during_call">Ở lại Android Auto trong khi gọi điện</string>
+    <string name="raise_projection_during_call_description">Chỉ Chế độ độc lập. Đưa màn hình chiếu trở lại phía trên màn hình cuộc gọi của điện thoại, để trả lời và kết thúc cuộc gọi trong giao diện Android Auto</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -953,4 +953,6 @@
     <string name="auto_connect_delay_summary_format">%1$s（延遲 %2$d 秒）</string>
     <string name="failed_aa_not_system">失敗：Android Auto 未作為系統應用程式安裝！</string>
     <string name="failed_aa_not_installed">失敗：未安裝 Android Auto！</string>
+    <string name="raise_projection_during_call">通話期間停留在 Android Auto</string>
+    <string name="raise_projection_during_call_description">僅限自我模式。將投影帶回手機通話畫面之上,以便在 Android Auto 介面中接聽及結束通話</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -741,6 +741,8 @@
 
     <string name="kill_on_disconnect">Close app on disconnect</string>
     <string name="kill_on_disconnect_description">Automatically close the app when Android Auto disconnects</string>
+    <string name="raise_projection_during_call">Stay in Android Auto during calls</string>
+    <string name="raise_projection_during_call_description">Self Mode only. Brings the projection back over the phone\'s call screen so calls are answered and ended in the Android Auto interface</string>
     <string name="kill_on_disconnect_warning_title">Warning</string>
     <string name="kill_on_disconnect_warning">The following reconnection settings will conflict with closing the app on disconnect:\n\n%1$s\n\nYour initial connection settings (auto-connect, auto-start) will still work when the headunit turns on. However, after the first disconnection the app will close immediately instead of trying to reconnect.\n\nNote: Some aftermarket head units never fully shut down — they hibernate instead, similar to a phone that locks its screen but never actually powers off. With this option enabled, the app will close after the first disconnection and may not reopen automatically on the next ignition cycle.\n\nWould you like to disable the reconnection settings listed above?</string>
     <string name="kill_on_disconnect_disable_and_enable">Disable and enable</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -487,7 +487,7 @@
     <string name="playback_focus_mode_auto">Automatic</string>
     <string name="playback_focus_mode_always">Always</string>
     <string name="playback_focus_mode_never">Never</string>
-    <string name="playback_focus_mode_auto_hint">Pauses another player on the headunit (for example the radio) while Android Auto audio plays, but not while a Bluetooth audio link is connected — that link is usually the same phone, and pausing it would stop Android Auto\'s own sound.</string>
+    <string name="playback_focus_mode_auto_hint">Pauses another player on the headunit (for example the radio) while Android Auto audio plays. If that turns out to stop your phone\'s own playback instead, which happens when the headunit is the phone\'s Bluetooth speaker, it stops doing it and remembers. Choose this mode again to let it try once more.</string>
     <string name="playback_focus_mode_always_hint">Always pauses other audio while Android Auto plays. If your music stops after a second or two whenever Bluetooth is on, switch back to Automatic.</string>
     <string name="playback_focus_mode_never_hint">Never touches system audio focus. Other audio on the headunit may keep playing over Android Auto.</string>
     <string name="playback_focus_mode_static_hint">With Static Audio Focus on, this applies from the moment the phone connects and lasts the whole session, rather than only while audio is playing.</string>

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/ProjectionWatchdogPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/ProjectionWatchdogPolicyTest.kt
@@ -133,10 +133,10 @@ class ProjectionWatchdogPolicyTest {
     private fun nudge(
         sessionLive: Boolean = true,
         surfaceSet: Boolean = true,
-        renderedSinceSurfaceSet: Boolean = false,
+        crediblePictureOnSurface: Boolean = false,
         warmRelaunchCycleSpent: Boolean = false,
     ) = ProjectionWatchdogPolicy.shouldNudgeForFirstFrame(
-        sessionLive, surfaceSet, renderedSinceSurfaceSet, warmRelaunchCycleSpent
+        sessionLive, surfaceSet, crediblePictureOnSurface, warmRelaunchCycleSpent
     )
 
     @Test
@@ -146,7 +146,9 @@ class ProjectionWatchdogPolicyTest {
 
     @Test
     fun `a picture on the current surface ends the loop`() {
-        assertFalse(nudge(renderedSinceSurfaceSet = true))
+        assertFalse(nudge(crediblePictureOnSurface = true))
+        // Gray P-frame output after a backend switch is not a picture, so the nudge stays armed.
+        assertTrue(nudge(sessionLive = true, surfaceSet = true, crediblePictureOnSurface = false))
     }
 
     @Test
@@ -181,7 +183,7 @@ class ProjectionWatchdogPolicyTest {
         // compile, which is the point.
         assertTrue(
             "the rule must depend only on session, surface, picture and the escalation's claim",
-            nudge(sessionLive = true, surfaceSet = true, renderedSinceSurfaceSet = false)
+            nudge(sessionLive = true, surfaceSet = true, crediblePictureOnSurface = false)
         )
     }
 

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/VideoFocusReleasePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/VideoFocusReleasePolicyTest.kt
@@ -1,0 +1,71 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.VideoFocusReleasePolicy.TOUCH_WINDOW_MS
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VideoFocusReleasePolicyTest {
+
+    @Test
+    fun `a cover with no touch behind it always releases`() {
+        // The regression guard. This is Home, a notification, an alarm and every real teardown,
+        // and the release is what brings the picture back in 42-96 ms instead of seconds.
+        assertTrue(release(coverFollowsTouch = false))
+        assertTrue(release(coverFollowsTouch = false, sessionConnected = false))
+        assertTrue(release(coverFollowsTouch = false, pipActive = true))
+    }
+
+    @Test
+    fun `a keyboard-shaped cover holds focus`() {
+        assertFalse(release())
+    }
+
+    @Test
+    fun `there is nothing to protect without a session`() {
+        assertTrue(release(sessionConnected = false))
+    }
+
+    @Test
+    fun `an activity that is going away tells the phone`() {
+        assertTrue(release(activityEnding = true))
+    }
+
+    @Test
+    fun `picture-in-picture is covered on purpose`() {
+        assertTrue(release(pipActive = true))
+    }
+
+    @Test
+    fun `a cycle already holding focus released is left alone`() {
+        // Withholding would change nothing - focus is already released - and the cycle owns the
+        // regain that follows.
+        assertTrue(release(focusCycleInFlight = true))
+    }
+
+    @Test
+    fun `the touch window is inclusive at its edge`() {
+        val start = 10_000L
+        assertTrue(VideoFocusReleasePolicy.coverFollowsTouch(start, start + TOUCH_WINDOW_MS))
+        assertFalse(VideoFocusReleasePolicy.coverFollowsTouch(start, start + TOUCH_WINDOW_MS + 1))
+    }
+
+    @Test
+    fun `a session that has never forwarded a touch has no touch to follow`() {
+        assertFalse(VideoFocusReleasePolicy.coverFollowsTouch(lastTouchAtMs = 0L, coveredAtMs = 10_000L))
+    }
+
+    private fun release(
+        coverFollowsTouch: Boolean = true,
+        sessionConnected: Boolean = true,
+        activityEnding: Boolean = false,
+        pipActive: Boolean = false,
+        focusCycleInFlight: Boolean = false,
+    ): Boolean = VideoFocusReleasePolicy.shouldReleaseOnSurfaceLost(
+        coverFollowsTouch = coverFollowsTouch,
+        sessionConnected = sessionConnected,
+        activityEnding = activityEnding,
+        pipActive = pipActive,
+        focusCycleInFlight = focusCycleInFlight,
+    )
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/self/SelfModeCallRaisePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/self/SelfModeCallRaisePolicyTest.kt
@@ -1,0 +1,217 @@
+package com.andrerinas.openheadunit.connection.self
+
+import com.andrerinas.openheadunit.connection.self.SelfModeCallRaisePolicy.Action
+import com.andrerinas.openheadunit.connection.self.SelfModeCallRaisePolicy.ATTEMPT_CARRY_WINDOW_MS
+import com.andrerinas.openheadunit.connection.self.SelfModeCallRaisePolicy.CALL_CONFIRM_WINDOW_MS
+import com.andrerinas.openheadunit.connection.self.SelfModeCallRaisePolicy.Episode
+import com.andrerinas.openheadunit.connection.self.SelfModeCallRaisePolicy.FIRST_ATTEMPT_DELAY_MS
+import com.andrerinas.openheadunit.connection.self.SelfModeCallRaisePolicy.IDLE_TICK_MS
+import com.andrerinas.openheadunit.connection.self.SelfModeCallRaisePolicy.MAX_ATTEMPTS_PER_CALL
+import com.andrerinas.openheadunit.connection.self.SelfModeCallRaisePolicy.POST_CALL_SETTLE_MS
+import com.andrerinas.openheadunit.connection.self.SelfModeCallRaisePolicy.RETRY_INTERVAL_MS
+import com.andrerinas.openheadunit.connection.self.SelfModeCallRaisePolicy.TICK_MS
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SelfModeCallRaisePolicyTest {
+
+    private val start = 10_000L
+
+    private fun decide(
+        nowMs: Long,
+        episode: Episode,
+        callActive: Boolean = true,
+        isForeground: Boolean = false,
+        pipActive: Boolean = false,
+    ): Action = SelfModeCallRaisePolicy.decide(
+        nowMs = nowMs,
+        episode = SelfModeCallRaisePolicy.observe(episode, nowMs, callActive),
+        callActive = callActive,
+        isForeground = isForeground,
+        pipActive = pipActive,
+    )
+
+    /** One tick of the loop the activity runs, so a whole call can be played out in a test. */
+    private fun tick(episode: Episode, nowMs: Long, callActive: Boolean): Pair<Action, Episode> {
+        val observed = SelfModeCallRaisePolicy.observe(episode, nowMs, callActive)
+        val action = SelfModeCallRaisePolicy.decide(
+            nowMs = nowMs,
+            episode = observed,
+            callActive = callActive,
+            isForeground = false,
+            pipActive = false,
+        )
+        val next = if (action == Action.RAISE) {
+            SelfModeCallRaisePolicy.onRaised(observed, nowMs, callActive)
+        } else {
+            observed
+        }
+        return action to next
+    }
+
+    @Test
+    fun `the first attempt waits for the call screen to settle`() {
+        val episode = Episode(startedAtMs = start)
+        assertEquals(Action.WAIT, decide(nowMs = start + FIRST_ATTEMPT_DELAY_MS - 1, episode = episode))
+        assertEquals(Action.RAISE, decide(nowMs = start + FIRST_ATTEMPT_DELAY_MS, episode = episode))
+    }
+
+    @Test
+    fun `attempts are spaced by the retry interval`() {
+        val episode = Episode(startedAtMs = start, sawCallActive = true, attempts = 1, lastAttemptAtMs = start + 600)
+        assertEquals(Action.WAIT, decide(nowMs = start + 600 + RETRY_INTERVAL_MS - 1, episode = episode))
+        assertEquals(Action.RAISE, decide(nowMs = start + 600 + RETRY_INTERVAL_MS, episode = episode))
+    }
+
+    @Test
+    fun `a call gets exactly three attempts and then silence`() {
+        var episode = Episode(startedAtMs = start)
+        var now = start
+        var raises = 0
+        repeat(120) {
+            now += TICK_MS
+            val (action, next) = tick(episode, now, callActive = true)
+            if (action == Action.RAISE) raises++
+            episode = next
+        }
+        assertEquals(MAX_ATTEMPTS_PER_CALL, raises)
+        assertEquals(Action.WAIT, tick(episode, now + TICK_MS, callActive = true).first)
+    }
+
+    @Test
+    fun `the projection coming back closes the episode`() {
+        val episode = Episode(startedAtMs = start, sawCallActive = true, attempts = 1, lastAttemptAtMs = start)
+        assertEquals(Action.DONE, decide(nowMs = start + 5_000, episode = episode, isForeground = true))
+    }
+
+    @Test
+    fun `picture-in-picture closes the episode`() {
+        val episode = Episode(startedAtMs = start, sawCallActive = true)
+        assertEquals(Action.DONE, decide(nowMs = start + 5_000, episode = episode, pipActive = true))
+    }
+
+    @Test
+    fun `something that is not a call is left alone`() {
+        val episode = Episode(startedAtMs = start)
+        assertEquals(
+            Action.WAIT,
+            decide(nowMs = start + CALL_CONFIRM_WINDOW_MS - 1, episode = episode, callActive = false)
+        )
+        assertEquals(
+            Action.DONE,
+            decide(nowMs = start + CALL_CONFIRM_WINDOW_MS, episode = episode, callActive = false)
+        )
+    }
+
+    @Test
+    fun `a call that registers late still opens the episode`() {
+        var episode = Episode(startedAtMs = start)
+        val (early, afterEarly) = tick(episode, start + TICK_MS, callActive = false)
+        assertEquals(Action.WAIT, early)
+        episode = afterEarly
+
+        val (late, _) = tick(episode, start + FIRST_ATTEMPT_DELAY_MS, callActive = true)
+        assertEquals(Action.RAISE, late)
+    }
+
+    @Test
+    fun `the call ending gets one attempt, and only one`() {
+        var episode = Episode(startedAtMs = start, sawCallActive = true, attempts = MAX_ATTEMPTS_PER_CALL)
+        val endedAt = start + 30_000
+
+        assertEquals(Action.WAIT, tick(episode, endedAt, callActive = false).first)
+        episode = tick(episode, endedAt, callActive = false).second
+
+        val (action, afterRaise) = tick(episode, endedAt + POST_CALL_SETTLE_MS, callActive = false)
+        assertEquals(Action.RAISE, action)
+        assertEquals(
+            Action.DONE,
+            tick(afterRaise, endedAt + POST_CALL_SETTLE_MS + TICK_MS, callActive = false).first
+        )
+    }
+
+    @Test
+    fun `the post-call attempt never happens when the projection came back on its own`() {
+        val episode = Episode(
+            startedAtMs = start,
+            sawCallActive = true,
+            attempts = MAX_ATTEMPTS_PER_CALL,
+            callEndedAtMs = start + 30_000,
+        )
+        assertEquals(
+            Action.DONE,
+            decide(
+                nowMs = start + 30_000 + POST_CALL_SETTLE_MS,
+                episode = episode,
+                callActive = false,
+                isForeground = true,
+            )
+        )
+    }
+
+    @Test
+    fun `the post-call attempt does not spend a call attempt`() {
+        val episode = Episode(startedAtMs = start, sawCallActive = true, attempts = 1, callEndedAtMs = start + 5_000)
+        val raised = SelfModeCallRaisePolicy.onRaised(episode, start + 6_000, callActive = false)
+        assertEquals(1, raised.attempts)
+        assertTrue(raised.postCallAttemptUsed)
+    }
+
+    @Test
+    fun `a call screen that relaunches does not buy a second budget`() {
+        val spentAtMs = start + 3_000
+        assertEquals(
+            MAX_ATTEMPTS_PER_CALL,
+            SelfModeCallRaisePolicy.carriedAttempts(
+                previousAttempts = MAX_ATTEMPTS_PER_CALL,
+                lastAttemptAtMs = spentAtMs,
+                nowMs = spentAtMs + ATTEMPT_CARRY_WINDOW_MS,
+            )
+        )
+        assertEquals(
+            Action.WAIT,
+            decide(
+                nowMs = spentAtMs + ATTEMPT_CARRY_WINDOW_MS,
+                episode = Episode(
+                    startedAtMs = spentAtMs + ATTEMPT_CARRY_WINDOW_MS,
+                    sawCallActive = true,
+                    attempts = MAX_ATTEMPTS_PER_CALL,
+                    lastAttemptAtMs = spentAtMs,
+                ),
+            )
+        )
+    }
+
+    @Test
+    fun `a later call starts with a full budget`() {
+        assertEquals(
+            0,
+            SelfModeCallRaisePolicy.carriedAttempts(
+                previousAttempts = MAX_ATTEMPTS_PER_CALL,
+                lastAttemptAtMs = start,
+                nowMs = start + ATTEMPT_CARRY_WINDOW_MS + 1,
+            )
+        )
+        assertEquals(
+            0,
+            SelfModeCallRaisePolicy.carriedAttempts(
+                previousAttempts = MAX_ATTEMPTS_PER_CALL,
+                lastAttemptAtMs = 0L,
+                nowMs = start,
+            )
+        )
+    }
+
+    @Test
+    fun `ticking slows down once the attempts are spent`() {
+        val spending = Episode(startedAtMs = start, sawCallActive = true, attempts = MAX_ATTEMPTS_PER_CALL - 1)
+        assertEquals(TICK_MS, SelfModeCallRaisePolicy.nextTickDelayMs(spending))
+
+        val spent = spending.copy(attempts = MAX_ATTEMPTS_PER_CALL)
+        assertEquals(IDLE_TICK_MS, SelfModeCallRaisePolicy.nextTickDelayMs(spent))
+
+        val ended = spent.copy(callEndedAtMs = start + 30_000)
+        assertEquals(TICK_MS, SelfModeCallRaisePolicy.nextTickDelayMs(ended))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/audio/CallStateTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/audio/CallStateTest.kt
@@ -1,0 +1,71 @@
+package com.andrerinas.openheadunit.decoder.audio
+
+import android.media.AudioManager
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CallStateTest {
+
+    @Test
+    fun `a cellular call is a call`() {
+        assertTrue(
+            CallState.isCallActive(
+                audioMode = AudioManager.MODE_IN_CALL,
+                appHoldsCommunicationMode = false
+            )
+        )
+    }
+
+    @Test
+    fun `a voip call is a call`() {
+        assertTrue(
+            CallState.isCallActive(
+                audioMode = AudioManager.MODE_IN_COMMUNICATION,
+                appHoldsCommunicationMode = false
+            )
+        )
+    }
+
+    @Test
+    fun `our own microphone uplink is not a call`() {
+        assertFalse(
+            CallState.isCallActive(
+                audioMode = AudioManager.MODE_IN_COMMUNICATION,
+                appHoldsCommunicationMode = true
+            )
+        )
+    }
+
+    @Test
+    fun `the uplink does not mask a cellular call`() {
+        assertTrue(
+            CallState.isCallActive(
+                audioMode = AudioManager.MODE_IN_CALL,
+                appHoldsCommunicationMode = true
+            )
+        )
+    }
+
+    @Test
+    fun `nothing playing is not a call`() {
+        assertFalse(
+            CallState.isCallActive(
+                audioMode = AudioManager.MODE_NORMAL,
+                appHoldsCommunicationMode = false
+            )
+        )
+    }
+
+    @Test
+    fun `ringing is not yet a call`() {
+        assertFalse(
+            CallState.isCallActive(
+                audioMode = AudioManager.MODE_RINGTONE,
+                appHoldsCommunicationMode = false
+            )
+        )
+        assertTrue(CallState.isCallStarting(audioMode = AudioManager.MODE_RINGTONE))
+        assertFalse(CallState.isCallStarting(audioMode = AudioManager.MODE_NORMAL))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/audio/PlaybackFocusPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/audio/PlaybackFocusPolicyTest.kt
@@ -13,14 +13,12 @@ class PlaybackFocusPolicyTest {
         staticAudioFocus: Boolean = false,
         audioSinkEnabled: Boolean = true,
         isAudioChannel: Boolean = true,
-        btMediaLinkActive: Boolean = false,
         selfDefeatingLatched: Boolean = false
     ) = PlaybackFocusPolicy.shouldAcquire(
         mode = mode,
         staticAudioFocus = staticAudioFocus,
         audioSinkEnabled = audioSinkEnabled,
         isAudioChannel = isAudioChannel,
-        btMediaLinkActive = btMediaLinkActive,
         selfDefeatingLatched = selfDefeatingLatched
     )
 
@@ -50,36 +48,38 @@ class PlaybackFocusPolicyTest {
     // --- AUTO ---
 
     @Test
-    fun `auto takes focus when no bluetooth media link is up`() {
-        // The car-radio case this feature was written for: nothing on Bluetooth, so the player we
-        // silence is genuinely a local one.
-        assertTrue(acquire(mode = Mode.AUTO, btMediaLinkActive = false))
+    fun `auto takes focus until the harm is observed`() {
+        // The car-radio case this feature was written for, and also the head unit that unmutes its
+        // amplifier from the focus request: both need us to ask.
+        assertTrue(acquire(mode = Mode.AUTO))
     }
 
     @Test
-    fun `auto declines while a bluetooth media link is up`() {
-        // Taking focus here makes the A2DP sink AVRCP-pause the phone that is feeding us.
-        assertFalse(acquire(mode = Mode.AUTO, btMediaLinkActive = true))
+    fun `auto declines once the latch has tripped`() {
+        // Taking focus here makes the A2DP sink AVRCP-pause the phone that is feeding us, and the
+        // latch is what saw it happen. This is the only thing that stops AUTO.
+        assertFalse(acquire(mode = Mode.AUTO, selfDefeatingLatched = true))
     }
 
     @Test
-    fun `auto declines once the latch has tripped, even with no bluetooth link detected`() {
-        // The backstop for units where the Bluetooth probe reports nothing useful.
-        assertFalse(acquire(mode = Mode.AUTO, btMediaLinkActive = false, selfDefeatingLatched = true))
+    fun `auto and always agree until the latch trips`() {
+        // A connected Bluetooth media link used to veto the grab here. Any paired phone has one, so
+        // a head unit that routes its amplifier from the focus request played nothing at all, while
+        // the harm the veto guessed at is what the latch measures directly.
+        assertEquals(acquire(mode = Mode.ALWAYS), acquire(mode = Mode.AUTO))
     }
 
     // --- ALWAYS / NEVER ---
 
     @Test
     fun `always keeps taking focus whatever the detection says`() {
-        assertTrue(acquire(mode = Mode.ALWAYS, btMediaLinkActive = true))
+        assertTrue(acquire(mode = Mode.ALWAYS))
         assertTrue(acquire(mode = Mode.ALWAYS, selfDefeatingLatched = true))
-        assertTrue(acquire(mode = Mode.ALWAYS, btMediaLinkActive = true, selfDefeatingLatched = true))
     }
 
     @Test
-    fun `never declines even when the detection is clean`() {
-        assertFalse(acquire(mode = Mode.NEVER, btMediaLinkActive = false, selfDefeatingLatched = false))
+    fun `never declines even when nothing has gone wrong`() {
+        assertFalse(acquire(mode = Mode.NEVER, selfDefeatingLatched = false))
     }
 
     // --- static mode's permanent grab ---
@@ -142,7 +142,6 @@ class PlaybackFocusPolicyTest {
                                 staticAudioFocus = static,
                                 audioSinkEnabled = sink,
                                 isAudioChannel = true,
-                                btMediaLinkActive = bt,
                                 selfDefeatingLatched = latched
                             )
                             val permanent = acquirePermanent(
@@ -206,7 +205,7 @@ class PlaybackFocusPolicyTest {
     }
 
     @Test
-    fun `auto is the stored default so an unset preference behaves like 3 point 1 point 1 plus detection`() {
+    fun `auto is the stored default so an unset preference takes focus until it learns not to`() {
         assertEquals(0, Mode.AUTO.value)
     }
 }

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/video/PictureCredibilityPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/video/PictureCredibilityPolicyTest.kt
@@ -1,0 +1,90 @@
+package com.andrerinas.openheadunit.decoder.video
+
+import com.andrerinas.openheadunit.decoder.video.PictureCredibilityPolicy.PENDING_KEYFRAME_GRACE_MS
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PictureCredibilityPolicyTest {
+
+    @Test
+    fun `a surface with nothing rendered has no picture`() {
+        for (accounting in listOf(true, false)) {
+            for (decoded in listOf(true, false)) {
+                for (pending in listOf(0L, 500L, Long.MAX_VALUE)) {
+                    assertFalse(
+                        credible(
+                            rendered = false,
+                            accounting = accounting,
+                            decoded = decoded,
+                            pendingAgeMs = pending,
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `a stream rendering after a decoded keyframe has a picture`() {
+        // The regression guard. If this ever answers false, every healthy stream earns a focus
+        // cycle it does not need.
+        assertTrue(credible(decoded = true, pendingAgeMs = Long.MAX_VALUE))
+        assertTrue(credible(decoded = true, pendingAgeMs = 10L))
+    }
+
+    @Test
+    fun `frames decoded from P-frames alone are not a picture`() {
+        // The measured defect: a live view-mode switch rebuilds the codec from cached parameter
+        // sets, it emits gray output, and no keyframe has been anywhere near it.
+        assertFalse(credible(decoded = false, pendingAgeMs = Long.MAX_VALUE))
+    }
+
+    @Test
+    fun `a keyframe still working its way to the output is given the grace`() {
+        assertTrue(credible(decoded = false, pendingAgeMs = 100L))
+        assertTrue(credible(decoded = false, pendingAgeMs = PENDING_KEYFRAME_GRACE_MS - 1))
+    }
+
+    @Test
+    fun `a keyframe that produced nothing stops counting after the grace`() {
+        assertFalse(credible(decoded = false, pendingAgeMs = PENDING_KEYFRAME_GRACE_MS + 1))
+    }
+
+    @Test
+    fun `the grace boundary is exclusive`() {
+        assertFalse(credible(decoded = false, pendingAgeMs = PENDING_KEYFRAME_GRACE_MS))
+    }
+
+    @Test
+    fun `the bundled software decoder keeps no keyframe accounting so a rendered frame is the only evidence`() {
+        assertTrue(credible(accounting = false, decoded = false, pendingAgeMs = Long.MAX_VALUE))
+    }
+
+    @Test
+    fun `the grace outlasts the tracker's own timestamp disbelief`() {
+        // KeyframeRepairTracker gives up on timestamps after this many renders and confirms by
+        // count instead. At the lowest plausible rate that is the wait below, and calling a stream
+        // incredible before the tracker has had its own chance to confirm would fire on healthy
+        // output from a component whose timestamps cannot be read.
+        val slowestConfirmMs = KeyframeRepairTracker.RENDERS_BEFORE_TIMESTAMPS_DISBELIEVED * 1000L / 30L
+        assertTrue(PENDING_KEYFRAME_GRACE_MS >= slowestConfirmMs)
+    }
+
+    @Test
+    fun `the answer settles long before the starvation path`() {
+        assertTrue(PENDING_KEYFRAME_GRACE_MS < DecoderStallCausePolicy.KEYFRAME_STARVATION_PATIENCE_MS)
+    }
+
+    private fun credible(
+        rendered: Boolean = true,
+        accounting: Boolean = true,
+        decoded: Boolean = false,
+        pendingAgeMs: Long,
+    ): Boolean = PictureCredibilityPolicy.hasCrediblePicture(
+        renderedSinceCodecStart = rendered,
+        keyframeAccountingAvailable = accounting,
+        keyframeDecodedSinceCodecStart = decoded,
+        msSincePendingKeyframeFed = pendingAgeMs,
+    )
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/video/WarmRelaunchKeyframePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/video/WarmRelaunchKeyframePolicyTest.kt
@@ -18,7 +18,7 @@ class WarmRelaunchKeyframePolicyTest {
     /** A relaunch that has gone 5s without a picture while the phone is on the link: the whole point. */
     private fun warmRelaunch(
         sessionHasRendered: Boolean = true,
-        renderedSinceSurfaceSet: Boolean = false,
+        crediblePictureOnSurface: Boolean = false,
         transportStarted: Boolean = true,
         msSinceSurfaceSet: Long = 5_000,
         msSinceLinkActivity: Long = 100,
@@ -27,7 +27,7 @@ class WarmRelaunchKeyframePolicyTest {
         msSinceLastRequest: Long = 60_000
     ) = WarmRelaunchKeyframePolicy.decide(
         sessionHasRendered = sessionHasRendered,
-        renderedSinceSurfaceSet = renderedSinceSurfaceSet,
+        crediblePictureOnSurface = crediblePictureOnSurface,
         transportStarted = transportStarted,
         msSinceSurfaceSet = msSinceSurfaceSet,
         msSinceLinkActivity = msSinceLinkActivity,
@@ -67,10 +67,24 @@ class WarmRelaunchKeyframePolicyTest {
     @Test
     fun `a picture on screen is never disturbed`() {
         // The regression this exists to avoid: asking again is what costs a working stream.
-        assertEquals(Action.NONE, warmRelaunch(renderedSinceSurfaceSet = true))
+        assertEquals(Action.NONE, warmRelaunch(crediblePictureOnSurface = true))
         assertEquals(
             Action.NONE,
-            warmRelaunch(renderedSinceSurfaceSet = true, cycleAlreadySpent = true)
+            warmRelaunch(crediblePictureOnSurface = true, cycleAlreadySpent = true)
+        )
+    }
+
+    @Test
+    fun `gray output with no keyframe behind it still gets the cycle`() {
+        // The parameter is about a picture, not about a rendered frame. A live view-mode switch
+        // rebuilds the codec from cached parameter sets and it renders P-frames into gray; reading
+        // that as a picture is what left the screen gray for a whole GOP.
+        assertEquals(
+            Action.CYCLE_FOCUS,
+            warmRelaunch(
+                crediblePictureOnSurface = false,
+                msSinceSurfaceSet = WarmRelaunchKeyframePolicy.ESCALATE_AFTER_SURFACE_MS
+            )
         )
     }
 


### PR DESCRIPTION
## Why

- Best approach to solve #846 while keeping the new audio behaviour
- **The Dialer buries the projection in Self Mode** (discussion #883). The phone is both the head unit and the phone, so answering a call covers the projection with the phone's own call screen, in portrait.
- **That is not fixable at the source.** Android Auto never enables its car-mode in-call service on Android 13+, so Telecom's swap, the only thing in AOSP that suppresses the Dialer during projection, can never fire. `pm enable` of that component is refused even to adb shell, so putting the projection back on top is what is left.
- **The Android Auto keyboard appears and immediately vanishes** (#882), leaving no keyboard at all. On the SurfaceView backend the opaque cover makes the framework destroy our surface, and the teardown answers with a video-focus release; Android Auto reads that as the projection being over and tears its session down, taking the keyboard with it 28 to 49 ms later.
- **Two reporters already found the workaround**, switching to TextureView or GLES. Those backends never lose their surface to a cover and never send the release, which is the control identifying the release rather than the cover as the cause.
- **Fixing the keyboard exposed a third defect already in the tree.** A decoder rebuilt against a new surface keeps its cached parameter sets, starts on a P-frame, and renders gray output from it, which every recovery gate read as a working picture. A live backend switch from Quick Settings therefore stayed gray for 11.0s, 32.4s or more, and 66.5s, with throughput healthy at 49-54fps and `dropped=0` throughout.

## What changed

| Layer | Change |
|---|---|
| `connection/self/` | `SelfModeCallRaisePolicy` decides, per tick, whether a cover is a call screen worth answering. `SelfLauncherManager` clears its active flag on the two paths that previously left it true for the life of the process. |
| `aap/` | `AapProjectionActivity` opens a raise episode when it is paused by something that is not the user, and consults `VideoFocusReleasePolicy` before releasing video focus on a surface teardown. `AapService` gains the `ACTION_RAISE_PROJECTION` route through its existing overlay trampoline, and `ProjectionWatchdogPolicy` now asks about a credible picture rather than a rendered frame. |
| `decoder/video/` | `PictureCredibilityPolicy` turns `KeyframeRepairTracker`'s per-codec accounting into the one boolean the recovery gates read. `WarmRelaunchKeyframePolicy` and `VideoDecoder` are switched onto it, and the warm-relaunch escalation now runs on every watchdog tick rather than only before the first frame. |
| `decoder/audio/` | `CallState` reads the call from `AudioManager.mode`, which needs no permission and covers VoIP. `MicRecorder` excludes our own uplink, which sets `MODE_IN_COMMUNICATION` for SCO routing. |
| `main/`, `utils/`, `res/` | One setting for the raise, default on, with its two strings in all twenty locales. |

## Where to focus your review

- **`VideoFocusReleasePolicy` is the only behaviour change on a path every session takes.** The release is what makes the phone re-run sink setup, worth 42-96 ms to a picture, so it is withheld for one cover shape only: opaque, live session, arriving within 3 s of a touch we forwarded, not finishing, not PiP, no focus cycle already in flight. Home, notifications, alarms, the Dialer and every real teardown keep the fast path.
- **It is withheld, never deferred.** That is the form this was drafted in twice and withdrawn: a release posted to fire later can land after a keyframe cycle completed and strand the phone released with nothing pending to take focus back.
- **`PictureCredibilityPolicy` has two deliberate exceptions.** The bundled software HEVC path keeps no keyframe accounting, so a rendered frame is the only evidence it has and asking for more would starve it forever. A keyframe still working its way to the output is given 2 s before the picture stops counting, twice the tracker's own confirm-by-count fallback at the lowest plausible frame rate.
- **The raise is bounded so it never turns into a fight.** `onUserLeaveHint` separates a call screen covering us from the user pressing Home, so leaving on purpose is never argued with. Three attempts per call and then silence, attempts carrying 5 s so a relaunching call screen cannot buy a second budget, plus one last attempt a second after the call ends for the report that the projection never came back.
- **The stale-flag fix stands on its own.** `SelfLauncherManager.isActive` was set in `start()` and cleared in exactly one place, so a service destroyed with it set, or a launch timeout whose `mayDisconnect` is false by design, left it true. The next session in the same process then announced no media or speech audio sinks; the raise would have inherited the same flag.

## Verification

- **Built from source and measured on hardware:** POCO X3 NFC, Android 15, Android Auto 17.5.663204, Self Mode, negotiated 1920x1080 H.264, `c2.qti.avc.decoder`, ~69 s GOP.
- **`./gradlew :app:testGithubDebugUnitTest`: 863 tests, 0 failures, 0 errors**, including the four new suites `SelfModeCallRaisePolicyTest`, `CallStateTest`, `PictureCredibilityPolicyTest` and `VideoFocusReleasePolicyTest`.
- **The keyboard stays.** Held 23 s and 108 s across two runs, both ended by the operator rather than by a bounce, with zero video-focus notifications during either hold and zero `Asked by projected IME to detach` in either capture. Typing worked and the session never dropped: no `ByeBye`, no re-handshake, no unacked-window stall.
- **The withhold is narrow.** A Home press still releases focus in the same millisecond as `onSurfaceDestroyed`, with no hold line, and `onResume` to first frame is 359 ms.
- **The cost is 1643 ms and 1615 ms** from `onResume` to a repaired picture, paid only on the covers that are withheld.
- **Steady state is clean.** Two 10-minute runs, one on the loopback route and one offline over the dummy VPN, logged 251 throughput windows with `dropped=0` in every one, 49-60 fps, and not one of the new lines.
- **The credible-picture gate fixes the defect it was written for.** Gray to picture is 1648, 1634 and 1555 ms on the three backend transitions that previously took 11.0s, 32.4s or more, and 66.5s. The gate fires exactly once per switch and the focus cycle pulls an on-demand IDR, 8200 bytes against 72-140 KB for the phone's natural-GOP keyframes in the same session.
- **The raise, from an earlier round on the same unit:** six raise cycles across incoming and outgoing calls, every one landing on attempt 1, 1927-2124 ms from the Dialer's launch to our `onResume`, mean 2076. A Home press mid-call raises nothing, and with the setting off the old behaviour is exact.
- **The raise costs no picture:** `dropped=0` in every window and one decoder configure in the whole capture, at session start.