### PR TITLE
Mic: fix the uplink, and let the phone keep the microphone

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,6 +69,9 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <!-- Declared so the microphone type can be claimed; it is only ever requested when
+         RECORD_AUDIO is actually granted, because claiming it without throws on Android 14+. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <!--
         Only requested up to API 32. From API 33 (Android 13) a granted READ_LOGS makes the app a
@@ -213,7 +216,7 @@
         <service
             android:name=".aap.AapService"
             android:exported="false"
-            android:foregroundServiceType="connectedDevice|mediaPlayback"
+            android:foregroundServiceType="connectedDevice|mediaPlayback|microphone"
             android:stopWithTask="false">
             <!-- MediaButtonReceiver looks for a Service with this intent-filter -->
             <intent-filter>

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapControl.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapControl.kt
@@ -183,7 +183,8 @@ internal class AapControlMedia(
                     // assistant reads as a setting rather than as a fault.
                     AppLog.i("Mic request: the head unit microphone is off in Settings. Declining " +
                         "and sending nothing, so a Bluetooth headset keeps this microphone. The " +
-                        "phone does not switch to its own, so the assistant will not answer")
+                        "service is not announced either, so a request arriving here means the " +
+                        "phone kept an older record of this head unit")
                     Common.MessageStatus.STATUS_INTERNAL_ERROR_VALUE
                 }
                 MicrophonePolicy.Decline.NO_MICROPHONE -> {

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapControl.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapControl.kt
@@ -7,6 +7,7 @@ import com.andrerinas.openheadunit.aap.protocol.AudioConfigs
 import com.andrerinas.openheadunit.aap.protocol.Channel
 import com.andrerinas.openheadunit.aap.protocol.messages.DrivingStatusEvent
 import com.andrerinas.openheadunit.aap.protocol.messages.LocationUpdateEvent
+import com.andrerinas.openheadunit.aap.protocol.messages.MicrophoneResponse
 import com.andrerinas.openheadunit.aap.protocol.messages.ServiceDiscoveryResponse
 import com.andrerinas.openheadunit.aap.protocol.proto.Common
 import com.andrerinas.openheadunit.aap.protocol.proto.Control
@@ -64,7 +65,12 @@ internal class AapControlMedia(
                 aapTransport.onUpdateUiConfigReplyReceived?.invoke()
                 return 0
             }
-            Media.MsgType.MEDIA_MESSAGE_ACK_VALUE -> return 0
+            Media.MsgType.MEDIA_MESSAGE_ACK_VALUE -> {
+                // The phone flow-controls this stream and nothing here has ever counted its acks,
+                // so a window we ran past would have looked like silence. Counted, not acted on.
+                if (message.channel == Channel.ID_MIC) aapTransport.onMicAck()
+                return 0
+            }
             else -> AppLog.e("Unsupported Media message type: ${message.type}")
         }
         return 0
@@ -140,6 +146,13 @@ internal class AapControlMedia(
             // Before the sink goes: this silence is one the phone asked for.
             aapTransport.noteAudioSinkStopped(channel)
             aapAudio.stopAudio(channel)
+        } else if (channel == Channel.ID_MIC) {
+            // The mic is a source, so Channel.isAudio deliberately excludes it - widening that
+            // predicate would make this head unit claim audio focus and precreate an AudioTrack for
+            // a microphone. A stop here is still the phone saying it wants no more PCM, and until
+            // now the recorder kept running and kept sending.
+            micRecorder.stop()
+            aapTransport.onMicSessionEnded()
         } else if (channel == Channel.ID_VID) {
             if (aapTransport.ignoreNextStopRequest) {
                 AppLog.i("Video Sink Stopped -> Ignored (Forced Keyframe Request)")
@@ -151,14 +164,34 @@ internal class AapControlMedia(
         return 0
     }
 
+    /**
+     * Open or close the microphone, and say so.
+     *
+     * At INFO because the request's own toString is the only place anyone will ever see what
+     * Android Auto asks for - anc_enabled, ec_enabled and the flow-control window - none of which
+     * this head unit has ever recorded, let alone honoured.
+     */
     private fun micRequest(micRequest: Media.MicrophoneRequest): Int {
-        AppLog.d("Mic request: %s", micRequest)
+        AppLog.i("Mic request: %s", micRequest)
 
-        if (micRequest.open) {
-            micRecorder.start()
+        val status = if (micRequest.open) {
+            val result = micRecorder.start()
+            if (result != 0) {
+                AppLog.w("Mic request: capture did not start (code $result); telling the phone so " +
+                    "rather than leaving it waiting on a stream that will never arrive")
+                Common.MessageStatus.STATUS_INTERNAL_ERROR_VALUE
+            } else {
+                Common.MessageStatus.STATUS_SUCCESS_VALUE
+            }
         } else {
             micRecorder.stop()
+            // The session boundary the uplink report is measured over. Without it the line only
+            // appears at disconnect, long after the assistant session it describes.
+            aapTransport.onMicSessionEnded()
+            Common.MessageStatus.STATUS_SUCCESS_VALUE
         }
+
+        aapTransport.send(MicrophoneResponse(status, aapTransport.getSessionId(Channel.ID_MIC)))
         return 0
     }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapControl.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapControl.kt
@@ -74,6 +74,7 @@ internal class AapControlMedia(
         AppLog.i("Media Start Request %s: session=%d, config_index=%d", Channel.name(channel), request.sessionId, request.configurationIndex)
 
         aapTransport.setSessionId(channel, request.sessionId)
+        aapTransport.noteAudioSinkStarted(channel)
         return 0
     }
 
@@ -136,6 +137,8 @@ internal class AapControlMedia(
     private fun mediaSinkStopRequest(channel: Int): Int {
         AppLog.i("Media Sink Stop Request: " + Channel.name(channel))
         if (Channel.isAudio(channel)) {
+            // Before the sink goes: this silence is one the phone asked for.
+            aapTransport.noteAudioSinkStopped(channel)
             aapAudio.stopAudio(channel)
         } else if (channel == Channel.ID_VID) {
             if (aapTransport.ignoreNextStopRequest) {

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapControl.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapControl.kt
@@ -15,6 +15,7 @@ import com.andrerinas.openheadunit.aap.protocol.proto.Input
 import com.andrerinas.openheadunit.aap.protocol.proto.Media
 import com.andrerinas.openheadunit.aap.protocol.proto.Sensors
 import com.andrerinas.openheadunit.decoder.audio.MicRecorder
+import com.andrerinas.openheadunit.decoder.audio.MicrophonePolicy
 import com.andrerinas.openheadunit.decoder.video.VideoDecoder
 import com.andrerinas.openheadunit.location.LocationHolder
 import com.andrerinas.openheadunit.utils.AppLog
@@ -175,13 +176,30 @@ internal class AapControlMedia(
         AppLog.i("Mic request: %s", micRequest)
 
         val status = if (micRequest.open) {
-            val result = micRecorder.start()
-            if (result != 0) {
-                AppLog.w("Mic request: capture did not start (code $result); telling the phone so " +
-                    "rather than leaving it waiting on a stream that will never arrive")
-                Common.MessageStatus.STATUS_INTERNAL_ERROR_VALUE
-            } else {
-                Common.MessageStatus.STATUS_SUCCESS_VALUE
+            when (MicrophonePolicy.declineReason(
+                    aapTransport.settings.useHeadUnitMicrophone, micRecorder.isAvailable)) {
+                MicrophonePolicy.Decline.USER_SETTING -> {
+                    // Named in the user's terms, the same way the audio-sink skip is, so a silent
+                    // assistant reads as a setting rather than as a fault.
+                    AppLog.i("Mic request: the head unit microphone is off in Settings. Declining " +
+                        "and sending nothing, so a Bluetooth headset keeps this microphone. The " +
+                        "phone does not switch to its own, so the assistant will not answer")
+                    Common.MessageStatus.STATUS_INTERNAL_ERROR_VALUE
+                }
+                MicrophonePolicy.Decline.NO_MICROPHONE -> {
+                    AppLog.w("Mic request: this device has no usable microphone capture; declining")
+                    Common.MessageStatus.STATUS_INTERNAL_ERROR_VALUE
+                }
+                MicrophonePolicy.Decline.NONE -> {
+                    val result = micRecorder.start()
+                    if (result != 0) {
+                        AppLog.w("Mic request: capture did not start (code $result); telling the " +
+                            "phone so rather than leaving it waiting on a stream that will never arrive")
+                        Common.MessageStatus.STATUS_INTERNAL_ERROR_VALUE
+                    } else {
+                        Common.MessageStatus.STATUS_SUCCESS_VALUE
+                    }
+                }
             }
         } else {
             micRecorder.stop()

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -1,5 +1,6 @@
 package com.andrerinas.openheadunit.aap
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.PendingIntent
@@ -10,6 +11,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.ServiceInfo
 import android.content.SharedPreferences
 import android.net.wifi.WifiManager
 import android.net.ConnectivityManager
@@ -22,11 +24,13 @@ import android.os.PowerManager
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.IntentCompat
+import androidx.core.content.PermissionChecker
 import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.app.ActivityLaunchPolicy
 import com.andrerinas.openheadunit.app.BootCompleteReceiver
 import com.andrerinas.openheadunit.app.BootLoopPolicy
 import com.andrerinas.openheadunit.app.BtAutoStartRearmPolicy
+import com.andrerinas.openheadunit.app.ForegroundServiceTypePolicy
 import com.andrerinas.openheadunit.app.WifiAutoStartReceiver
 import com.andrerinas.openheadunit.connection.wifi.HotspotExitAction
 import com.andrerinas.openheadunit.connection.wifi.UsbSessionQuiescePolicy
@@ -36,11 +40,13 @@ import com.andrerinas.openheadunit.main.MainActivity
 import com.andrerinas.openheadunit.R
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.AppPermissions
+import com.andrerinas.openheadunit.utils.BluetoothAddressSeedPolicy
 import com.andrerinas.openheadunit.utils.BluetoothHelper
 import com.andrerinas.openheadunit.utils.DummyVpnPolicy
 import com.andrerinas.openheadunit.utils.ToastUtils
 import com.andrerinas.openheadunit.aap.protocol.messages.NightModeEvent
 import com.andrerinas.openheadunit.aap.protocol.proto.MediaPlayback
+import com.andrerinas.openheadunit.decoder.audio.MicRecorder
 import com.andrerinas.openheadunit.connection.CommManager
 import com.andrerinas.openheadunit.connection.wifi.NetworkDiscovery
 import android.support.v4.media.session.MediaSessionCompat
@@ -58,7 +64,6 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.SystemClock
 import android.app.NotificationManager
-import android.content.pm.ServiceInfo
 import android.graphics.PixelFormat
 import android.media.AudioAttributes
 import android.media.AudioFocusRequest
@@ -763,6 +768,85 @@ class AapService : Service() {
     // Lifecycle
     // -------------------------------------------------------------------------
 
+    /**
+     * Put the head unit's own Bluetooth address in Settings the first time, if it can be read.
+     *
+     * The service discovery response omits the Bluetooth service entirely when this is blank, so
+     * the phone is never told where to connect hands-free - and Android Auto keeps phone calls on
+     * the phone until that link exists. The field was typed by hand, so most installs announce
+     * nothing, while BluetoothHelper has been able to resolve the real address all along and used
+     * it only for description strings.
+     *
+     * Never overwrites what the user typed: a hand-entered address is usually there because the
+     * detected one was wrong.
+     */
+    private fun fillBluetoothAddressIfUnset() {
+        val detected = try {
+            BluetoothHelper.getBluetoothMacAddress(this)
+        } catch (e: Exception) {
+            AppLog.w("AapService: could not read this device's Bluetooth address: ${e.message}")
+            null
+        }
+        val seeded = BluetoothAddressSeedPolicy.seed(settings.bluetoothAddress, detected)
+        if (seeded.isNotEmpty() && seeded != settings.bluetoothAddress) {
+            settings.bluetoothAddress = seeded
+            AppLog.i("AapService: filled in this device's Bluetooth address ($seeded) so the " +
+                "Bluetooth service can be announced; phone calls need it")
+        }
+    }
+
+    /**
+     * Re-claims the foreground types with the microphone added, for as long as capture is open.
+     *
+     * The microphone type is while-in-use, so it cannot be claimed at service start: a background
+     * start is refused even with RECORD_AUDIO granted. Here the projection is on screen and the app
+     * is eligible. Returns whether the claim succeeded, so a refusal declines the phone's request
+     * rather than losing the service.
+     */
+    private fun promoteForMicrophone(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return true
+
+        val mask = ForegroundServiceTypePolicy.withMicrophone(
+            sdkInt = Build.VERSION.SDK_INT,
+            recordAudioGranted = PermissionChecker.checkSelfPermission(
+                this, Manifest.permission.RECORD_AUDIO) == PermissionChecker.PERMISSION_GRANTED,
+            headUnitMicEnabled = settings.useHeadUnitMicrophone)
+
+        // The mask can come back without the microphone type when the permission or the setting
+        // says no. Capture has already checked both by this point, so say which happened rather
+        // than claiming something that did not.
+        val claimed = mask and ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE != 0
+
+        return try {
+            startForeground(1, createNotification(), mask)
+            if (claimed) {
+                AppLog.i("AapService: claimed the microphone foreground-service type for this capture")
+            } else {
+                AppLog.i("AapService: the microphone foreground-service type was not asked for; " +
+                    "the permission or the setting says no")
+            }
+            true
+        } catch (e: Exception) {
+            AppLog.e("AapService: could not claim the microphone foreground-service type " +
+                "(${e.message}); declining the phone's request rather than capturing without it", e)
+            false
+        }
+    }
+
+    /** Drops the microphone type again once capture is closed, so it is held only while it is true. */
+    private fun demoteAfterMicrophone() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return
+
+        try {
+            startForeground(1, createNotification(),
+                ForegroundServiceTypePolicy.baseTypeMask(Build.VERSION.SDK_INT))
+        } catch (e: Exception) {
+            // Nothing to do about it and nothing depends on it: the service stays foreground with
+            // the wider mask, which is the state it was already in a moment ago.
+            AppLog.w("AapService: could not drop the microphone foreground-service type: ${e.message}")
+        }
+    }
+
     override fun onCreate() {
         super.onCreate()
         AppLog.i("AapService creating...")
@@ -771,7 +855,7 @@ class AapService : Service() {
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 startForeground(1, createNotification(),
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE or ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
+                    ForegroundServiceTypePolicy.baseTypeMask(Build.VERSION.SDK_INT))
             } else {
                 startForeground(1, createNotification())
             }
@@ -780,10 +864,16 @@ class AapService : Service() {
             stopSelf()
             return
         }
+        fillBluetoothAddressIfUnset()
         setupCarMode()
         setupNightMode()
         observeConnectionState()
         registerReceivers()
+
+        MicRecorder.foregroundClaim = object : MicRecorder.ForegroundMicrophoneClaim {
+            override fun claim() = promoteForMicrophone()
+            override fun release() = demoteAfterMicrophone()
+        }
 
         // Handle immediate WiFi auto-start check (e.g. if already connected on boot/wake)
         WifiAutoStartReceiver.checkAndStart(this)
@@ -1871,6 +1961,8 @@ class AapService : Service() {
             AppLog.e("Error releasing MediaSession: ${e.message}")
         }
         mediaSession = null
+        // The claim outlives no service: a stale one would call startForeground on a dead instance.
+        MicRecorder.foregroundClaim = null
         commManager.destroy()
         nightModeManager?.stop()
         stopService(GpsLocationService.intent(this))
@@ -1905,7 +1997,7 @@ class AapService : Service() {
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 startForeground(1, createNotification(),
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE or ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
+                    ForegroundServiceTypePolicy.baseTypeMask(Build.VERSION.SDK_INT))
             } else {
                 startForeground(1, createNotification())
             }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
@@ -203,6 +203,20 @@ class AapTransport(
         LinkGapMonitor.MAX_DEAD_PERCENT_MEDIA
     )
 
+    /**
+     * Which audio channels the phone currently has started.
+     *
+     * Android Auto stops the media sink for every assistant session and every pause, and the audio
+     * gap series counted those deliberate silences as outages - one window read 36% dead when all
+     * of it was an assistant session.
+     *
+     * Skipping the gap when the first sink comes back puts that silence outside the window while
+     * keeping what the window has already measured. A gate on the feed would instead have hidden
+     * any stream that arrives without a start request; a reset would have restarted the 30 s window
+     * on every cycle. The set keeps one channel closing from discarding another's window.
+     */
+    private val startedAudioChannels = HashSet<Int>()
+
     /** Whether our own writes are draining. See [UplinkStallMonitor]. */
     private val uplinkStallMonitor = UplinkStallMonitor()
 
@@ -232,6 +246,28 @@ class AapTransport(
             Channel.isAudio(channel) ->
                 audioGapMonitor.onMessage(now)?.let { AppLog.i("AapTransport: %s", it) }
         }
+    }
+
+    /**
+     * The phone started an audio sink. Called from [AapControlMedia.mediaStartRequest].
+     *
+     * The lock guards the set. The monitor itself needs none: this, [noteAudioSinkStopped] and
+     * [noteMessageReceived] all reach here from the transport's poll thread.
+     */
+    internal fun noteAudioSinkStarted(channel: Int) {
+        if (!Channel.isAudio(channel)) return
+        val firstSink = synchronized(startedAudioChannels) {
+            val wasEmpty = startedAudioChannels.isEmpty()
+            startedAudioChannels.add(channel)
+            wasEmpty
+        }
+        if (firstSink) audioGapMonitor.skipExpectedGap(SystemClock.elapsedRealtime())
+    }
+
+    /** The phone stopped an audio sink. Called from [AapControlMedia.mediaSinkStopRequest]. */
+    internal fun noteAudioSinkStopped(channel: Int) {
+        if (!Channel.isAudio(channel)) return
+        synchronized(startedAudioChannels) { startedAudioChannels.remove(channel) }
     }
 
     // Escalation state for KeyframeCycleEscalationPolicy - see triggerFocusCycleRecovery().
@@ -652,6 +688,7 @@ class AapTransport(
         linkGapMonitor.reset()
         videoGapMonitor.reset()
         audioGapMonitor.reset()
+        synchronized(startedAudioChannels) { startedAudioChannels.clear() }
         uplinkStallMonitor.reset()
         inboundRateMonitor.reset()
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Context.UI_MODE_SERVICE
 import android.content.Intent
 import android.media.AudioManager
+import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.Process
@@ -18,6 +19,7 @@ import com.andrerinas.openheadunit.aap.protocol.messages.Messages
 import com.andrerinas.openheadunit.aap.protocol.messages.ScrollWheelEvent
 import com.andrerinas.openheadunit.aap.protocol.messages.SensorEvent
 import com.andrerinas.openheadunit.aap.protocol.messages.VideoFocusEvent
+import com.andrerinas.openheadunit.decoder.audio.MicChunkAccumulator
 import com.andrerinas.openheadunit.decoder.video.FocusCycleLever
 import com.andrerinas.openheadunit.decoder.video.KeyframeCycleEscalationPolicy
 import com.andrerinas.openheadunit.decoder.video.WarmRelaunchKeyframePolicy
@@ -35,6 +37,7 @@ import com.andrerinas.openheadunit.ssl.SingleKeyKeyManager
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.Settings
 import com.andrerinas.openheadunit.aap.protocol.proto.Control
+import com.andrerinas.openheadunit.aap.protocol.proto.Media
 import com.andrerinas.openheadunit.aap.protocol.proto.MediaPlayback
 import com.andrerinas.openheadunit.utils.Utils
 
@@ -79,7 +82,7 @@ class AapTransport(
     internal val aapVideo: AapVideo
     private var sendThread: HandlerThread? = null
     private var pollThread: HandlerThread? = null
-    private val micRecorder: MicRecorder = MicRecorder(settings.micSampleRate, context)
+    private val micRecorder: MicRecorder = MicRecorder(context)
     private val sessionIds = SparseIntArray(4)
     private val startedSensors = HashSet<Int>(4)
     private val droppedSensorEvents = HashMap<Int, Int>(4)
@@ -228,6 +231,12 @@ class AapTransport(
      * [InboundRateMonitor].
      */
     private val inboundRateMonitor = InboundRateMonitor()
+
+    /** What the microphone session sent, so a silent assistant has something to read. */
+    private val micUplinkMonitor = MicUplinkMonitor()
+
+    /** Whole 2048-frame messages, whatever size the device's reads happen to be. */
+    private val micChunks = MicChunkAccumulator()
 
     /**
      * Called for every decrypted inbound message, from [AapMessageHandlerType.handle].
@@ -639,6 +648,7 @@ class AapTransport(
         cb.invoke(clean)
         micRecorder.stop()
         micRecorder.listener = null
+        onMicSessionEnded()
         sendHandler?.removeCallbacks(focusCycleGainRunnable)
         sendHandler?.removeCallbacks(unrepairedCheckRunnable)
         pollThread?.quit()
@@ -691,6 +701,8 @@ class AapTransport(
         synchronized(startedAudioChannels) { startedAudioChannels.clear() }
         uplinkStallMonitor.reset()
         inboundRateMonitor.reset()
+        micUplinkMonitor.reset()
+        micChunks.reset()
 
         sendThread = HandlerThread("AapTransport:Handler::Send", Process.THREAD_PRIORITY_AUDIO)
         sendThread!!.start()
@@ -952,17 +964,51 @@ class AapTransport(
         sessionIds.put(channel, sessionId)
     }
 
-    override fun onMicDataAvailable(mic_buf: ByteArray, mic_audio_len: Int) {
-        if (mic_audio_len > 64) {  // If we read at least 64 bytes of audio data
-            val length = mic_audio_len + 12  // 4 header + 8 timestamp + PCM
-            val data = ByteArray(length)
-            data[0] = Channel.ID_MIC.toByte()
-            data[1] = 0x0b
-            // Timestamp at byte 4 so the full 8 bytes are inside the encrypted payload (HEADER_SIZE=4)
-            Utils.put_time(4, data, SystemClock.elapsedRealtime())
-            System.arraycopy(mic_buf, 0, data, 12, mic_audio_len)
-            send(AapMessage(Channel.ID_MIC, 0x0b.toByte(), -1, 2, length, data))
+    /**
+     * The session id a MediaStart left for [channel], or 0 if the phone never sent one.
+     *
+     * Zero is the honest answer on the microphone channel: every captured session opens it with a
+     * ChannelOpenRequest and a MicrophoneRequest and no Start in between.
+     */
+    internal fun getSessionId(channel: Int): Int = sessionIds.get(channel)
+
+    override fun onMicDataAvailable(mic_buf: ByteArray, mic_audio_len: Int, peak: Int) {
+        if (mic_audio_len <= 0) return
+        micChunks.offer(mic_buf, mic_audio_len, micTimestampUs(), peak, ::sendMicChunk)
+    }
+
+    /** One whole microphone message. The buffer is the chunker's and is reused, so copy as we build. */
+    private fun sendMicChunk(chunk: ByteArray, chunkLen: Int, timestampUs: Long, peak: Int) {
+        val data = ByteArray(MicUplinkFrame.size(chunkLen))
+        val length = MicUplinkFrame.build(timestampUs, chunk, 0, chunkLen, data)
+        send(AapMessage(Channel.ID_MIC, MicUplinkFrame.FLAGS,
+            Media.MsgType.MEDIA_MESSAGE_DATA_VALUE, MicUplinkFrame.TIMESTAMP_OFFSET, length, data))
+
+        if (micUplinkMonitor.onFrame(chunkLen, peak, SystemClock.elapsedRealtime())) {
+            AppLog.i("AapTransport: mic uplink started (channel MIC, type 0, timestamps in " +
+                "microseconds, ${chunkLen}B messages)")
         }
+    }
+
+    /**
+     * A monotonic microsecond clock, which is the unit every other AAP media producer stamps with.
+     *
+     * The nanosecond clock is API 17 and the github flavor's minSdk is 16, so the fallback
+     * quantises to a millisecond - two orders below a chunk, and still monotonic.
+     */
+    private fun micTimestampUs(): Long =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
+            SystemClock.elapsedRealtimeNanos() / 1000L
+        else SystemClock.elapsedRealtime() * 1000L
+
+    /** One acknowledgement from the phone on the microphone channel. Diagnostic only. */
+    internal fun onMicAck() = micUplinkMonitor.onAck()
+
+    /** The phone closed the microphone. Says what the session put on the wire, then re-arms. */
+    internal fun onMicSessionEnded() {
+        micUplinkMonitor.onDiscarded(micChunks.reset())
+        micUplinkMonitor.onSessionEnd(SystemClock.elapsedRealtime())
+            ?.let { AppLog.i("AapTransport: %s", it) }
     }
 
     companion object {

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
@@ -20,6 +20,7 @@ import com.andrerinas.openheadunit.aap.protocol.messages.ScrollWheelEvent
 import com.andrerinas.openheadunit.aap.protocol.messages.SensorEvent
 import com.andrerinas.openheadunit.aap.protocol.messages.VideoFocusEvent
 import com.andrerinas.openheadunit.decoder.audio.MicChunkAccumulator
+import com.andrerinas.openheadunit.decoder.audio.MicrophonePolicy
 import com.andrerinas.openheadunit.decoder.video.FocusCycleLever
 import com.andrerinas.openheadunit.decoder.video.KeyframeCycleEscalationPolicy
 import com.andrerinas.openheadunit.decoder.video.WarmRelaunchKeyframePolicy
@@ -564,7 +565,15 @@ class AapTransport(
     }
 
     init {
-        micRecorder.listener = this
+        // Nothing is wired when the microphone is the phone's, so AudioRecord is never constructed
+        // and a Bluetooth intercom keeps the physical microphone.
+        if (MicrophonePolicy.shouldCapture(settings.useHeadUnitMicrophone, micRecorder.isAvailable)) {
+            micRecorder.listener = this
+        } else {
+            AppLog.i("AapTransport: not taking the microphone (setting " +
+                "useHeadUnitMicrophone=${settings.useHeadUnitMicrophone}, " +
+                "available=${micRecorder.isAvailable})")
+        }
         aapAudio = AapAudio(audioDecoder, audioManager, settings)
         // A corrupt access unit is the one fault the phone cannot heal for us inside a GOP, and
         // hasRenderedThisSession is the gate that keeps this clear of the warm-up window

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/LinkGapMonitor.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/LinkGapMonitor.kt
@@ -140,6 +140,21 @@ class LinkGapMonitor(
      * The transport outlives a session and is re-armed for the next one, so a stamp left by the
      * previous phone would otherwise be measured as this session's first gap.
      */
+    /**
+     * Excludes a silence the caller expected, without discarding the window.
+     *
+     * A [reset] here would restart the 30 s window on every media-sink cycle, so a series that
+     * stops and starts faster than that would never report at all. The interval before [nowMs] is
+     * not measured and the window is shifted past it, so what the window has already measured
+     * survives and its percentages stay against live time.
+     */
+    fun skipExpectedGap(nowMs: Long) {
+        if (!started) return
+        val silenceMs = nowMs - lastMessageMs
+        if (silenceMs > 0) windowStartMs += silenceMs
+        lastMessageMs = nowMs
+    }
+
     fun reset() {
         started = false
         lastMessageMs = 0L

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/MicUplinkFrame.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/MicUplinkFrame.kt
@@ -1,0 +1,74 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.protocol.Channel
+import com.andrerinas.openheadunit.aap.protocol.proto.Media
+
+/**
+ * The bytes of one microphone message, and the one sender that has to obey [AapMessageFraming].
+ *
+ * That table says a message with flag bit 0 set carries a 2-byte type at payload offset 0, and the
+ * receive path reads exactly that: [AapMessageIncoming] takes the type from payload offset 0 and
+ * [AapAudio.process] takes media data from offset 10, which is 2 of type plus 8 of timestamp. The
+ * uplink set the flags and never wrote the type, so the phone read six timestamp bytes plus the
+ * first PCM sample as the timestamp and started the audio one sample late, on every message. It
+ * parsed at all only because a millisecond `elapsedRealtime()` has two leading zero bytes.
+ *
+ * Pure: no Android, no logging. Its test is the record of the layout below.
+ */
+object MicUplinkFrame {
+
+    /** Channel, flags and the 2-byte length the encrypt step rewrites. Plaintext on the wire. */
+    const val HEADER_SIZE = 4
+
+    /** First byte the phone decrypts. [AapTransport.sendEncryptedMessage] encrypts from here. */
+    const val TYPE_OFFSET = HEADER_SIZE
+
+    const val TYPE_SIZE = 2
+
+    const val TIMESTAMP_OFFSET = TYPE_OFFSET + TYPE_SIZE
+
+    const val TIMESTAMP_SIZE = 8
+
+    const val PCM_OFFSET = TIMESTAMP_OFFSET + TIMESTAMP_SIZE
+
+    /** Complete, unfragmented, encrypted. Bit 0 is what obliges us to write a type. */
+    const val FLAGS: Byte = 0x0b
+
+    fun size(pcmLength: Int): Int = PCM_OFFSET + pcmLength
+
+    /**
+     * Writes one media message into [into] and returns its length.
+     *
+     * [timestampUs] is microseconds, matching every other AAP media producer. The caller owns the
+     * clock so a session can be replayed in a test.
+     */
+    fun build(
+        timestampUs: Long,
+        pcm: ByteArray,
+        pcmOffset: Int,
+        pcmLength: Int,
+        into: ByteArray
+    ): Int {
+        val length = size(pcmLength)
+        require(into.size >= length) { "buffer holds ${into.size}, frame needs $length" }
+
+        into[0] = Channel.ID_MIC.toByte()
+        into[1] = FLAGS
+        // [2..3] is the ciphertext length, written by sendEncryptedMessage once the payload exists.
+        into[2] = 0
+        into[3] = 0
+
+        val type = Media.MsgType.MEDIA_MESSAGE_DATA_VALUE
+        into[TYPE_OFFSET] = (type shr 8).toByte()
+        into[TYPE_OFFSET + 1] = (type and 0xFF).toByte()
+
+        var remaining = timestampUs
+        for (i in TIMESTAMP_SIZE - 1 downTo 0) {
+            into[TIMESTAMP_OFFSET + i] = (remaining and 0xFF).toByte()
+            remaining = remaining shr 8
+        }
+
+        System.arraycopy(pcm, pcmOffset, into, PCM_OFFSET, pcmLength)
+        return length
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/MicUplinkMonitor.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/MicUplinkMonitor.kt
@@ -1,0 +1,142 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.protocol.MicCaptureFormat
+
+/**
+ * What the microphone session actually put on the wire.
+ *
+ * The capture side already says whether the hardware heard anything
+ * ([com.andrerinas.openheadunit.decoder.audio.MicRecorder] logs a peak and a byte count). Nothing said
+ * whether those bytes then left the head unit, so a reporter log showed `Initializing AudioRecord`
+ * and then silence, and a dead input and a dead uplink read identically. This is the missing half:
+ * paired with the capture summary it separates "the microphone is routed nowhere" from "we heard it
+ * and never sent it".
+ *
+ * Reported per microphone session rather than per rolling window, because a session is a few
+ * seconds and a fixed window would straddle several or none.
+ *
+ * **Diagnostic only** - nothing reads the report. Pure and clock-free: the caller passes the time,
+ * so a measured session replays in a unit test.
+ */
+class MicUplinkMonitor {
+
+    private var open = false
+    private var startedMs = 0L
+    private var frames = 0
+    private var bytes = 0L
+    private var peak = 0
+    private var largest = 0
+    private var smallest = 0
+    private var acks = 0
+    private var discarded = 0
+
+    /** Whether a session is open. A frame arriving with none opens one. */
+    val isOpen: Boolean get() = open
+
+    /**
+     * Feed one message handed to the send queue.
+     *
+     * [payloadBytes] is the PCM only, so the percentage compares like with like against the capture
+     * rate. Returns true for the first frame of a session, which is the caller's cue to say once
+     * that the uplink started - its absence in a log being the finding when the phone asked for the
+     * microphone and nothing followed.
+     */
+    fun onFrame(payloadBytes: Int, framePeak: Int, nowMs: Long): Boolean {
+        val first = !open
+        if (first) {
+            open = true
+            startedMs = nowMs
+            smallest = payloadBytes
+        }
+
+        frames++
+        bytes += payloadBytes
+        if (framePeak > peak) peak = framePeak
+        if (payloadBytes > largest) largest = payloadBytes
+        if (payloadBytes < smallest) smallest = payloadBytes
+        return first
+    }
+
+    /** One acknowledgement from the phone on the microphone channel. */
+    fun onAck() {
+        if (open) acks++
+    }
+
+    /** Bytes the chunker could not fill a message with. At most one chunk, at the end of a session. */
+    fun onDiscarded(bytes: Int) {
+        if (open) discarded += bytes
+    }
+
+    /**
+     * Close the session and say what it produced, or null if no frame was ever sent.
+     *
+     * A null here after the phone asked for the microphone is itself the answer.
+     */
+    fun onSessionEnd(nowMs: Long): Report? {
+        if (!open) return null
+        val report = Report(
+            frames = frames,
+            bytes = bytes,
+            elapsedMs = nowMs - startedMs,
+            peak = peak,
+            largest = largest,
+            smallest = smallest,
+            acks = acks,
+            discarded = discarded
+        )
+        reset()
+        return report
+    }
+
+    /**
+     * Forget the previous session. The transport outlives a session and is re-armed for the next
+     * one, so every field a session writes has to be restored here.
+     */
+    fun reset() {
+        open = false
+        startedMs = 0L
+        frames = 0
+        bytes = 0L
+        peak = 0
+        largest = 0
+        smallest = 0
+        acks = 0
+        discarded = 0
+    }
+
+    /** One microphone session's worth of uplink. */
+    data class Report(
+        val frames: Int,
+        val bytes: Long,
+        val elapsedMs: Long,
+        val peak: Int,
+        val largest: Int,
+        val smallest: Int,
+        val acks: Int,
+        val discarded: Int
+    ) {
+        /**
+         * Bytes sent as a percentage of what 16 kHz mono 16-bit produces over the same span.
+         *
+         * Near 100 means the uplink kept up with the microphone. Far below it means messages were
+         * dropped or the capture starved, which the capture summary then tells apart.
+         */
+        val percentOfExpected: Int
+            get() {
+                val expected = BYTES_PER_SECOND * elapsedMs / 1000L
+                return if (expected <= 0L) -1 else (bytes * 100L / expected).toInt()
+            }
+
+        override fun toString(): String =
+            "mic uplink | $frames frame${if (frames == 1) "" else "s"}, $bytes B in ${elapsedMs}ms " +
+                "($percentOfExpected% of expected), peak=$peak/32767, " +
+                "largest=${largest}B, smallest=${smallest}B, acks=$acks, discarded=${discarded}B"
+    }
+
+    companion object {
+        /** What the microphone service announces, so the percentage cannot drift from the wire. */
+        // Not a const: the announced format owns the number, and a const initializer cannot call
+        // toLong() on it.
+        val BYTES_PER_SECOND: Long = MicCaptureFormat.BYTES_PER_SECOND.toLong()
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/VehicleIdentityPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/VehicleIdentityPolicy.kt
@@ -1,0 +1,21 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * The vehicle id this head unit announces, which is part of how Android Auto identifies it.
+ *
+ * The phone looks its stored record up by make, model, year and a hash of this id, and on a hit it
+ * stamps the stored vehicle type over the one we declare. The hash also folds in the phone's own
+ * android_id and our TLS certificate subject, so we can only move it by moving the id. Giving each
+ * type its own id misses that lookup, which is what lets a changed type survive to the session.
+ *
+ * Pure: no Android, no logging.
+ */
+object VehicleIdentityPolicy {
+
+    /** A car keeps the user's own id, so nothing changes for a head unit that never claims another type. */
+    fun vehicleId(base: String, vehicleType: Int): String = when (vehicleType) {
+        VehicleTypePolicy.TRUCK -> "$base-truck"
+        VehicleTypePolicy.MOTORCYCLE -> "$base-moto"
+        else -> base
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/VehicleTypePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/VehicleTypePolicy.kt
@@ -1,0 +1,38 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * What kind of vehicle this head unit says it is, in Android Auto's own numbering.
+ *
+ * The user picks this, but the microphone setting overrides it. A motorcycle is the only claim that
+ * makes the phone record with its own microphone instead of asking for ours. It also matters for
+ * connecting at all: the phone ships two car services, and the newer one aborts setup when a head
+ * unit announces no microphone under any other type. Nothing tells us which one is running, so the
+ * claim goes out either way.
+ *
+ * Pure: no Android, no logging.
+ */
+object VehicleTypePolicy {
+
+    /** Android Auto's VEHICLE_TYPE_CAR. */
+    const val CAR = 1
+
+    /** Android Auto's VEHICLE_TYPE_TRUCK. */
+    const val TRUCK = 2
+
+    /** Android Auto's VEHICLE_TYPE_MOTORCYCLE. */
+    const val MOTORCYCLE = 3
+
+    /** The types a user can choose, in the order the picker shows them. */
+    val SELECTABLE = listOf(CAR, TRUCK, MOTORCYCLE)
+
+    /** What to announce. A head unit that will not record has to claim a motorcycle. */
+    fun vehicleType(selected: Int, headUnitMicEnabled: Boolean): Int =
+        if (headUnitMicEnabled) sanitised(selected) else MOTORCYCLE
+
+    /** A stored value that is not one of ours reads as a car, the same as sending nothing. */
+    fun sanitised(vehicleType: Int): Int = if (vehicleType in SELECTABLE) vehicleType else CAR
+
+    fun indexOf(vehicleType: Int): Int = SELECTABLE.indexOf(sanitised(vehicleType))
+
+    fun atIndex(index: Int): Int = SELECTABLE.getOrElse(index) { CAR }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/AudioConfigs.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/AudioConfigs.kt
@@ -40,6 +40,9 @@ object AudioConfigs {
         }.build()
         audioTracks.put(Channel.ID_AU1, audioConfig1)
 
+        // 16 kHz mono is required here, not preferred. The phone accepts the SYSTEM sink only if
+        // it offers that config, and with the audio sink off this is the only sink left - so
+        // anything else empties its endpoint list and the session ends with "No audio/mic".
         val audioConfig2 = Media.AudioConfiguration.newBuilder().apply {
             sampleRate = AudioDecoder.SAMPLE_RATE_HZ_16
             numberOfBits = 16

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/MicCaptureFormat.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/MicCaptureFormat.kt
@@ -8,6 +8,10 @@ package com.andrerinas.openheadunit.aap.protocol
  * rejected, and the teardown reasons include a bad microphone config. The announcement and the
  * capture used to be two separate literals, which is how a head unit came to declare 16 kHz and
  * send 48.
+ *
+ * That 48000 is not an option here. `AudioConfiguration` is one message shared by every audio
+ * service, so the validator accepts the union across all of them, and 48 kHz is in it for the media
+ * channel's stereo stream. For the microphone the guide names one rate.
  */
 object MicCaptureFormat {
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/MicCaptureFormat.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/MicCaptureFormat.kt
@@ -1,0 +1,43 @@
+package com.andrerinas.openheadunit.aap.protocol
+
+/**
+ * The one microphone format Android Auto is told about, and the only one it is ever sent.
+ *
+ * Google's head unit guide requires PCM 16 kHz 16-bit mono for speech, and Android Auto validates
+ * the announced configuration: anything outside {16000, 48000} Hz, 16 bits and 1 or 2 channels is
+ * rejected, and the teardown reasons include a bad microphone config. The announcement and the
+ * capture used to be two separate literals, which is how a head unit came to declare 16 kHz and
+ * send 48.
+ */
+object MicCaptureFormat {
+
+    const val SAMPLE_RATE_HZ = 16000
+
+    const val BITS = 16
+
+    const val CHANNELS = 1
+
+    /** Bytes in one mono 16-bit sample. */
+    const val FRAME_BYTES = 2
+
+    /** What one second of this format weighs, which is what the uplink report is measured against. */
+    const val BYTES_PER_SECOND = SAMPLE_RATE_HZ * FRAME_BYTES
+
+    /**
+     * Frames in one message, which Google's head unit guide names and requires messages to be a
+     * multiple of. Android Auto's own audio classes use the same number.
+     */
+    const val CHUNK_FRAMES = 2048
+
+    /** [CHUNK_FRAMES] as bytes. 128 ms of audio at the announced rate. */
+    const val CHUNK_BYTES = CHUNK_FRAMES * FRAME_BYTES
+
+    /**
+     * The only rate worth falling back to when the hardware refuses 16 kHz.
+     *
+     * Every Android device supports it, Android Auto accepts it, and three-to-one is a whole-group
+     * decimation with no filter to design. A non-integer ratio would need a low-pass nobody here
+     * can measure.
+     */
+    const val FALLBACK_SAMPLE_RATE_HZ = 48000
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/MicrophoneResponse.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/MicrophoneResponse.kt
@@ -1,0 +1,31 @@
+package com.andrerinas.openheadunit.aap.protocol.messages
+
+import com.andrerinas.openheadunit.aap.AapMessage
+import com.andrerinas.openheadunit.aap.protocol.Channel
+import com.andrerinas.openheadunit.aap.protocol.proto.Media
+import com.google.protobuf.Message
+
+/**
+ * The defined reply to a MicrophoneRequest, which this head unit never sent.
+ *
+ * Nothing acknowledged the phone opening or closing the microphone: the request only started or
+ * stopped the recorder. Android Auto knows the message - its own protocol enum names it - and a
+ * phone waiting on it before opening its speech pipeline would look exactly like a microphone that
+ * is heard but never understood.
+ *
+ * The session id is whatever a MediaStart left behind, which on every captured session is zero
+ * because the phone opens the microphone channel without one.
+ */
+class MicrophoneResponse(status: Int, sessionId: Int)
+    : AapMessage(Channel.ID_MIC, Media.MsgType.MEDIA_MESSAGE_MICROPHONE_RESPONSE_VALUE,
+        makeProto(status, sessionId)) {
+
+    companion object {
+        private fun makeProto(status: Int, sessionId: Int): Message {
+            return Media.MicrophoneResponse.newBuilder().apply {
+                this.status = status
+                this.sessionId = sessionId
+            }.build()
+        }
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/ServiceDiscoveryResponse.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/ServiceDiscoveryResponse.kt
@@ -8,6 +8,7 @@ import com.andrerinas.openheadunit.aap.NarrowBandProfilePolicy
 import com.andrerinas.openheadunit.input.KeyCode
 import com.andrerinas.openheadunit.aap.protocol.AudioConfigs
 import com.andrerinas.openheadunit.aap.protocol.Channel
+import com.andrerinas.openheadunit.aap.protocol.MicCaptureFormat
 import com.andrerinas.openheadunit.aap.protocol.proto.Control
 import com.andrerinas.openheadunit.aap.protocol.proto.Media
 import com.andrerinas.openheadunit.aap.protocol.proto.Sensors
@@ -195,15 +196,19 @@ class ServiceDiscoveryResponse(private val context: Context)
                         "channels - the phone will not send audio and this is not a fault")
             }
 
-            // Microphone Service (Channel 7) - Always required for AA connection (Assistant)
+            // Microphone Service (Channel 7). Announced unconditionally: a head unit that omits it
+            // does not connect - Android Auto's own required-service check fails with "No audio/mic".
+            // The format comes from MicCaptureFormat so the announcement and the capture cannot
+            // drift again, and it is never anything but 16 kHz: the phone validates this config and
+            // rejects everything outside {16000, 48000} Hz, 16 bits, 1 or 2 channels.
             val mic = Control.Service.newBuilder().also { service ->
                 service.id = Channel.ID_MIC
                 service.mediaSourceService = Control.Service.MediaSourceService.newBuilder().also {
                     it.type = Media.MediaCodecType.MEDIA_CODEC_AUDIO_PCM
                     it.audioConfig = Media.AudioConfiguration.newBuilder().apply {
-                        sampleRate = 16000
-                        numberOfBits = 16
-                        numberOfChannels = 1
+                        sampleRate = MicCaptureFormat.SAMPLE_RATE_HZ
+                        numberOfBits = MicCaptureFormat.BITS
+                        numberOfChannels = MicCaptureFormat.CHANNELS
                     }.build()
                 }.build()
             }.build()

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/ServiceDiscoveryResponse.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/ServiceDiscoveryResponse.kt
@@ -5,6 +5,8 @@ import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.aap.AapMessage
 import com.andrerinas.openheadunit.aap.AapService
 import com.andrerinas.openheadunit.aap.NarrowBandProfilePolicy
+import com.andrerinas.openheadunit.aap.VehicleIdentityPolicy
+import com.andrerinas.openheadunit.aap.VehicleTypePolicy
 import com.andrerinas.openheadunit.input.KeyCode
 import com.andrerinas.openheadunit.aap.protocol.AudioConfigs
 import com.andrerinas.openheadunit.aap.protocol.Channel
@@ -196,25 +198,37 @@ class ServiceDiscoveryResponse(private val context: Context)
                         "channels - the phone will not send audio and this is not a fault")
             }
 
-            // Microphone Service (Channel 7). Announced unconditionally: a head unit that omits it
-            // does not connect - Android Auto's own required-service check fails with "No audio/mic".
+            // Microphone Service (Channel 7), announced only when this head unit will record.
+            // Advertising it and then declining every request leaves the assistant with nothing:
+            // the phone chooses its recorder once at projection start, and takes its own only for a
+            // motorcycle that offers it no microphone. Omitting it is safe only because we claim a
+            // motorcycle - the phone aborts connection setup with "No audio/mic" for any other
+            // type, so the two go together and neither works alone.
             // The format comes from MicCaptureFormat so the announcement and the capture cannot
             // drift again, and it is never anything but 16 kHz: the phone validates this config and
             // rejects everything outside {16000, 48000} Hz, 16 bits, 1 or 2 channels. 48 kHz is in
             // that set for the media channel, not for this one - AudioConfiguration is shared by
             // every audio service and the validator accepts the union.
-            val mic = Control.Service.newBuilder().also { service ->
-                service.id = Channel.ID_MIC
-                service.mediaSourceService = Control.Service.MediaSourceService.newBuilder().also {
-                    it.type = Media.MediaCodecType.MEDIA_CODEC_AUDIO_PCM
-                    it.audioConfig = Media.AudioConfiguration.newBuilder().apply {
-                        sampleRate = MicCaptureFormat.SAMPLE_RATE_HZ
-                        numberOfBits = MicCaptureFormat.BITS
-                        numberOfChannels = MicCaptureFormat.CHANNELS
+            if (settings.useHeadUnitMicrophone) {
+                val mic = Control.Service.newBuilder().also { service ->
+                    service.id = Channel.ID_MIC
+                    service.mediaSourceService = Control.Service.MediaSourceService.newBuilder().also {
+                        it.type = Media.MediaCodecType.MEDIA_CODEC_AUDIO_PCM
+                        it.audioConfig = Media.AudioConfiguration.newBuilder().apply {
+                            sampleRate = MicCaptureFormat.SAMPLE_RATE_HZ
+                            numberOfBits = MicCaptureFormat.BITS
+                            numberOfChannels = MicCaptureFormat.CHANNELS
+                        }.build()
                     }.build()
                 }.build()
-            }.build()
-            services.add(mic)
+                services.add(mic)
+            } else {
+                AppLog.i("Head unit microphone is off in Settings. Skipping the microphone " +
+                        "service - the phone is told this head unit cannot record, no voice " +
+                        "request will arrive here, and this is not a fault. This needs the phone " +
+                        "to keep our motorcycle claim, which Android 10 and older do not, so a " +
+                        "session that connects once and then stops on an older phone may be this")
+            }
 
             // Bluetooth Service
             if (settings.bluetoothAddress.isNotEmpty()) {
@@ -259,11 +273,19 @@ class ServiceDiscoveryResponse(private val context: Context)
                 (if (settings.hideBatteryLevel) 0x04 else 0)
             // 0x08 is "CAN_PLAY_NATIVE_MEDIA_DURING_VR"
 
+            // Every type gets its own announced id. The phone looks its stored record up by
+            // make/model/year and a hash of this id, and on a hit it stamps the stored vehicle type
+            // over the one we declare. A different id misses that lookup, so our claim survives;
+            // reusing one would make a changed type arrive as the old one.
+            val vehicleType = VehicleTypePolicy.vehicleType(
+                settings.vehicleType, settings.useHeadUnitMicrophone)
+            val announcedVehicleId = VehicleIdentityPolicy.vehicleId(settings.vehicleId, vehicleType)
+
             return Control.ServiceDiscoveryResponse.newBuilder().apply {
                 make = settings.vehicleMake
                 model = settings.vehicleModel // fun fact: AA checks internally if it ends with "truck"?!
                 year = settings.vehicleYear
-                vehicleId = settings.vehicleId
+                vehicleId = announcedVehicleId
                 headUnitModel = settings.headUnitModel
                 headUnitMake = settings.headUnitMake
                 headUnitSoftwareBuild = "1"
@@ -280,9 +302,14 @@ class ServiceDiscoveryResponse(private val context: Context)
                     setMake(settings.vehicleMake)
                     setModel(settings.vehicleModel)
                     setYear(settings.vehicleYear)
-                    setVehicleId(settings.vehicleId)
+                    setVehicleId(announcedVehicleId)
                     setHeadUnitSoftwareBuild("1")
                     setHeadUnitSoftwareVersion("0.1.0")
+                    // The phone stores this per head unit and reads it in a dozen places, and an
+                    // absent field reads as a car. A motorcycle is the only claim it answers by
+                    // recording with its own microphone, so the microphone setting overrides the
+                    // user's choice here.
+                    setVehicleType(vehicleType)
                 }.build())
 
                 addAllServices(services)

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/ServiceDiscoveryResponse.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/ServiceDiscoveryResponse.kt
@@ -200,7 +200,9 @@ class ServiceDiscoveryResponse(private val context: Context)
             // does not connect - Android Auto's own required-service check fails with "No audio/mic".
             // The format comes from MicCaptureFormat so the announcement and the capture cannot
             // drift again, and it is never anything but 16 kHz: the phone validates this config and
-            // rejects everything outside {16000, 48000} Hz, 16 bits, 1 or 2 channels.
+            // rejects everything outside {16000, 48000} Hz, 16 bits, 1 or 2 channels. 48 kHz is in
+            // that set for the media channel, not for this one - AudioConfiguration is shared by
+            // every audio service and the validator accepts the union.
             val mic = Control.Service.newBuilder().also { service ->
                 service.id = Channel.ID_MIC
                 service.mediaSourceService = Control.Service.MediaSourceService.newBuilder().also {
@@ -228,7 +230,12 @@ class ServiceDiscoveryResponse(private val context: Context)
                 }.build()
                 services.add(bluetooth)
             } else {
-                AppLog.i("BT MAC Address is empty. Skip bluetooth service")
+                // What the omission costs, in the user's terms. Android Auto keeps telephony
+                // disabled until a hands-free link is up, and this is the message that tells the
+                // phone where to connect one - so a blank field is why calls stay on the phone.
+                AppLog.i("BT MAC Address is empty, so no Bluetooth service is announced. The phone " +
+                    "is not told where to connect hands-free, and Android Auto keeps phone calls " +
+                    "on the phone until it is")
             }
 
             val mediaPlaybackStatus = Control.Service.newBuilder().also { service ->

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/proto/Common.java
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/proto/Common.java
@@ -386,123 +386,123 @@ public final class Common {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional string head_unit_make = 1;</code>
-     * @return Whether the headUnitMake field is set.
-     */
-    boolean hasHeadUnitMake();
-    /**
-     * <code>optional string head_unit_make = 1;</code>
-     * @return The headUnitMake.
-     */
-    java.lang.String getHeadUnitMake();
-    /**
-     * <code>optional string head_unit_make = 1;</code>
-     * @return The bytes for headUnitMake.
-     */
-    com.google.protobuf.ByteString
-        getHeadUnitMakeBytes();
-
-    /**
-     * <code>optional string head_unit_model = 2;</code>
-     * @return Whether the headUnitModel field is set.
-     */
-    boolean hasHeadUnitModel();
-    /**
-     * <code>optional string head_unit_model = 2;</code>
-     * @return The headUnitModel.
-     */
-    java.lang.String getHeadUnitModel();
-    /**
-     * <code>optional string head_unit_model = 2;</code>
-     * @return The bytes for headUnitModel.
-     */
-    com.google.protobuf.ByteString
-        getHeadUnitModelBytes();
-
-    /**
-     * <code>optional string make = 3;</code>
+     * <code>optional string make = 1;</code>
      * @return Whether the make field is set.
      */
     boolean hasMake();
     /**
-     * <code>optional string make = 3;</code>
+     * <code>optional string make = 1;</code>
      * @return The make.
      */
     java.lang.String getMake();
     /**
-     * <code>optional string make = 3;</code>
+     * <code>optional string make = 1;</code>
      * @return The bytes for make.
      */
     com.google.protobuf.ByteString
         getMakeBytes();
 
     /**
-     * <code>optional string model = 4;</code>
+     * <code>optional string model = 2;</code>
      * @return Whether the model field is set.
      */
     boolean hasModel();
     /**
-     * <code>optional string model = 4;</code>
+     * <code>optional string model = 2;</code>
      * @return The model.
      */
     java.lang.String getModel();
     /**
-     * <code>optional string model = 4;</code>
+     * <code>optional string model = 2;</code>
      * @return The bytes for model.
      */
     com.google.protobuf.ByteString
         getModelBytes();
 
     /**
-     * <code>optional string year = 5;</code>
+     * <code>optional string year = 3;</code>
      * @return Whether the year field is set.
      */
     boolean hasYear();
     /**
-     * <code>optional string year = 5;</code>
+     * <code>optional string year = 3;</code>
      * @return The year.
      */
     java.lang.String getYear();
     /**
-     * <code>optional string year = 5;</code>
+     * <code>optional string year = 3;</code>
      * @return The bytes for year.
      */
     com.google.protobuf.ByteString
         getYearBytes();
 
     /**
-     * <code>optional string head_unit_software_build = 6;</code>
-     * @return Whether the headUnitSoftwareBuild field is set.
-     */
-    boolean hasHeadUnitSoftwareBuild();
-    /**
-     * <code>optional string head_unit_software_build = 6;</code>
-     * @return The headUnitSoftwareBuild.
-     */
-    java.lang.String getHeadUnitSoftwareBuild();
-    /**
-     * <code>optional string head_unit_software_build = 6;</code>
-     * @return The bytes for headUnitSoftwareBuild.
-     */
-    com.google.protobuf.ByteString
-        getHeadUnitSoftwareBuildBytes();
-
-    /**
-     * <code>optional string vehicle_id = 7;</code>
+     * <code>optional string vehicle_id = 4;</code>
      * @return Whether the vehicleId field is set.
      */
     boolean hasVehicleId();
     /**
-     * <code>optional string vehicle_id = 7;</code>
+     * <code>optional string vehicle_id = 4;</code>
      * @return The vehicleId.
      */
     java.lang.String getVehicleId();
     /**
-     * <code>optional string vehicle_id = 7;</code>
+     * <code>optional string vehicle_id = 4;</code>
      * @return The bytes for vehicleId.
      */
     com.google.protobuf.ByteString
         getVehicleIdBytes();
+
+    /**
+     * <code>optional string head_unit_make = 5;</code>
+     * @return Whether the headUnitMake field is set.
+     */
+    boolean hasHeadUnitMake();
+    /**
+     * <code>optional string head_unit_make = 5;</code>
+     * @return The headUnitMake.
+     */
+    java.lang.String getHeadUnitMake();
+    /**
+     * <code>optional string head_unit_make = 5;</code>
+     * @return The bytes for headUnitMake.
+     */
+    com.google.protobuf.ByteString
+        getHeadUnitMakeBytes();
+
+    /**
+     * <code>optional string head_unit_model = 6;</code>
+     * @return Whether the headUnitModel field is set.
+     */
+    boolean hasHeadUnitModel();
+    /**
+     * <code>optional string head_unit_model = 6;</code>
+     * @return The headUnitModel.
+     */
+    java.lang.String getHeadUnitModel();
+    /**
+     * <code>optional string head_unit_model = 6;</code>
+     * @return The bytes for headUnitModel.
+     */
+    com.google.protobuf.ByteString
+        getHeadUnitModelBytes();
+
+    /**
+     * <code>optional string head_unit_software_build = 7;</code>
+     * @return Whether the headUnitSoftwareBuild field is set.
+     */
+    boolean hasHeadUnitSoftwareBuild();
+    /**
+     * <code>optional string head_unit_software_build = 7;</code>
+     * @return The headUnitSoftwareBuild.
+     */
+    java.lang.String getHeadUnitSoftwareBuild();
+    /**
+     * <code>optional string head_unit_software_build = 7;</code>
+     * @return The bytes for headUnitSoftwareBuild.
+     */
+    com.google.protobuf.ByteString
+        getHeadUnitSoftwareBuildBytes();
 
     /**
      * <code>optional string head_unit_software_version = 8;</code>
@@ -520,8 +520,36 @@ public final class Common {
      */
     com.google.protobuf.ByteString
         getHeadUnitSoftwareVersionBytes();
+
+    /**
+     * <pre>
+     * Android Auto's vehicle type: 0 unspecified, 1 car, 2 truck, 3 motorcycle. Unset reads
+     * as unspecified, and only a motorcycle makes the phone record with its own microphone.
+     * </pre>
+     *
+     * <code>optional int32 vehicle_type = 9;</code>
+     * @return Whether the vehicleType field is set.
+     */
+    boolean hasVehicleType();
+    /**
+     * <pre>
+     * Android Auto's vehicle type: 0 unspecified, 1 car, 2 truck, 3 motorcycle. Unset reads
+     * as unspecified, and only a motorcycle makes the phone record with its own microphone.
+     * </pre>
+     *
+     * <code>optional int32 vehicle_type = 9;</code>
+     * @return The vehicleType.
+     */
+    int getVehicleType();
   }
   /**
+   * <pre>
+   * Numbers taken from Android Auto's own copy of this message, which is the only reader.
+   * The previous order put head_unit_make first, so every value arrived under the wrong name:
+   * the phone keys its per-head-unit records on make/model/year/vehicle_id and matches vendor
+   * workarounds against them.
+   * </pre>
+   *
    * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.HeadUnitInfo}
    */
   public static final class HeadUnitInfo extends
@@ -534,13 +562,13 @@ public final class Common {
       super(builder);
     }
     private HeadUnitInfo() {
-      headUnitMake_ = "";
-      headUnitModel_ = "";
       make_ = "";
       model_ = "";
       year_ = "";
-      headUnitSoftwareBuild_ = "";
       vehicleId_ = "";
+      headUnitMake_ = "";
+      headUnitModel_ = "";
+      headUnitSoftwareBuild_ = "";
       headUnitSoftwareVersion_ = "";
     }
 
@@ -565,117 +593,19 @@ public final class Common {
     }
 
     private int bitField0_;
-    public static final int HEAD_UNIT_MAKE_FIELD_NUMBER = 1;
-    @SuppressWarnings("serial")
-    private volatile java.lang.Object headUnitMake_ = "";
-    /**
-     * <code>optional string head_unit_make = 1;</code>
-     * @return Whether the headUnitMake field is set.
-     */
-    @java.lang.Override
-    public boolean hasHeadUnitMake() {
-      return ((bitField0_ & 0x00000001) != 0);
-    }
-    /**
-     * <code>optional string head_unit_make = 1;</code>
-     * @return The headUnitMake.
-     */
-    @java.lang.Override
-    public java.lang.String getHeadUnitMake() {
-      java.lang.Object ref = headUnitMake_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          headUnitMake_ = s;
-        }
-        return s;
-      }
-    }
-    /**
-     * <code>optional string head_unit_make = 1;</code>
-     * @return The bytes for headUnitMake.
-     */
-    @java.lang.Override
-    public com.google.protobuf.ByteString
-        getHeadUnitMakeBytes() {
-      java.lang.Object ref = headUnitMake_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        headUnitMake_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
-    }
-
-    public static final int HEAD_UNIT_MODEL_FIELD_NUMBER = 2;
-    @SuppressWarnings("serial")
-    private volatile java.lang.Object headUnitModel_ = "";
-    /**
-     * <code>optional string head_unit_model = 2;</code>
-     * @return Whether the headUnitModel field is set.
-     */
-    @java.lang.Override
-    public boolean hasHeadUnitModel() {
-      return ((bitField0_ & 0x00000002) != 0);
-    }
-    /**
-     * <code>optional string head_unit_model = 2;</code>
-     * @return The headUnitModel.
-     */
-    @java.lang.Override
-    public java.lang.String getHeadUnitModel() {
-      java.lang.Object ref = headUnitModel_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          headUnitModel_ = s;
-        }
-        return s;
-      }
-    }
-    /**
-     * <code>optional string head_unit_model = 2;</code>
-     * @return The bytes for headUnitModel.
-     */
-    @java.lang.Override
-    public com.google.protobuf.ByteString
-        getHeadUnitModelBytes() {
-      java.lang.Object ref = headUnitModel_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        headUnitModel_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
-    }
-
-    public static final int MAKE_FIELD_NUMBER = 3;
+    public static final int MAKE_FIELD_NUMBER = 1;
     @SuppressWarnings("serial")
     private volatile java.lang.Object make_ = "";
     /**
-     * <code>optional string make = 3;</code>
+     * <code>optional string make = 1;</code>
      * @return Whether the make field is set.
      */
     @java.lang.Override
     public boolean hasMake() {
-      return ((bitField0_ & 0x00000004) != 0);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
-     * <code>optional string make = 3;</code>
+     * <code>optional string make = 1;</code>
      * @return The make.
      */
     @java.lang.Override
@@ -694,7 +624,7 @@ public final class Common {
       }
     }
     /**
-     * <code>optional string make = 3;</code>
+     * <code>optional string make = 1;</code>
      * @return The bytes for make.
      */
     @java.lang.Override
@@ -712,19 +642,19 @@ public final class Common {
       }
     }
 
-    public static final int MODEL_FIELD_NUMBER = 4;
+    public static final int MODEL_FIELD_NUMBER = 2;
     @SuppressWarnings("serial")
     private volatile java.lang.Object model_ = "";
     /**
-     * <code>optional string model = 4;</code>
+     * <code>optional string model = 2;</code>
      * @return Whether the model field is set.
      */
     @java.lang.Override
     public boolean hasModel() {
-      return ((bitField0_ & 0x00000008) != 0);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
-     * <code>optional string model = 4;</code>
+     * <code>optional string model = 2;</code>
      * @return The model.
      */
     @java.lang.Override
@@ -743,7 +673,7 @@ public final class Common {
       }
     }
     /**
-     * <code>optional string model = 4;</code>
+     * <code>optional string model = 2;</code>
      * @return The bytes for model.
      */
     @java.lang.Override
@@ -761,19 +691,19 @@ public final class Common {
       }
     }
 
-    public static final int YEAR_FIELD_NUMBER = 5;
+    public static final int YEAR_FIELD_NUMBER = 3;
     @SuppressWarnings("serial")
     private volatile java.lang.Object year_ = "";
     /**
-     * <code>optional string year = 5;</code>
+     * <code>optional string year = 3;</code>
      * @return Whether the year field is set.
      */
     @java.lang.Override
     public boolean hasYear() {
-      return ((bitField0_ & 0x00000010) != 0);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
-     * <code>optional string year = 5;</code>
+     * <code>optional string year = 3;</code>
      * @return The year.
      */
     @java.lang.Override
@@ -792,7 +722,7 @@ public final class Common {
       }
     }
     /**
-     * <code>optional string year = 5;</code>
+     * <code>optional string year = 3;</code>
      * @return The bytes for year.
      */
     @java.lang.Override
@@ -810,68 +740,19 @@ public final class Common {
       }
     }
 
-    public static final int HEAD_UNIT_SOFTWARE_BUILD_FIELD_NUMBER = 6;
-    @SuppressWarnings("serial")
-    private volatile java.lang.Object headUnitSoftwareBuild_ = "";
-    /**
-     * <code>optional string head_unit_software_build = 6;</code>
-     * @return Whether the headUnitSoftwareBuild field is set.
-     */
-    @java.lang.Override
-    public boolean hasHeadUnitSoftwareBuild() {
-      return ((bitField0_ & 0x00000020) != 0);
-    }
-    /**
-     * <code>optional string head_unit_software_build = 6;</code>
-     * @return The headUnitSoftwareBuild.
-     */
-    @java.lang.Override
-    public java.lang.String getHeadUnitSoftwareBuild() {
-      java.lang.Object ref = headUnitSoftwareBuild_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          headUnitSoftwareBuild_ = s;
-        }
-        return s;
-      }
-    }
-    /**
-     * <code>optional string head_unit_software_build = 6;</code>
-     * @return The bytes for headUnitSoftwareBuild.
-     */
-    @java.lang.Override
-    public com.google.protobuf.ByteString
-        getHeadUnitSoftwareBuildBytes() {
-      java.lang.Object ref = headUnitSoftwareBuild_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        headUnitSoftwareBuild_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
-    }
-
-    public static final int VEHICLE_ID_FIELD_NUMBER = 7;
+    public static final int VEHICLE_ID_FIELD_NUMBER = 4;
     @SuppressWarnings("serial")
     private volatile java.lang.Object vehicleId_ = "";
     /**
-     * <code>optional string vehicle_id = 7;</code>
+     * <code>optional string vehicle_id = 4;</code>
      * @return Whether the vehicleId field is set.
      */
     @java.lang.Override
     public boolean hasVehicleId() {
-      return ((bitField0_ & 0x00000040) != 0);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
-     * <code>optional string vehicle_id = 7;</code>
+     * <code>optional string vehicle_id = 4;</code>
      * @return The vehicleId.
      */
     @java.lang.Override
@@ -890,7 +771,7 @@ public final class Common {
       }
     }
     /**
-     * <code>optional string vehicle_id = 7;</code>
+     * <code>optional string vehicle_id = 4;</code>
      * @return The bytes for vehicleId.
      */
     @java.lang.Override
@@ -902,6 +783,153 @@ public final class Common {
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         vehicleId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int HEAD_UNIT_MAKE_FIELD_NUMBER = 5;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object headUnitMake_ = "";
+    /**
+     * <code>optional string head_unit_make = 5;</code>
+     * @return Whether the headUnitMake field is set.
+     */
+    @java.lang.Override
+    public boolean hasHeadUnitMake() {
+      return ((bitField0_ & 0x00000010) != 0);
+    }
+    /**
+     * <code>optional string head_unit_make = 5;</code>
+     * @return The headUnitMake.
+     */
+    @java.lang.Override
+    public java.lang.String getHeadUnitMake() {
+      java.lang.Object ref = headUnitMake_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          headUnitMake_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string head_unit_make = 5;</code>
+     * @return The bytes for headUnitMake.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getHeadUnitMakeBytes() {
+      java.lang.Object ref = headUnitMake_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        headUnitMake_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int HEAD_UNIT_MODEL_FIELD_NUMBER = 6;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object headUnitModel_ = "";
+    /**
+     * <code>optional string head_unit_model = 6;</code>
+     * @return Whether the headUnitModel field is set.
+     */
+    @java.lang.Override
+    public boolean hasHeadUnitModel() {
+      return ((bitField0_ & 0x00000020) != 0);
+    }
+    /**
+     * <code>optional string head_unit_model = 6;</code>
+     * @return The headUnitModel.
+     */
+    @java.lang.Override
+    public java.lang.String getHeadUnitModel() {
+      java.lang.Object ref = headUnitModel_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          headUnitModel_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string head_unit_model = 6;</code>
+     * @return The bytes for headUnitModel.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getHeadUnitModelBytes() {
+      java.lang.Object ref = headUnitModel_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        headUnitModel_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int HEAD_UNIT_SOFTWARE_BUILD_FIELD_NUMBER = 7;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object headUnitSoftwareBuild_ = "";
+    /**
+     * <code>optional string head_unit_software_build = 7;</code>
+     * @return Whether the headUnitSoftwareBuild field is set.
+     */
+    @java.lang.Override
+    public boolean hasHeadUnitSoftwareBuild() {
+      return ((bitField0_ & 0x00000040) != 0);
+    }
+    /**
+     * <code>optional string head_unit_software_build = 7;</code>
+     * @return The headUnitSoftwareBuild.
+     */
+    @java.lang.Override
+    public java.lang.String getHeadUnitSoftwareBuild() {
+      java.lang.Object ref = headUnitSoftwareBuild_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          headUnitSoftwareBuild_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string head_unit_software_build = 7;</code>
+     * @return The bytes for headUnitSoftwareBuild.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getHeadUnitSoftwareBuildBytes() {
+      java.lang.Object ref = headUnitSoftwareBuild_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        headUnitSoftwareBuild_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
@@ -957,6 +985,35 @@ public final class Common {
       }
     }
 
+    public static final int VEHICLE_TYPE_FIELD_NUMBER = 9;
+    private int vehicleType_ = 0;
+    /**
+     * <pre>
+     * Android Auto's vehicle type: 0 unspecified, 1 car, 2 truck, 3 motorcycle. Unset reads
+     * as unspecified, and only a motorcycle makes the phone record with its own microphone.
+     * </pre>
+     *
+     * <code>optional int32 vehicle_type = 9;</code>
+     * @return Whether the vehicleType field is set.
+     */
+    @java.lang.Override
+    public boolean hasVehicleType() {
+      return ((bitField0_ & 0x00000100) != 0);
+    }
+    /**
+     * <pre>
+     * Android Auto's vehicle type: 0 unspecified, 1 car, 2 truck, 3 motorcycle. Unset reads
+     * as unspecified, and only a motorcycle makes the phone record with its own microphone.
+     * </pre>
+     *
+     * <code>optional int32 vehicle_type = 9;</code>
+     * @return The vehicleType.
+     */
+    @java.lang.Override
+    public int getVehicleType() {
+      return vehicleType_;
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -972,28 +1029,31 @@ public final class Common {
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) != 0)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, headUnitMake_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, make_);
       }
       if (((bitField0_ & 0x00000002) != 0)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, headUnitModel_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, model_);
       }
       if (((bitField0_ & 0x00000004) != 0)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, make_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, year_);
       }
       if (((bitField0_ & 0x00000008) != 0)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 4, model_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 4, vehicleId_);
       }
       if (((bitField0_ & 0x00000010) != 0)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 5, year_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 5, headUnitMake_);
       }
       if (((bitField0_ & 0x00000020) != 0)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 6, headUnitSoftwareBuild_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 6, headUnitModel_);
       }
       if (((bitField0_ & 0x00000040) != 0)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 7, vehicleId_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 7, headUnitSoftwareBuild_);
       }
       if (((bitField0_ & 0x00000080) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 8, headUnitSoftwareVersion_);
+      }
+      if (((bitField0_ & 0x00000100) != 0)) {
+        output.writeInt32(9, vehicleType_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -1005,28 +1065,32 @@ public final class Common {
 
       size = 0;
       if (((bitField0_ & 0x00000001) != 0)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, headUnitMake_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, make_);
       }
       if (((bitField0_ & 0x00000002) != 0)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, headUnitModel_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, model_);
       }
       if (((bitField0_ & 0x00000004) != 0)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, make_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, year_);
       }
       if (((bitField0_ & 0x00000008) != 0)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, model_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, vehicleId_);
       }
       if (((bitField0_ & 0x00000010) != 0)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, year_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, headUnitMake_);
       }
       if (((bitField0_ & 0x00000020) != 0)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, headUnitSoftwareBuild_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, headUnitModel_);
       }
       if (((bitField0_ & 0x00000040) != 0)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(7, vehicleId_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(7, headUnitSoftwareBuild_);
       }
       if (((bitField0_ & 0x00000080) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(8, headUnitSoftwareVersion_);
+      }
+      if (((bitField0_ & 0x00000100) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(9, vehicleType_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
@@ -1043,16 +1107,6 @@ public final class Common {
       }
       com.andrerinas.openheadunit.aap.protocol.proto.Common.HeadUnitInfo other = (com.andrerinas.openheadunit.aap.protocol.proto.Common.HeadUnitInfo) obj;
 
-      if (hasHeadUnitMake() != other.hasHeadUnitMake()) return false;
-      if (hasHeadUnitMake()) {
-        if (!getHeadUnitMake()
-            .equals(other.getHeadUnitMake())) return false;
-      }
-      if (hasHeadUnitModel() != other.hasHeadUnitModel()) return false;
-      if (hasHeadUnitModel()) {
-        if (!getHeadUnitModel()
-            .equals(other.getHeadUnitModel())) return false;
-      }
       if (hasMake() != other.hasMake()) return false;
       if (hasMake()) {
         if (!getMake()
@@ -1068,20 +1122,35 @@ public final class Common {
         if (!getYear()
             .equals(other.getYear())) return false;
       }
-      if (hasHeadUnitSoftwareBuild() != other.hasHeadUnitSoftwareBuild()) return false;
-      if (hasHeadUnitSoftwareBuild()) {
-        if (!getHeadUnitSoftwareBuild()
-            .equals(other.getHeadUnitSoftwareBuild())) return false;
-      }
       if (hasVehicleId() != other.hasVehicleId()) return false;
       if (hasVehicleId()) {
         if (!getVehicleId()
             .equals(other.getVehicleId())) return false;
       }
+      if (hasHeadUnitMake() != other.hasHeadUnitMake()) return false;
+      if (hasHeadUnitMake()) {
+        if (!getHeadUnitMake()
+            .equals(other.getHeadUnitMake())) return false;
+      }
+      if (hasHeadUnitModel() != other.hasHeadUnitModel()) return false;
+      if (hasHeadUnitModel()) {
+        if (!getHeadUnitModel()
+            .equals(other.getHeadUnitModel())) return false;
+      }
+      if (hasHeadUnitSoftwareBuild() != other.hasHeadUnitSoftwareBuild()) return false;
+      if (hasHeadUnitSoftwareBuild()) {
+        if (!getHeadUnitSoftwareBuild()
+            .equals(other.getHeadUnitSoftwareBuild())) return false;
+      }
       if (hasHeadUnitSoftwareVersion() != other.hasHeadUnitSoftwareVersion()) return false;
       if (hasHeadUnitSoftwareVersion()) {
         if (!getHeadUnitSoftwareVersion()
             .equals(other.getHeadUnitSoftwareVersion())) return false;
+      }
+      if (hasVehicleType() != other.hasVehicleType()) return false;
+      if (hasVehicleType()) {
+        if (getVehicleType()
+            != other.getVehicleType()) return false;
       }
       if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
@@ -1094,14 +1163,6 @@ public final class Common {
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
-      if (hasHeadUnitMake()) {
-        hash = (37 * hash) + HEAD_UNIT_MAKE_FIELD_NUMBER;
-        hash = (53 * hash) + getHeadUnitMake().hashCode();
-      }
-      if (hasHeadUnitModel()) {
-        hash = (37 * hash) + HEAD_UNIT_MODEL_FIELD_NUMBER;
-        hash = (53 * hash) + getHeadUnitModel().hashCode();
-      }
       if (hasMake()) {
         hash = (37 * hash) + MAKE_FIELD_NUMBER;
         hash = (53 * hash) + getMake().hashCode();
@@ -1114,17 +1175,29 @@ public final class Common {
         hash = (37 * hash) + YEAR_FIELD_NUMBER;
         hash = (53 * hash) + getYear().hashCode();
       }
-      if (hasHeadUnitSoftwareBuild()) {
-        hash = (37 * hash) + HEAD_UNIT_SOFTWARE_BUILD_FIELD_NUMBER;
-        hash = (53 * hash) + getHeadUnitSoftwareBuild().hashCode();
-      }
       if (hasVehicleId()) {
         hash = (37 * hash) + VEHICLE_ID_FIELD_NUMBER;
         hash = (53 * hash) + getVehicleId().hashCode();
       }
+      if (hasHeadUnitMake()) {
+        hash = (37 * hash) + HEAD_UNIT_MAKE_FIELD_NUMBER;
+        hash = (53 * hash) + getHeadUnitMake().hashCode();
+      }
+      if (hasHeadUnitModel()) {
+        hash = (37 * hash) + HEAD_UNIT_MODEL_FIELD_NUMBER;
+        hash = (53 * hash) + getHeadUnitModel().hashCode();
+      }
+      if (hasHeadUnitSoftwareBuild()) {
+        hash = (37 * hash) + HEAD_UNIT_SOFTWARE_BUILD_FIELD_NUMBER;
+        hash = (53 * hash) + getHeadUnitSoftwareBuild().hashCode();
+      }
       if (hasHeadUnitSoftwareVersion()) {
         hash = (37 * hash) + HEAD_UNIT_SOFTWARE_VERSION_FIELD_NUMBER;
         hash = (53 * hash) + getHeadUnitSoftwareVersion().hashCode();
+      }
+      if (hasVehicleType()) {
+        hash = (37 * hash) + VEHICLE_TYPE_FIELD_NUMBER;
+        hash = (53 * hash) + getVehicleType();
       }
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
@@ -1224,6 +1297,13 @@ public final class Common {
       return builder;
     }
     /**
+     * <pre>
+     * Numbers taken from Android Auto's own copy of this message, which is the only reader.
+     * The previous order put head_unit_make first, so every value arrived under the wrong name:
+     * the phone keys its per-head-unit records on make/model/year/vehicle_id and matches vendor
+     * workarounds against them.
+     * </pre>
+     *
      * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.HeadUnitInfo}
      */
     public static final class Builder extends
@@ -1257,14 +1337,15 @@ public final class Common {
       public Builder clear() {
         super.clear();
         bitField0_ = 0;
-        headUnitMake_ = "";
-        headUnitModel_ = "";
         make_ = "";
         model_ = "";
         year_ = "";
-        headUnitSoftwareBuild_ = "";
         vehicleId_ = "";
+        headUnitMake_ = "";
+        headUnitModel_ = "";
+        headUnitSoftwareBuild_ = "";
         headUnitSoftwareVersion_ = "";
+        vehicleType_ = 0;
         return this;
       }
 
@@ -1300,36 +1381,40 @@ public final class Common {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
-          result.headUnitMake_ = headUnitMake_;
+          result.make_ = make_;
           to_bitField0_ |= 0x00000001;
         }
         if (((from_bitField0_ & 0x00000002) != 0)) {
-          result.headUnitModel_ = headUnitModel_;
+          result.model_ = model_;
           to_bitField0_ |= 0x00000002;
         }
         if (((from_bitField0_ & 0x00000004) != 0)) {
-          result.make_ = make_;
+          result.year_ = year_;
           to_bitField0_ |= 0x00000004;
         }
         if (((from_bitField0_ & 0x00000008) != 0)) {
-          result.model_ = model_;
+          result.vehicleId_ = vehicleId_;
           to_bitField0_ |= 0x00000008;
         }
         if (((from_bitField0_ & 0x00000010) != 0)) {
-          result.year_ = year_;
+          result.headUnitMake_ = headUnitMake_;
           to_bitField0_ |= 0x00000010;
         }
         if (((from_bitField0_ & 0x00000020) != 0)) {
-          result.headUnitSoftwareBuild_ = headUnitSoftwareBuild_;
+          result.headUnitModel_ = headUnitModel_;
           to_bitField0_ |= 0x00000020;
         }
         if (((from_bitField0_ & 0x00000040) != 0)) {
-          result.vehicleId_ = vehicleId_;
+          result.headUnitSoftwareBuild_ = headUnitSoftwareBuild_;
           to_bitField0_ |= 0x00000040;
         }
         if (((from_bitField0_ & 0x00000080) != 0)) {
           result.headUnitSoftwareVersion_ = headUnitSoftwareVersion_;
           to_bitField0_ |= 0x00000080;
+        }
+        if (((from_bitField0_ & 0x00000100) != 0)) {
+          result.vehicleType_ = vehicleType_;
+          to_bitField0_ |= 0x00000100;
         }
         result.bitField0_ |= to_bitField0_;
       }
@@ -1378,38 +1463,38 @@ public final class Common {
 
       public Builder mergeFrom(com.andrerinas.openheadunit.aap.protocol.proto.Common.HeadUnitInfo other) {
         if (other == com.andrerinas.openheadunit.aap.protocol.proto.Common.HeadUnitInfo.getDefaultInstance()) return this;
-        if (other.hasHeadUnitMake()) {
-          headUnitMake_ = other.headUnitMake_;
-          bitField0_ |= 0x00000001;
-          onChanged();
-        }
-        if (other.hasHeadUnitModel()) {
-          headUnitModel_ = other.headUnitModel_;
-          bitField0_ |= 0x00000002;
-          onChanged();
-        }
         if (other.hasMake()) {
           make_ = other.make_;
-          bitField0_ |= 0x00000004;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         if (other.hasModel()) {
           model_ = other.model_;
-          bitField0_ |= 0x00000008;
+          bitField0_ |= 0x00000002;
           onChanged();
         }
         if (other.hasYear()) {
           year_ = other.year_;
-          bitField0_ |= 0x00000010;
-          onChanged();
-        }
-        if (other.hasHeadUnitSoftwareBuild()) {
-          headUnitSoftwareBuild_ = other.headUnitSoftwareBuild_;
-          bitField0_ |= 0x00000020;
+          bitField0_ |= 0x00000004;
           onChanged();
         }
         if (other.hasVehicleId()) {
           vehicleId_ = other.vehicleId_;
+          bitField0_ |= 0x00000008;
+          onChanged();
+        }
+        if (other.hasHeadUnitMake()) {
+          headUnitMake_ = other.headUnitMake_;
+          bitField0_ |= 0x00000010;
+          onChanged();
+        }
+        if (other.hasHeadUnitModel()) {
+          headUnitModel_ = other.headUnitModel_;
+          bitField0_ |= 0x00000020;
+          onChanged();
+        }
+        if (other.hasHeadUnitSoftwareBuild()) {
+          headUnitSoftwareBuild_ = other.headUnitSoftwareBuild_;
           bitField0_ |= 0x00000040;
           onChanged();
         }
@@ -1417,6 +1502,9 @@ public final class Common {
           headUnitSoftwareVersion_ = other.headUnitSoftwareVersion_;
           bitField0_ |= 0x00000080;
           onChanged();
+        }
+        if (other.hasVehicleType()) {
+          setVehicleType(other.getVehicleType());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
@@ -1445,37 +1533,37 @@ public final class Common {
                 done = true;
                 break;
               case 10: {
-                headUnitMake_ = input.readBytes();
+                make_ = input.readBytes();
                 bitField0_ |= 0x00000001;
                 break;
               } // case 10
               case 18: {
-                headUnitModel_ = input.readBytes();
+                model_ = input.readBytes();
                 bitField0_ |= 0x00000002;
                 break;
               } // case 18
               case 26: {
-                make_ = input.readBytes();
+                year_ = input.readBytes();
                 bitField0_ |= 0x00000004;
                 break;
               } // case 26
               case 34: {
-                model_ = input.readBytes();
+                vehicleId_ = input.readBytes();
                 bitField0_ |= 0x00000008;
                 break;
               } // case 34
               case 42: {
-                year_ = input.readBytes();
+                headUnitMake_ = input.readBytes();
                 bitField0_ |= 0x00000010;
                 break;
               } // case 42
               case 50: {
-                headUnitSoftwareBuild_ = input.readBytes();
+                headUnitModel_ = input.readBytes();
                 bitField0_ |= 0x00000020;
                 break;
               } // case 50
               case 58: {
-                vehicleId_ = input.readBytes();
+                headUnitSoftwareBuild_ = input.readBytes();
                 bitField0_ |= 0x00000040;
                 break;
               } // case 58
@@ -1484,6 +1572,11 @@ public final class Common {
                 bitField0_ |= 0x00000080;
                 break;
               } // case 66
+              case 72: {
+                vehicleType_ = input.readInt32();
+                bitField0_ |= 0x00000100;
+                break;
+              } // case 72
               default: {
                 if (!super.parseUnknownField(input, extensionRegistry, tag)) {
                   done = true; // was an endgroup tag
@@ -1501,176 +1594,16 @@ public final class Common {
       }
       private int bitField0_;
 
-      private java.lang.Object headUnitMake_ = "";
-      /**
-       * <code>optional string head_unit_make = 1;</code>
-       * @return Whether the headUnitMake field is set.
-       */
-      public boolean hasHeadUnitMake() {
-        return ((bitField0_ & 0x00000001) != 0);
-      }
-      /**
-       * <code>optional string head_unit_make = 1;</code>
-       * @return The headUnitMake.
-       */
-      public java.lang.String getHeadUnitMake() {
-        java.lang.Object ref = headUnitMake_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            headUnitMake_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
-      }
-      /**
-       * <code>optional string head_unit_make = 1;</code>
-       * @return The bytes for headUnitMake.
-       */
-      public com.google.protobuf.ByteString
-          getHeadUnitMakeBytes() {
-        java.lang.Object ref = headUnitMake_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          headUnitMake_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
-      }
-      /**
-       * <code>optional string head_unit_make = 1;</code>
-       * @param value The headUnitMake to set.
-       * @return This builder for chaining.
-       */
-      public Builder setHeadUnitMake(
-          java.lang.String value) {
-        if (value == null) { throw new NullPointerException(); }
-        headUnitMake_ = value;
-        bitField0_ |= 0x00000001;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional string head_unit_make = 1;</code>
-       * @return This builder for chaining.
-       */
-      public Builder clearHeadUnitMake() {
-        headUnitMake_ = getDefaultInstance().getHeadUnitMake();
-        bitField0_ = (bitField0_ & ~0x00000001);
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional string head_unit_make = 1;</code>
-       * @param value The bytes for headUnitMake to set.
-       * @return This builder for chaining.
-       */
-      public Builder setHeadUnitMakeBytes(
-          com.google.protobuf.ByteString value) {
-        if (value == null) { throw new NullPointerException(); }
-        headUnitMake_ = value;
-        bitField0_ |= 0x00000001;
-        onChanged();
-        return this;
-      }
-
-      private java.lang.Object headUnitModel_ = "";
-      /**
-       * <code>optional string head_unit_model = 2;</code>
-       * @return Whether the headUnitModel field is set.
-       */
-      public boolean hasHeadUnitModel() {
-        return ((bitField0_ & 0x00000002) != 0);
-      }
-      /**
-       * <code>optional string head_unit_model = 2;</code>
-       * @return The headUnitModel.
-       */
-      public java.lang.String getHeadUnitModel() {
-        java.lang.Object ref = headUnitModel_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            headUnitModel_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
-      }
-      /**
-       * <code>optional string head_unit_model = 2;</code>
-       * @return The bytes for headUnitModel.
-       */
-      public com.google.protobuf.ByteString
-          getHeadUnitModelBytes() {
-        java.lang.Object ref = headUnitModel_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          headUnitModel_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
-      }
-      /**
-       * <code>optional string head_unit_model = 2;</code>
-       * @param value The headUnitModel to set.
-       * @return This builder for chaining.
-       */
-      public Builder setHeadUnitModel(
-          java.lang.String value) {
-        if (value == null) { throw new NullPointerException(); }
-        headUnitModel_ = value;
-        bitField0_ |= 0x00000002;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional string head_unit_model = 2;</code>
-       * @return This builder for chaining.
-       */
-      public Builder clearHeadUnitModel() {
-        headUnitModel_ = getDefaultInstance().getHeadUnitModel();
-        bitField0_ = (bitField0_ & ~0x00000002);
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional string head_unit_model = 2;</code>
-       * @param value The bytes for headUnitModel to set.
-       * @return This builder for chaining.
-       */
-      public Builder setHeadUnitModelBytes(
-          com.google.protobuf.ByteString value) {
-        if (value == null) { throw new NullPointerException(); }
-        headUnitModel_ = value;
-        bitField0_ |= 0x00000002;
-        onChanged();
-        return this;
-      }
-
       private java.lang.Object make_ = "";
       /**
-       * <code>optional string make = 3;</code>
+       * <code>optional string make = 1;</code>
        * @return Whether the make field is set.
        */
       public boolean hasMake() {
-        return ((bitField0_ & 0x00000004) != 0);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
-       * <code>optional string make = 3;</code>
+       * <code>optional string make = 1;</code>
        * @return The make.
        */
       public java.lang.String getMake() {
@@ -1688,7 +1621,7 @@ public final class Common {
         }
       }
       /**
-       * <code>optional string make = 3;</code>
+       * <code>optional string make = 1;</code>
        * @return The bytes for make.
        */
       public com.google.protobuf.ByteString
@@ -1705,7 +1638,7 @@ public final class Common {
         }
       }
       /**
-       * <code>optional string make = 3;</code>
+       * <code>optional string make = 1;</code>
        * @param value The make to set.
        * @return This builder for chaining.
        */
@@ -1713,22 +1646,22 @@ public final class Common {
           java.lang.String value) {
         if (value == null) { throw new NullPointerException(); }
         make_ = value;
-        bitField0_ |= 0x00000004;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
       /**
-       * <code>optional string make = 3;</code>
+       * <code>optional string make = 1;</code>
        * @return This builder for chaining.
        */
       public Builder clearMake() {
         make_ = getDefaultInstance().getMake();
-        bitField0_ = (bitField0_ & ~0x00000004);
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
       /**
-       * <code>optional string make = 3;</code>
+       * <code>optional string make = 1;</code>
        * @param value The bytes for make to set.
        * @return This builder for chaining.
        */
@@ -1736,21 +1669,21 @@ public final class Common {
           com.google.protobuf.ByteString value) {
         if (value == null) { throw new NullPointerException(); }
         make_ = value;
-        bitField0_ |= 0x00000004;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
 
       private java.lang.Object model_ = "";
       /**
-       * <code>optional string model = 4;</code>
+       * <code>optional string model = 2;</code>
        * @return Whether the model field is set.
        */
       public boolean hasModel() {
-        return ((bitField0_ & 0x00000008) != 0);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
-       * <code>optional string model = 4;</code>
+       * <code>optional string model = 2;</code>
        * @return The model.
        */
       public java.lang.String getModel() {
@@ -1768,7 +1701,7 @@ public final class Common {
         }
       }
       /**
-       * <code>optional string model = 4;</code>
+       * <code>optional string model = 2;</code>
        * @return The bytes for model.
        */
       public com.google.protobuf.ByteString
@@ -1785,7 +1718,7 @@ public final class Common {
         }
       }
       /**
-       * <code>optional string model = 4;</code>
+       * <code>optional string model = 2;</code>
        * @param value The model to set.
        * @return This builder for chaining.
        */
@@ -1793,22 +1726,22 @@ public final class Common {
           java.lang.String value) {
         if (value == null) { throw new NullPointerException(); }
         model_ = value;
-        bitField0_ |= 0x00000008;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
       /**
-       * <code>optional string model = 4;</code>
+       * <code>optional string model = 2;</code>
        * @return This builder for chaining.
        */
       public Builder clearModel() {
         model_ = getDefaultInstance().getModel();
-        bitField0_ = (bitField0_ & ~0x00000008);
+        bitField0_ = (bitField0_ & ~0x00000002);
         onChanged();
         return this;
       }
       /**
-       * <code>optional string model = 4;</code>
+       * <code>optional string model = 2;</code>
        * @param value The bytes for model to set.
        * @return This builder for chaining.
        */
@@ -1816,21 +1749,21 @@ public final class Common {
           com.google.protobuf.ByteString value) {
         if (value == null) { throw new NullPointerException(); }
         model_ = value;
-        bitField0_ |= 0x00000008;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
 
       private java.lang.Object year_ = "";
       /**
-       * <code>optional string year = 5;</code>
+       * <code>optional string year = 3;</code>
        * @return Whether the year field is set.
        */
       public boolean hasYear() {
-        return ((bitField0_ & 0x00000010) != 0);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
-       * <code>optional string year = 5;</code>
+       * <code>optional string year = 3;</code>
        * @return The year.
        */
       public java.lang.String getYear() {
@@ -1848,7 +1781,7 @@ public final class Common {
         }
       }
       /**
-       * <code>optional string year = 5;</code>
+       * <code>optional string year = 3;</code>
        * @return The bytes for year.
        */
       public com.google.protobuf.ByteString
@@ -1865,7 +1798,7 @@ public final class Common {
         }
       }
       /**
-       * <code>optional string year = 5;</code>
+       * <code>optional string year = 3;</code>
        * @param value The year to set.
        * @return This builder for chaining.
        */
@@ -1873,22 +1806,22 @@ public final class Common {
           java.lang.String value) {
         if (value == null) { throw new NullPointerException(); }
         year_ = value;
-        bitField0_ |= 0x00000010;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
       /**
-       * <code>optional string year = 5;</code>
+       * <code>optional string year = 3;</code>
        * @return This builder for chaining.
        */
       public Builder clearYear() {
         year_ = getDefaultInstance().getYear();
-        bitField0_ = (bitField0_ & ~0x00000010);
+        bitField0_ = (bitField0_ & ~0x00000004);
         onChanged();
         return this;
       }
       /**
-       * <code>optional string year = 5;</code>
+       * <code>optional string year = 3;</code>
        * @param value The bytes for year to set.
        * @return This builder for chaining.
        */
@@ -1896,101 +1829,21 @@ public final class Common {
           com.google.protobuf.ByteString value) {
         if (value == null) { throw new NullPointerException(); }
         year_ = value;
-        bitField0_ |= 0x00000010;
-        onChanged();
-        return this;
-      }
-
-      private java.lang.Object headUnitSoftwareBuild_ = "";
-      /**
-       * <code>optional string head_unit_software_build = 6;</code>
-       * @return Whether the headUnitSoftwareBuild field is set.
-       */
-      public boolean hasHeadUnitSoftwareBuild() {
-        return ((bitField0_ & 0x00000020) != 0);
-      }
-      /**
-       * <code>optional string head_unit_software_build = 6;</code>
-       * @return The headUnitSoftwareBuild.
-       */
-      public java.lang.String getHeadUnitSoftwareBuild() {
-        java.lang.Object ref = headUnitSoftwareBuild_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            headUnitSoftwareBuild_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
-      }
-      /**
-       * <code>optional string head_unit_software_build = 6;</code>
-       * @return The bytes for headUnitSoftwareBuild.
-       */
-      public com.google.protobuf.ByteString
-          getHeadUnitSoftwareBuildBytes() {
-        java.lang.Object ref = headUnitSoftwareBuild_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          headUnitSoftwareBuild_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
-      }
-      /**
-       * <code>optional string head_unit_software_build = 6;</code>
-       * @param value The headUnitSoftwareBuild to set.
-       * @return This builder for chaining.
-       */
-      public Builder setHeadUnitSoftwareBuild(
-          java.lang.String value) {
-        if (value == null) { throw new NullPointerException(); }
-        headUnitSoftwareBuild_ = value;
-        bitField0_ |= 0x00000020;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional string head_unit_software_build = 6;</code>
-       * @return This builder for chaining.
-       */
-      public Builder clearHeadUnitSoftwareBuild() {
-        headUnitSoftwareBuild_ = getDefaultInstance().getHeadUnitSoftwareBuild();
-        bitField0_ = (bitField0_ & ~0x00000020);
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional string head_unit_software_build = 6;</code>
-       * @param value The bytes for headUnitSoftwareBuild to set.
-       * @return This builder for chaining.
-       */
-      public Builder setHeadUnitSoftwareBuildBytes(
-          com.google.protobuf.ByteString value) {
-        if (value == null) { throw new NullPointerException(); }
-        headUnitSoftwareBuild_ = value;
-        bitField0_ |= 0x00000020;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
 
       private java.lang.Object vehicleId_ = "";
       /**
-       * <code>optional string vehicle_id = 7;</code>
+       * <code>optional string vehicle_id = 4;</code>
        * @return Whether the vehicleId field is set.
        */
       public boolean hasVehicleId() {
-        return ((bitField0_ & 0x00000040) != 0);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
-       * <code>optional string vehicle_id = 7;</code>
+       * <code>optional string vehicle_id = 4;</code>
        * @return The vehicleId.
        */
       public java.lang.String getVehicleId() {
@@ -2008,7 +1861,7 @@ public final class Common {
         }
       }
       /**
-       * <code>optional string vehicle_id = 7;</code>
+       * <code>optional string vehicle_id = 4;</code>
        * @return The bytes for vehicleId.
        */
       public com.google.protobuf.ByteString
@@ -2025,7 +1878,7 @@ public final class Common {
         }
       }
       /**
-       * <code>optional string vehicle_id = 7;</code>
+       * <code>optional string vehicle_id = 4;</code>
        * @param value The vehicleId to set.
        * @return This builder for chaining.
        */
@@ -2033,22 +1886,22 @@ public final class Common {
           java.lang.String value) {
         if (value == null) { throw new NullPointerException(); }
         vehicleId_ = value;
-        bitField0_ |= 0x00000040;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
       /**
-       * <code>optional string vehicle_id = 7;</code>
+       * <code>optional string vehicle_id = 4;</code>
        * @return This builder for chaining.
        */
       public Builder clearVehicleId() {
         vehicleId_ = getDefaultInstance().getVehicleId();
-        bitField0_ = (bitField0_ & ~0x00000040);
+        bitField0_ = (bitField0_ & ~0x00000008);
         onChanged();
         return this;
       }
       /**
-       * <code>optional string vehicle_id = 7;</code>
+       * <code>optional string vehicle_id = 4;</code>
        * @param value The bytes for vehicleId to set.
        * @return This builder for chaining.
        */
@@ -2056,6 +1909,246 @@ public final class Common {
           com.google.protobuf.ByteString value) {
         if (value == null) { throw new NullPointerException(); }
         vehicleId_ = value;
+        bitField0_ |= 0x00000008;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object headUnitMake_ = "";
+      /**
+       * <code>optional string head_unit_make = 5;</code>
+       * @return Whether the headUnitMake field is set.
+       */
+      public boolean hasHeadUnitMake() {
+        return ((bitField0_ & 0x00000010) != 0);
+      }
+      /**
+       * <code>optional string head_unit_make = 5;</code>
+       * @return The headUnitMake.
+       */
+      public java.lang.String getHeadUnitMake() {
+        java.lang.Object ref = headUnitMake_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            headUnitMake_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string head_unit_make = 5;</code>
+       * @return The bytes for headUnitMake.
+       */
+      public com.google.protobuf.ByteString
+          getHeadUnitMakeBytes() {
+        java.lang.Object ref = headUnitMake_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          headUnitMake_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string head_unit_make = 5;</code>
+       * @param value The headUnitMake to set.
+       * @return This builder for chaining.
+       */
+      public Builder setHeadUnitMake(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        headUnitMake_ = value;
+        bitField0_ |= 0x00000010;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string head_unit_make = 5;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearHeadUnitMake() {
+        headUnitMake_ = getDefaultInstance().getHeadUnitMake();
+        bitField0_ = (bitField0_ & ~0x00000010);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string head_unit_make = 5;</code>
+       * @param value The bytes for headUnitMake to set.
+       * @return This builder for chaining.
+       */
+      public Builder setHeadUnitMakeBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        headUnitMake_ = value;
+        bitField0_ |= 0x00000010;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object headUnitModel_ = "";
+      /**
+       * <code>optional string head_unit_model = 6;</code>
+       * @return Whether the headUnitModel field is set.
+       */
+      public boolean hasHeadUnitModel() {
+        return ((bitField0_ & 0x00000020) != 0);
+      }
+      /**
+       * <code>optional string head_unit_model = 6;</code>
+       * @return The headUnitModel.
+       */
+      public java.lang.String getHeadUnitModel() {
+        java.lang.Object ref = headUnitModel_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            headUnitModel_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string head_unit_model = 6;</code>
+       * @return The bytes for headUnitModel.
+       */
+      public com.google.protobuf.ByteString
+          getHeadUnitModelBytes() {
+        java.lang.Object ref = headUnitModel_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          headUnitModel_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string head_unit_model = 6;</code>
+       * @param value The headUnitModel to set.
+       * @return This builder for chaining.
+       */
+      public Builder setHeadUnitModel(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        headUnitModel_ = value;
+        bitField0_ |= 0x00000020;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string head_unit_model = 6;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearHeadUnitModel() {
+        headUnitModel_ = getDefaultInstance().getHeadUnitModel();
+        bitField0_ = (bitField0_ & ~0x00000020);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string head_unit_model = 6;</code>
+       * @param value The bytes for headUnitModel to set.
+       * @return This builder for chaining.
+       */
+      public Builder setHeadUnitModelBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        headUnitModel_ = value;
+        bitField0_ |= 0x00000020;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object headUnitSoftwareBuild_ = "";
+      /**
+       * <code>optional string head_unit_software_build = 7;</code>
+       * @return Whether the headUnitSoftwareBuild field is set.
+       */
+      public boolean hasHeadUnitSoftwareBuild() {
+        return ((bitField0_ & 0x00000040) != 0);
+      }
+      /**
+       * <code>optional string head_unit_software_build = 7;</code>
+       * @return The headUnitSoftwareBuild.
+       */
+      public java.lang.String getHeadUnitSoftwareBuild() {
+        java.lang.Object ref = headUnitSoftwareBuild_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            headUnitSoftwareBuild_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string head_unit_software_build = 7;</code>
+       * @return The bytes for headUnitSoftwareBuild.
+       */
+      public com.google.protobuf.ByteString
+          getHeadUnitSoftwareBuildBytes() {
+        java.lang.Object ref = headUnitSoftwareBuild_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          headUnitSoftwareBuild_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string head_unit_software_build = 7;</code>
+       * @param value The headUnitSoftwareBuild to set.
+       * @return This builder for chaining.
+       */
+      public Builder setHeadUnitSoftwareBuild(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        headUnitSoftwareBuild_ = value;
+        bitField0_ |= 0x00000040;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string head_unit_software_build = 7;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearHeadUnitSoftwareBuild() {
+        headUnitSoftwareBuild_ = getDefaultInstance().getHeadUnitSoftwareBuild();
+        bitField0_ = (bitField0_ & ~0x00000040);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string head_unit_software_build = 7;</code>
+       * @param value The bytes for headUnitSoftwareBuild to set.
+       * @return This builder for chaining.
+       */
+      public Builder setHeadUnitSoftwareBuildBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        headUnitSoftwareBuild_ = value;
         bitField0_ |= 0x00000040;
         onChanged();
         return this;
@@ -2140,6 +2233,66 @@ public final class Common {
         onChanged();
         return this;
       }
+
+      private int vehicleType_ ;
+      /**
+       * <pre>
+       * Android Auto's vehicle type: 0 unspecified, 1 car, 2 truck, 3 motorcycle. Unset reads
+       * as unspecified, and only a motorcycle makes the phone record with its own microphone.
+       * </pre>
+       *
+       * <code>optional int32 vehicle_type = 9;</code>
+       * @return Whether the vehicleType field is set.
+       */
+      @java.lang.Override
+      public boolean hasVehicleType() {
+        return ((bitField0_ & 0x00000100) != 0);
+      }
+      /**
+       * <pre>
+       * Android Auto's vehicle type: 0 unspecified, 1 car, 2 truck, 3 motorcycle. Unset reads
+       * as unspecified, and only a motorcycle makes the phone record with its own microphone.
+       * </pre>
+       *
+       * <code>optional int32 vehicle_type = 9;</code>
+       * @return The vehicleType.
+       */
+      @java.lang.Override
+      public int getVehicleType() {
+        return vehicleType_;
+      }
+      /**
+       * <pre>
+       * Android Auto's vehicle type: 0 unspecified, 1 car, 2 truck, 3 motorcycle. Unset reads
+       * as unspecified, and only a motorcycle makes the phone record with its own microphone.
+       * </pre>
+       *
+       * <code>optional int32 vehicle_type = 9;</code>
+       * @param value The vehicleType to set.
+       * @return This builder for chaining.
+       */
+      public Builder setVehicleType(int value) {
+
+        vehicleType_ = value;
+        bitField0_ |= 0x00000100;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Android Auto's vehicle type: 0 unspecified, 1 car, 2 truck, 3 motorcycle. Unset reads
+       * as unspecified, and only a motorcycle makes the phone record with its own microphone.
+       * </pre>
+       *
+       * <code>optional int32 vehicle_type = 9;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearVehicleType() {
+        bitField0_ = (bitField0_ & ~0x00000100);
+        vehicleType_ = 0;
+        onChanged();
+        return this;
+      }
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -2218,47 +2371,48 @@ public final class Common {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\012\014common.proto\022.com.andrerinas.openheadu" +
-      "nit.aap.protocol.proto\"\304\001\012\014HeadUnitInfo\022" +
-      "\026\012\016head_unit_make\030\001 \001(\011\022\027\012\017head_unit_mod" +
-      "el\030\002 \001(\011\022\014\012\004make\030\003 \001(\011\022\015\012\005model\030\004 \001(\011\022\014\012" +
-      "\004year\030\005 \001(\011\022 \012\030head_unit_software_build\030" +
-      "\006 \001(\011\022\022\012\012vehicle_id\030\007 \001(\011\022\"\012\032head_unit_s" +
-      "oftware_version\030\010 \001(\011*\323\012\012\015MessageStatus\022" +
-      "\022\012\016STATUS_SUCCESS\020\000\022\036\012\032STATUS_UNSOLICITE" +
-      "D_MESSAGE\020\001\022)\012\034STATUS_NO_COMPATIBLE_VERS" +
-      "ION\020\377\377\377\377\377\377\377\377\377\001\022%\012\030STATUS_CERTIFICATE_ERR" +
-      "OR\020\376\377\377\377\377\377\377\377\377\001\022*\012\035STATUS_AUTHENTICATION_F" +
-      "AILURE\020\375\377\377\377\377\377\377\377\377\001\022#\012\026STATUS_INVALID_SERV" +
-      "ICE\020\374\377\377\377\377\377\377\377\377\001\022#\012\026STATUS_INVALID_CHANNEL" +
-      "\020\373\377\377\377\377\377\377\377\377\001\022$\012\027STATUS_INVALID_PRIORITY\020\372" +
-      "\377\377\377\377\377\377\377\377\001\022\"\012\025STATUS_INTERNAL_ERROR\020\371\377\377\377\377" +
-      "\377\377\377\377\001\022)\012\034STATUS_MEDIA_CONFIG_MISMATCH\020\370\377" +
-      "\377\377\377\377\377\377\377\001\022\"\012\025STATUS_INVALID_SENSOR\020\367\377\377\377\377\377" +
-      "\377\377\377\001\022-\012 STATUS_BLUETOOTH_PAIRING_DELAYED" +
-      "\020\366\377\377\377\377\377\377\377\377\001\022)\012\034STATUS_BLUETOOTH_UNAVAILA" +
-      "BLE\020\365\377\377\377\377\377\377\377\377\001\022-\012 STATUS_BLUETOOTH_INVAL" +
-      "ID_ADDRESS\020\364\377\377\377\377\377\377\377\377\001\0224\012'STATUS_BLUETOOT" +
-      "H_INVALID_PAIRING_METHOD\020\363\377\377\377\377\377\377\377\377\001\022/\012\"S" +
-      "TATUS_BLUETOOTH_INVALID_AUTH_DATA\020\362\377\377\377\377\377" +
-      "\377\377\377\001\0220\012#STATUS_BLUETOOTH_AUTH_DATA_MISMA" +
-      "TCH\020\361\377\377\377\377\377\377\377\377\001\0224\012'STATUS_BLUETOOTH_HFP_A" +
-      "NOTHER_CONNECTION\020\360\377\377\377\377\377\377\377\377\001\0224\012'STATUS_B" +
-      "LUETOOTH_HFP_CONNECTION_FAILURE\020\357\377\377\377\377\377\377\377" +
-      "\377\001\022%\012\030STATUS_KEYCODE_NOT_BOUND\020\356\377\377\377\377\377\377\377\377" +
-      "\001\022)\012\034STATUS_RADIO_INVALID_STATION\020\355\377\377\377\377\377" +
-      "\377\377\377\001\022!\012\024STATUS_INVALID_INPUT\020\354\377\377\377\377\377\377\377\377\001\022" +
-      "7\012*STATUS_RADIO_STATION_PRESETS_NOT_SUPP" +
-      "ORTED\020\353\377\377\377\377\377\377\377\377\001\022$\012\027STATUS_RADIO_COMM_ER" +
-      "ROR\020\352\377\377\377\377\377\377\377\377\001\022=\0120STATUS_AUTHENTICATION_" +
-      "FAILURE_CERT_NOT_YET_VALID\020\351\377\377\377\377\377\377\377\377\001\0227\012" +
-      "*STATUS_AUTHENTICATION_FAILURE_CERT_EXPI" +
-      "RED\020\350\377\377\377\377\377\377\377\377\001\022 \012\023STATUS_PING_TIMEOUT\020\347\377" +
-      "\377\377\377\377\377\377\377\001\022)\012\034STATUS_COMMAND_NOT_SUPPORTED" +
-      "\020\206\376\377\377\377\377\377\377\377\001\022!\012\024STATUS_FRAMING_ERROR\020\205\376\377\377" +
-      "\377\377\377\377\377\001\022&\012\031STATUS_UNEXPECTED_MESSAGE\020\203\376\377\377" +
-      "\377\377\377\377\377\001\022\030\012\013STATUS_BUSY\020\202\376\377\377\377\377\377\377\377\001\022!\012\024STAT" +
-      "US_OUT_OF_MEMORY\020\201\376\377\377\377\377\377\377\377\001"
+      "\n\014common.proto\022.com.andrerinas.openheadu" +
+      "nit.aap.protocol.proto\"\332\001\n\014HeadUnitInfo\022" +
+      "\014\n\004make\030\001 \001(\t\022\r\n\005model\030\002 \001(\t\022\014\n\004year\030\003 \001" +
+      "(\t\022\022\n\nvehicle_id\030\004 \001(\t\022\026\n\016head_unit_make" +
+      "\030\005 \001(\t\022\027\n\017head_unit_model\030\006 \001(\t\022 \n\030head_" +
+      "unit_software_build\030\007 \001(\t\022\"\n\032head_unit_s" +
+      "oftware_version\030\010 \001(\t\022\024\n\014vehicle_type\030\t " +
+      "\001(\005*\323\n\n\rMessageStatus\022\022\n\016STATUS_SUCCESS\020" +
+      "\000\022\036\n\032STATUS_UNSOLICITED_MESSAGE\020\001\022)\n\034STA" +
+      "TUS_NO_COMPATIBLE_VERSION\020\377\377\377\377\377\377\377\377\377\001\022%\n\030" +
+      "STATUS_CERTIFICATE_ERROR\020\376\377\377\377\377\377\377\377\377\001\022*\n\035S" +
+      "TATUS_AUTHENTICATION_FAILURE\020\375\377\377\377\377\377\377\377\377\001\022" +
+      "#\n\026STATUS_INVALID_SERVICE\020\374\377\377\377\377\377\377\377\377\001\022#\n\026" +
+      "STATUS_INVALID_CHANNEL\020\373\377\377\377\377\377\377\377\377\001\022$\n\027STA" +
+      "TUS_INVALID_PRIORITY\020\372\377\377\377\377\377\377\377\377\001\022\"\n\025STATU" +
+      "S_INTERNAL_ERROR\020\371\377\377\377\377\377\377\377\377\001\022)\n\034STATUS_ME" +
+      "DIA_CONFIG_MISMATCH\020\370\377\377\377\377\377\377\377\377\001\022\"\n\025STATUS" +
+      "_INVALID_SENSOR\020\367\377\377\377\377\377\377\377\377\001\022-\n STATUS_BLU" +
+      "ETOOTH_PAIRING_DELAYED\020\366\377\377\377\377\377\377\377\377\001\022)\n\034STA" +
+      "TUS_BLUETOOTH_UNAVAILABLE\020\365\377\377\377\377\377\377\377\377\001\022-\n " +
+      "STATUS_BLUETOOTH_INVALID_ADDRESS\020\364\377\377\377\377\377\377" +
+      "\377\377\001\0224\n\'STATUS_BLUETOOTH_INVALID_PAIRING_" +
+      "METHOD\020\363\377\377\377\377\377\377\377\377\001\022/\n\"STATUS_BLUETOOTH_IN" +
+      "VALID_AUTH_DATA\020\362\377\377\377\377\377\377\377\377\001\0220\n#STATUS_BLU" +
+      "ETOOTH_AUTH_DATA_MISMATCH\020\361\377\377\377\377\377\377\377\377\001\0224\n\'" +
+      "STATUS_BLUETOOTH_HFP_ANOTHER_CONNECTION\020" +
+      "\360\377\377\377\377\377\377\377\377\001\0224\n\'STATUS_BLUETOOTH_HFP_CONNE" +
+      "CTION_FAILURE\020\357\377\377\377\377\377\377\377\377\001\022%\n\030STATUS_KEYCO" +
+      "DE_NOT_BOUND\020\356\377\377\377\377\377\377\377\377\001\022)\n\034STATUS_RADIO_" +
+      "INVALID_STATION\020\355\377\377\377\377\377\377\377\377\001\022!\n\024STATUS_INV" +
+      "ALID_INPUT\020\354\377\377\377\377\377\377\377\377\001\0227\n*STATUS_RADIO_ST" +
+      "ATION_PRESETS_NOT_SUPPORTED\020\353\377\377\377\377\377\377\377\377\001\022$" +
+      "\n\027STATUS_RADIO_COMM_ERROR\020\352\377\377\377\377\377\377\377\377\001\022=\n0" +
+      "STATUS_AUTHENTICATION_FAILURE_CERT_NOT_Y" +
+      "ET_VALID\020\351\377\377\377\377\377\377\377\377\001\0227\n*STATUS_AUTHENTICA" +
+      "TION_FAILURE_CERT_EXPIRED\020\350\377\377\377\377\377\377\377\377\001\022 \n\023" +
+      "STATUS_PING_TIMEOUT\020\347\377\377\377\377\377\377\377\377\001\022)\n\034STATUS" +
+      "_COMMAND_NOT_SUPPORTED\020\206\376\377\377\377\377\377\377\377\001\022!\n\024STA" +
+      "TUS_FRAMING_ERROR\020\205\376\377\377\377\377\377\377\377\001\022&\n\031STATUS_U" +
+      "NEXPECTED_MESSAGE\020\203\376\377\377\377\377\377\377\377\001\022\030\n\013STATUS_B" +
+      "USY\020\202\376\377\377\377\377\377\377\377\001\022!\n\024STATUS_OUT_OF_MEMORY\020\201" +
+      "\376\377\377\377\377\377\377\377\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -2269,7 +2423,7 @@ public final class Common {
     internal_static_com_andrerinas_openheadunit_aap_protocol_proto_HeadUnitInfo_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_com_andrerinas_openheadunit_aap_protocol_proto_HeadUnitInfo_descriptor,
-        new java.lang.String[] { "HeadUnitMake", "HeadUnitModel", "Make", "Model", "Year", "HeadUnitSoftwareBuild", "VehicleId", "HeadUnitSoftwareVersion", });
+        new java.lang.String[] { "Make", "Model", "Year", "VehicleId", "HeadUnitMake", "HeadUnitModel", "HeadUnitSoftwareBuild", "HeadUnitSoftwareVersion", "VehicleType", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/app/src/main/java/com/andrerinas/openheadunit/app/ForegroundServiceTypePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/app/ForegroundServiceTypePolicy.kt
@@ -1,0 +1,50 @@
+package com.andrerinas.openheadunit.app
+
+import android.content.pm.ServiceInfo
+import android.os.Build
+
+/**
+ * Which foreground-service types this service claims, and when.
+ *
+ * The microphone type cannot be claimed at service start. Since Android 14 it is a while-in-use
+ * type, so holding the permission is necessary and not sufficient: a service started from the
+ * background is refused with "the app must be in the eligible state/exemptions" even with
+ * RECORD_AUDIO granted, and this service starts from boot, USB and Bluetooth receivers. Measured on
+ * a background Bluetooth auto-start, five times out of five.
+ *
+ * So the start claims [baseTypeMask], which holds no while-in-use type and cannot be refused, and
+ * the microphone is added by [withMicrophone] at the moment capture actually opens - by then the
+ * projection is on screen and the app is eligible. It is dropped again when capture stops, so the
+ * type is held only while it is true.
+ */
+object ForegroundServiceTypePolicy {
+
+    /**
+     * What to claim when the service starts, from any caller and any process state.
+     *
+     * @param sdkInt the running platform level.
+     * @return the mask for startForeground, or 0 before Android Q, where the call takes no types.
+     */
+    fun baseTypeMask(sdkInt: Int): Int {
+        if (sdkInt < Build.VERSION_CODES.Q) return 0
+
+        return ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE or
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+    }
+
+    /**
+     * What to claim while the microphone is open.
+     *
+     * @param sdkInt the running platform level.
+     * @param recordAudioGranted whether RECORD_AUDIO is held right now.
+     * @param headUnitMicEnabled the user's microphone setting.
+     * @return [baseTypeMask] plus the microphone type when both hold, and [baseTypeMask] otherwise.
+     */
+    fun withMicrophone(sdkInt: Int, recordAudioGranted: Boolean, headUnitMicEnabled: Boolean): Int {
+        val base = baseTypeMask(sdkInt)
+        if (base == 0) return 0
+        if (!recordAudioGranted || !headUnitMicEnabled) return base
+
+        return base or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/AudioPrerollPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/AudioPrerollPolicy.kt
@@ -1,0 +1,79 @@
+package com.andrerinas.openheadunit.decoder.audio
+
+/**
+ * How much audio to bank in an [android.media.AudioTrack] before starting playback on it.
+ *
+ * The track was started the moment it was built, on an empty buffer, and all five media-stream
+ * starts in a measured capture underran within a second. Audio arrives at real time, so the writer
+ * never fills a buffer faster than the mixer drains it and the opening deficit is never recovered -
+ * which is also why a deep [com.andrerinas.openheadunit.utils.Settings.audioLatencyMultiplier]
+ * bought so little.
+ *
+ * Bank frames first and play once there are enough, as [AudioMixer] already does for its channels.
+ *
+ * Pure and clock-free: the caller passes the elapsed time in.
+ */
+object AudioPrerollPolicy {
+
+    /**
+     * How much audio to bank, in milliseconds of playback.
+     *
+     * A ceiling in time, not a share of the buffer: the default buffer is eight times the device
+     * minimum, and filling it would put two thirds of a second between pressing play and hearing
+     * anything. Above the ~87 ms device minimum, below the ~250 ms where a resume feels detached.
+     */
+    const val TARGET_MS = 200L
+
+    /**
+     * Never bank more than this share of the track's own buffer.
+     *
+     * `write()` on a track that is not playing blocks until only `play()` can make room, and
+     * `play()` is called from the writing thread - so a target the next chunk cannot fit under is a
+     * deadlock, not a delay. The margin leaves that chunk room.
+     */
+    const val MAX_FILL_NUMERATOR = 3
+    const val MAX_FILL_DENOMINATOR = 4
+
+    /**
+     * Start anyway once this long has passed with anything at all banked.
+     *
+     * A notification blip can be shorter than [TARGET_MS], and waiting for a target it will never
+     * reach would silence it. Set beyond [TARGET_MS] so an ordinary stream still starts on fill.
+     */
+    const val MAX_WAIT_MS = 300L
+
+    /**
+     * Frames to bank before starting, for a track of [bufferCapacityFrames] at [sampleRateInHz].
+     *
+     * At least one, so a nonsense capacity still yields a track that plays.
+     */
+    fun targetFrames(sampleRateInHz: Int, bufferCapacityFrames: Int): Int {
+        if (sampleRateInHz <= 0) return 1
+        val byTime = (sampleRateInHz.toLong() * TARGET_MS / 1000L).toInt()
+        val byBuffer = bufferCapacityFrames / MAX_FILL_DENOMINATOR * MAX_FILL_NUMERATOR
+        val capped = if (bufferCapacityFrames > 0) minOf(byTime, byBuffer) else byTime
+        return capped.coerceAtLeast(1)
+    }
+
+    /**
+     * Whether the track should be started now.
+     *
+     * @param framesBanked frames already written to the track.
+     * @param framesIncoming frames about to be written, counted here so the decision is made before
+     *   the write rather than after it. See [MAX_FILL_NUMERATOR].
+     * @param targetFrames from [targetFrames].
+     * @param elapsedMs since the track was built.
+     */
+    fun shouldStart(
+        framesBanked: Long,
+        framesIncoming: Int,
+        targetFrames: Int,
+        elapsedMs: Long
+    ): Boolean {
+        val total = framesBanked + framesIncoming
+        if (total >= targetFrames) return true
+        // Nothing banked is a stream that has not begun, not a short one. Starting on it would be
+        // the empty-buffer start again, with a timer in front of it.
+        return total > 0 && elapsedMs >= MAX_WAIT_MS
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/AudioTrackWrapper.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/AudioTrackWrapper.kt
@@ -12,10 +12,12 @@ import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.Process
+import android.os.SystemClock
 import com.andrerinas.openheadunit.utils.AppLog
 import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 class AudioTrackWrapper(
     stream: Int,
@@ -39,6 +41,14 @@ class AudioTrackWrapper(
     companion object {
         private const val AUDIO_BUFFER_POOL_LIMIT = 16
         private const val MIN_POOLED_AUDIO_BUFFER_SIZE = 4096
+
+        /**
+         * Ceiling on the computed drain wait.
+         *
+         * The wait is normally a couple of hundred milliseconds. The cap is for when the frame
+         * accounting is off, so a bad subtraction costs a beat rather than a hang.
+         */
+        private const val DRAIN_CAP_MS = 1_000L
     }
 
     private val audioTrack: AudioTrack?
@@ -94,9 +104,32 @@ class AudioTrackWrapper(
         }
     }
 
-    // Track frames written for better draining
+    // Frames written, for the pre-roll trigger and the drain wait. Volatile because the AAC path
+    // advances it from the write executor while the playback thread reads it, and a long is not
+    // read atomically on 32-bit ABIs. Only one thread per instance increments it, so visibility is
+    // the only hazard.
+    @Volatile
     private var framesWritten: Long = 0
     private val bytesPerFrame: Int = channelCount * (if (bitDepth == 16) 2 else 1)
+    private val sampleRate: Int = sampleRateInHz
+
+    /** Byte size handed to the AudioTrack, recorded by [createAudioTrack] for the pre-roll target. */
+    private var trackBufferBytes: Int = 0
+
+    /** Frames to bank before [android.media.AudioTrack.play]. See [AudioPrerollPolicy]. */
+    private var prerollTargetFrames: Int = 1
+
+    /**
+     * When audio first reached this track, for the pre-roll deadline.
+     *
+     * Stamped on the first write rather than at construction: a track precreated at Media Sink
+     * Setup can sit idle for minutes, and a deadline measured from then has already expired when
+     * the first chunk arrives.
+     */
+    @Volatile
+    private var firstAudioMs: Long = 0L
+
+    private val playbackStarted = AtomicBoolean(false)
 
     init {
         this.name = "AudioPlaybackThread"
@@ -113,7 +146,10 @@ class AudioTrackWrapper(
             setVolume(gain)
             audioTrack?.let { track ->
                 attachHwDspEqualizerQuietly(track.audioSessionId)
-                track.play()
+                // Deliberately no play() here: started empty, the track underran on every media
+                // start. [AudioPrerollPolicy] decides when enough is banked to begin.
+                prerollTargetFrames =
+                    AudioPrerollPolicy.targetFrames(sampleRateInHz, trackCapacityFrames(track))
             }
         }
 
@@ -225,10 +261,48 @@ class AudioTrackWrapper(
             framesWritten += size / bytesPerFrame
         } else {
             applyGain(buffer, size)
+            // Before the write, on whichever thread makes it: write() on a track that is not
+            // playing blocks until only play() can make room, so a check after it is too late.
+            maybeStartPlayback(size / bytesPerFrame)
             val result = audioTrack?.write(buffer, 0, size) ?: 0
             if (result > 0) {
                 framesWritten += result / bytesPerFrame
             }
+        }
+    }
+
+    /**
+     * Starts the track once [AudioPrerollPolicy] says enough is banked.
+     *
+     * [writeToTrack] calls it in front of every write, which is where an ordinary stream starts;
+     * the run loop calls it once a pass, which is what plays a stream too short to reach its
+     * target. Idempotent because the AAC path writes from the write executor while the run loop
+     * turns, so both can arrive at once.
+     */
+    private fun maybeStartPlayback(framesIncoming: Int) {
+        if (playbackStarted.get()) return
+        val track = audioTrack ?: return
+        val now = SystemClock.elapsedRealtime()
+        if (framesIncoming > 0 && firstAudioMs == 0L) firstAudioMs = now
+        if (firstAudioMs == 0L) return
+        val elapsed = now - firstAudioMs
+        if (!AudioPrerollPolicy.shouldStart(
+                framesWritten,
+                framesIncoming,
+                prerollTargetFrames,
+                elapsed
+            )
+        ) return
+
+        if (!playbackStarted.compareAndSet(false, true)) return
+        try {
+            track.play()
+            AppLog.i(
+                "AudioTrackWrapper: playback started with $framesWritten frames banked " +
+                    "(target $prerollTargetFrames) after ${elapsed}ms"
+            )
+        } catch (e: Exception) {
+            AppLog.e("Failed to start AudioTrack playback", e)
         }
     }
 
@@ -240,6 +314,9 @@ class AudioTrackWrapper(
             try {
                 // Use poll to avoid blocking indefinitely if isRunning becomes false
                 val chunk = dataQueue.poll(200, TimeUnit.MILLISECONDS)
+                // The fill trigger lives in writeToTrack; this call carries only the deadline, so
+                // a stream too short to reach its target still gets played.
+                maybeStartPlayback(0)
                 if (chunk != null) {
                     try {
                         if (isAac && decoder != null) {
@@ -373,6 +450,8 @@ class AudioTrackWrapper(
         val minBufferSize = AudioTrack.getMinBufferSize(sampleRateInHz, channelConfig, dataFormat)
         val bufferSize = if (minBufferSize > 0) minBufferSize * multiplier else minBufferSize
 
+        trackBufferBytes = bufferSize
+
         AppLog.i("Audio stream: $stream buffer size: $bufferSize (min: $minBufferSize) sampleRateInHz: $sampleRateInHz channelCount: $channelCount")
 
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
@@ -420,6 +499,25 @@ class AudioTrackWrapper(
                 AudioTrack.MODE_STREAM
             )
         }
+    }
+
+    /**
+     * Frames the track can actually hold.
+     *
+     * `setBufferSizeInBytes()` is a request the framework may clamp, and the pre-roll margin is the
+     * only thing keeping a write off a not-yet-playing track from blocking on the thread that would
+     * start it. Ask the track where the API allows; fall back to the requested size below M.
+     */
+    private fun trackCapacityFrames(track: AudioTrack): Int {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val frames = try {
+                track.bufferSizeInFrames
+            } catch (e: Exception) {
+                0
+            }
+            if (frames > 0) return frames
+        }
+        return if (bytesPerFrame > 0) trackBufferBytes / bytesPerFrame else 0
     }
 
     private fun attachHwDspEqualizerQuietly(sessionId: Int) {
@@ -495,31 +593,52 @@ class AudioTrackWrapper(
             mixer.unregisterChannel(channelId)
         }
 
-        // 3. Gracefully stop the AudioTrack – stop() plays remaining buffer data
+        // 3. stop() plays out what is still buffered on a MODE_STREAM track; this only waits for
+        // that to finish before release().
+        //
+        // It used to wait by polling playbackHeadPosition against framesWritten *after* stop(),
+        // and neither exit could fire: stop() zeroes the head, and the stagnation escape was
+        // guarded on `pos > 0`. Measured: the full 2500 ms budget on every teardown, long enough
+        // to overlap the next track's start.
+        //
+        // Sampling the head *before* stop() says how much is left to play, so compute the wait.
         val track = audioTrack
-        if (track != null && track.playState == AudioTrack.PLAYSTATE_PLAYING) {
-            try {
-                track.stop()
-
-                // Wait for the AudioTrack hardware buffer to drain.
-                // Especially important on older devices (KitKat etc.).
-                var lastPos = -1
-                var stagnantCount = 0
-                val startTime = System.currentTimeMillis()
-                while (System.currentTimeMillis() - startTime < 2500) {
-                    val pos = track.playbackHeadPosition
-                    if (framesWritten > 0 && pos >= framesWritten) break
-                    if (pos == lastPos && pos > 0) {
-                        stagnantCount++
-                        if (stagnantCount >= 3) break
-                    } else {
-                        lastPos = pos
-                        stagnantCount = 0
-                    }
-                    Thread.sleep(100)
+        // A track that never reached its pre-roll target still holds everything written to it. It
+        // is not playing, so the guard below would skip stop() and release() would discard it -
+        // silence where a prompt shorter than the target used to be heard. Start it first.
+        if (track != null && !playbackStarted.get() && framesWritten > 0) {
+            if (playbackStarted.compareAndSet(false, true)) {
+                try {
+                    track.play()
+                } catch (e: Exception) {
+                    AppLog.e("Failed to start AudioTrack for its final drain", e)
                 }
+            }
+        }
+        if (track != null && track.playState == AudioTrack.PLAYSTATE_PLAYING) {
+            var drainMs = 0L
+            try {
+                val played = track.playbackHeadPosition.toLong() and 0xFFFFFFFFL
+                val pending = (framesWritten - played).coerceAtLeast(0L)
+                drainMs = if (sampleRate > 0) {
+                    (pending * 1000L / sampleRate).coerceAtMost(DRAIN_CAP_MS)
+                } else {
+                    0L
+                }
+                track.stop()
             } catch (e: Exception) {
-                AppLog.e("Error during audio track cleanup", e)
+                AppLog.e("Error stopping audio track", e)
+            }
+
+            if (drainMs > 0) {
+                try {
+                    Thread.sleep(drainMs)
+                } catch (e: InterruptedException) {
+                    // A restart, not a failure, and what is left in the buffer is stale anyway.
+                    // Logged at info: reporters attach these logs, and a stack trace here misled.
+                    AppLog.i("AudioTrackWrapper: ${drainMs}ms drain cut short by a restart")
+                    Thread.currentThread().interrupt()
+                }
             }
         }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/MicCaptureRatePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/MicCaptureRatePolicy.kt
@@ -1,0 +1,43 @@
+package com.andrerinas.openheadunit.decoder.audio
+
+import com.andrerinas.openheadunit.aap.protocol.MicCaptureFormat
+
+/**
+ * Which rate to open the microphone at, given that only 16 kHz ever reaches the phone.
+ *
+ * 16 kHz first, because then there is nothing to convert. A device whose AudioRecord will not open
+ * it is the only reason the rate setting still exists, and the only fallback worth taking is a whole
+ * multiple of 16 kHz so the conversion is an average over whole sample groups.
+ *
+ * Pure: the caller supplies the probe, so every branch is reachable in a test.
+ */
+object MicCaptureRatePolicy {
+
+    /**
+     * @param preferredFallbackHz what the user's compatibility setting asks for if 16 kHz fails.
+     * @param minBufferSize AudioRecord.getMinBufferSize for a rate, mono 16-bit; zero or less means
+     *   the device cannot open that configuration.
+     */
+    fun decide(preferredFallbackHz: Int, minBufferSize: (Int) -> Int): Decision? {
+        val direct = minBufferSize(MicCaptureFormat.SAMPLE_RATE_HZ)
+        if (direct > 0) return Decision(MicCaptureFormat.SAMPLE_RATE_HZ, direct)
+
+        val candidates = linkedSetOf(preferredFallbackHz, MicCaptureFormat.FALLBACK_SAMPLE_RATE_HZ)
+        for (rate in candidates) {
+            if (rate <= MicCaptureFormat.SAMPLE_RATE_HZ) continue
+            if (rate % MicCaptureFormat.SAMPLE_RATE_HZ != 0) continue
+            val size = minBufferSize(rate)
+            if (size > 0) return Decision(rate, size)
+        }
+        return null
+    }
+
+    /** A rate the device will open, and the buffer it needs. */
+    data class Decision(val captureRateHz: Int, val minBufferSize: Int) {
+
+        /** How many captured samples make one sample on the wire. One means send them as they are. */
+        val decimationFactor: Int get() = captureRateHz / MicCaptureFormat.SAMPLE_RATE_HZ
+
+        val isDirect: Boolean get() = decimationFactor == 1
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/MicChunkAccumulator.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/MicChunkAccumulator.kt
@@ -1,0 +1,85 @@
+package com.andrerinas.openheadunit.decoder.audio
+
+import com.andrerinas.openheadunit.aap.protocol.MicCaptureFormat
+
+/**
+ * Gathers microphone reads into the fixed-size messages the protocol asks for.
+ *
+ * Google's head unit guide gives the microphone a 2048-frame buffer and requires frames to be a
+ * multiple of it; AudioRecord hands back whatever the device feels like, and reporter logs show 640
+ * and 768 frames. The old sender also dropped any read of 64 bytes or fewer outright, so a short
+ * read became a hole rather than a wait.
+ *
+ * Stateful, and two details are the reason this is an object rather than four lines in the
+ * transport. A chunk is stamped with the capture time of its **first** byte, not of the read that
+ * completed it, because a chunk is 128 ms long and stamping at the end would put every message that
+ * far out. And the tail left over when capture stops is **discarded, never padded**: zero padding
+ * injects silence the microphone never heard into a speech stream, and a short final message
+ * violates the multiple-of-2048 rule.
+ *
+ * Pure: no Android, no logging, no clock of its own.
+ */
+class MicChunkAccumulator(private val chunkBytes: Int = MicCaptureFormat.CHUNK_BYTES) {
+
+    init {
+        require(chunkBytes > 0 && chunkBytes % MicCaptureFormat.FRAME_BYTES == 0) {
+            "chunk must be a whole number of frames, was $chunkBytes bytes"
+        }
+    }
+
+    private val chunk = ByteArray(chunkBytes)
+    private var pending = 0
+    private var chunkStartedUs = 0L
+    private var chunkPeak = 0
+
+    /** Bytes held back, waiting for the rest of a chunk. */
+    val residueBytes: Int get() = pending
+
+    /**
+     * Feed one read and emit every whole chunk it completes.
+     *
+     * [capturedAtUs] is when this read's first byte was captured; [peak] its loudest sample. The
+     * buffer handed to [emit] is reused, so a caller that keeps it has to copy.
+     */
+    fun offer(
+        src: ByteArray,
+        srcLen: Int,
+        capturedAtUs: Long,
+        peak: Int,
+        emit: (chunk: ByteArray, length: Int, timestampUs: Long, peak: Int) -> Unit
+    ) {
+        var i = 0
+        while (i < srcLen) {
+            if (pending == 0) {
+                chunkStartedUs = capturedAtUs + bytesToMicros(i)
+                chunkPeak = 0
+            }
+
+            val take = minOf(chunkBytes - pending, srcLen - i)
+            System.arraycopy(src, i, chunk, pending, take)
+            pending += take
+            i += take
+            if (peak > chunkPeak) chunkPeak = peak
+
+            if (pending == chunkBytes) {
+                emit(chunk, chunkBytes, chunkStartedUs, chunkPeak)
+                pending = 0
+            }
+        }
+    }
+
+    /**
+     * Drop the partial chunk and return how many bytes went with it, so the cost is reported rather
+     * than assumed. At most one chunk, after the user has stopped speaking.
+     */
+    fun reset(): Int {
+        val discarded = pending
+        pending = 0
+        chunkStartedUs = 0L
+        chunkPeak = 0
+        return discarded
+    }
+
+    private fun bytesToMicros(bytes: Int): Long =
+        bytes.toLong() * 1_000_000L / MicCaptureFormat.BYTES_PER_SECOND
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/MicPcmDecimator.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/MicPcmDecimator.kt
@@ -1,0 +1,55 @@
+package com.andrerinas.openheadunit.decoder.audio
+
+/**
+ * Whole-group averaging from a multiple of 16 kHz down to 16 kHz, on mono 16-bit little-endian PCM.
+ *
+ * Only reached when the device refuses to open 16 kHz. Averaging rather than picking every Nth
+ * sample because dropping samples folds everything above 8 kHz back into the band speech
+ * recognition listens to; an N-sample mean is a crude low-pass that costs one add per sample.
+ *
+ * Stateful on purpose: a read is not a whole number of groups, so the tail of one read has to be
+ * carried into the next or the stream loses a sample at every boundary.
+ */
+class MicPcmDecimator(private val factor: Int) {
+
+    init {
+        require(factor >= 1) { "factor must be at least 1, was $factor" }
+    }
+
+    private var pendingSum = 0
+    private var pendingCount = 0
+
+    /** Upper bound on the bytes [decimate] can produce from [inputBytes], for sizing a buffer. */
+    fun outputCapacity(inputBytes: Int): Int = (inputBytes / 2 + pendingCount) / factor * 2 + 2
+
+    /**
+     * Reads [srcLen] bytes from [src] and writes the converted samples to [dst], returning how many
+     * bytes it wrote. An odd trailing byte is ignored: it is half a sample and the next read starts
+     * a new one.
+     */
+    fun decimate(src: ByteArray, srcLen: Int, dst: ByteArray): Int {
+        var out = 0
+        var i = 0
+        while (i + 1 < srcLen) {
+            val sample = ((src[i + 1].toInt() shl 8) or (src[i].toInt() and 0xFF)).toShort().toInt()
+            pendingSum += sample
+            pendingCount++
+            if (pendingCount == factor) {
+                val averaged = pendingSum / factor
+                dst[out] = (averaged and 0xFF).toByte()
+                dst[out + 1] = ((averaged shr 8) and 0xFF).toByte()
+                out += 2
+                pendingSum = 0
+                pendingCount = 0
+            }
+            i += 2
+        }
+        return out
+    }
+
+    /** Drop the partial group. Called when capture stops, so the next session starts aligned. */
+    fun reset() {
+        pendingSum = 0
+        pendingCount = 0
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/MicRecorder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/MicRecorder.kt
@@ -128,6 +128,31 @@ class MicRecorder(private val context: Context) {
 
         /** AudioRecord would not initialise or start. */
         const val ERROR_RECORDER_FAILED = -5
+
+        /** The foreground service could not claim the microphone type, so capture must not open. */
+        const val ERROR_NO_FOREGROUND_TYPE = -6
+
+        /**
+         * How capture asks for the microphone foreground-service type, which Android 14 will not
+         * grant at service start.
+         *
+         * Held here rather than passed in because the service is a singleton and a [MicRecorder]
+         * is not: transports come and go within one service. Null outside a running service, where
+         * there is nothing to claim and capture proceeds as it always did.
+         */
+        @Volatile
+        @JvmStatic
+        var foregroundClaim: ForegroundMicrophoneClaim? = null
+    }
+
+    /** Implemented by the foreground service, which is the only thing that can call startForeground. */
+    interface ForegroundMicrophoneClaim {
+
+        /** Adds the microphone type. False means it was refused and capture must not open. */
+        fun claim(): Boolean
+
+        /** Drops it again, so it is held only while capture is running. */
+        fun release()
     }
 
     interface Listener {
@@ -174,6 +199,8 @@ class MicRecorder(private val context: Context) {
             cleanupSco()
         }
         holdsCommunicationMode = false
+
+        foregroundClaim?.release()
     }
 
     /**
@@ -305,6 +332,12 @@ class MicRecorder(private val context: Context) {
             }
             return ERROR_NO_PERMISSION
         }
+
+        // Android 14 refuses the microphone foreground-service type to a service started in the
+        // background, so it is claimed here instead, where the projection is on screen. Declining
+        // the phone's request is the right answer to a refusal; capturing without the type is not.
+        val claim = foregroundClaim
+        if (claim != null && !claim.claim()) return ERROR_NO_FOREGROUND_TYPE
 
         val configuredSource = getAudioSource(settings.micInputSource)
 

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/MicRecorder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/MicRecorder.kt
@@ -14,6 +14,8 @@ import android.media.audiofx.AcousticEchoCanceler
 import android.media.audiofx.AutomaticGainControl
 import android.media.audiofx.NoiseSuppressor
 import android.os.Build
+import android.os.Process
+import android.os.SystemClock
 import androidx.core.content.ContextCompat
 import androidx.core.content.PermissionChecker
 import com.andrerinas.openheadunit.utils.AppLog
@@ -48,9 +50,20 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
         }
     }
 
-    private var threadMicAudioActive = false
+    // Volatile: written from stop() on another thread and spun on by the capture loop, which now
+    // runs at urgent audio priority.
+    @Volatile private var threadMicAudioActive = false
     private var threadMicAudio: Thread? = null
     var listener: Listener? = null
+
+    // What the capture produced, summarised on stop(). A microphone delivering pure silence used
+    // to log exactly like a working one: read() returns a full buffer either way and no error path
+    // fires, so an assistant that could not hear the user left nothing to read.
+    @Volatile private var captureSource = -1
+    @Volatile private var captureStartedMs = 0L
+    @Volatile private var captureBytes = 0L
+    @Volatile private var captureEmptyReads = 0
+    @Volatile private var capturePeak = 0
 
     // Tracks whether this instance started Bluetooth SCO so we can clean it up
     private var bluetoothScoStarted = false
@@ -77,10 +90,13 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
 
     fun stop() {
         AppLog.i("MicRecorder: Stopping. Active: $threadMicAudioActive")
-        
+
         threadMicAudioActive = false
         threadMicAudio?.interrupt()
         threadMicAudio = null
+
+        // After the thread is told to stop, so the counters are the whole capture.
+        if (captureStartedMs != 0L) logCaptureSummary()
 
         audioRecord?.apply {
             try {
@@ -107,6 +123,25 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
             cleanupSco()
         }
         holdsCommunicationMode = false
+    }
+
+    /**
+     * One line saying what the capture produced, so a failing assistant session reads differently
+     * from a working one.
+     *
+     * `peak=0` over a real run means the input is routed nowhere and [Settings.micInputSource] is
+     * the next thing to change. Bytes far below the expected rate mean starved reads instead.
+     */
+    private fun logCaptureSummary() {
+        val elapsedMs = SystemClock.elapsedRealtime() - captureStartedMs
+        val expectedBytes = micSampleRate.toLong() * 2L * elapsedMs / 1000L
+        val percentOfExpected = if (expectedBytes > 0) captureBytes * 100L / expectedBytes else -1L
+        AppLog.i(
+            "MicRecorder: capture summary | source=${getAudioSourceName(captureSource)} ($captureSource) " +
+                "rate=$micSampleRate elapsed=${elapsedMs}ms bytes=$captureBytes " +
+                "($percentOfExpected% of expected) emptyReads=$captureEmptyReads peak=$capturePeak/32767"
+        )
+        captureStartedMs = 0L
     }
 
     private fun cleanupSco() {
@@ -144,14 +179,37 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
         
         val len = currentAudioRecord.read(aud_buf, 0, max_len)
         if (len <= 0) {
+            captureEmptyReads++
             if (len == AudioRecord.ERROR_INVALID_OPERATION && threadMicAudioActive) {
                 AppLog.e("MicRecorder: Unexpected interruption error: $len")
             }
             return len
         }
 
+        captureBytes += len
+        capturePeak = maxOf(capturePeak, peakAmplitude(aud_buf, len))
+
         currentListener.onMicDataAvailable(aud_buf, len)
         return len
+    }
+
+    /**
+     * Loudest sample in this read, as a 16-bit magnitude.
+     *
+     * What separates a microphone routed nowhere from a working one: both deliver bytes at the
+     * expected rate, but a dead input delivers zeros. Scanned every fourth frame, since this runs
+     * on the capture thread and a peak survives that.
+     */
+    private fun peakAmplitude(buf: ByteArray, len: Int): Int {
+        var peak = 0
+        var i = 0
+        while (i + 1 < len) {
+            val sample = ((buf[i + 1].toInt() shl 8) or (buf[i].toInt() and 0xFF)).toShort().toInt()
+            val magnitude = if (sample == Short.MIN_VALUE.toInt()) Short.MAX_VALUE.toInt() else kotlin.math.abs(sample)
+            if (magnitude > peak) peak = magnitude
+            i += 8
+        }
+        return peak
     }
 
     private fun getAudioSource(index: Int): Int {
@@ -300,9 +358,18 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
             }
             
             audioRecord?.startRecording()
-            
+
+            captureSource = source
+            captureStartedMs = SystemClock.elapsedRealtime()
+            captureBytes = 0L
+            captureEmptyReads = 0
+            capturePeak = 0
+
             threadMicAudioActive = true
             threadMicAudio = Thread({
+                // The only audio thread still at default priority, where a blocking read() on a
+                // loaded head unit becomes a gap in what the phone hears.
+                Process.setThreadPriority(Process.THREAD_PRIORITY_URGENT_AUDIO)
                 while (threadMicAudioActive) {
                     micAudioRead(micAudioBuf, micBufferSize)
                 }

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/MicRecorder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/MicRecorder.kt
@@ -18,10 +18,11 @@ import android.os.Process
 import android.os.SystemClock
 import androidx.core.content.ContextCompat
 import androidx.core.content.PermissionChecker
+import com.andrerinas.openheadunit.aap.protocol.MicCaptureFormat
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.Settings
 
-class MicRecorder(private val micSampleRate: Int, private val context: Context) {
+class MicRecorder(private val context: Context) {
 
     private var audioRecord: AudioRecord? = null
     private var aec: AcousticEchoCanceler? = null
@@ -29,23 +30,59 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
     private var agc: AutomaticGainControl? = null
     private val settings = Settings(context)
 
+    /**
+     * What the hardware is opened at. Normally [MicCaptureFormat.SAMPLE_RATE_HZ], which is also the
+     * only rate the phone is ever told about; a device that refuses it captures higher and is
+     * decimated by [decimator] before anything leaves here.
+     */
+    private val captureRateHz: Int
     private val micBufferSize: Int
     private var micAudioBuf: ByteArray
+
+    /** Null when the capture is already at the announced rate. */
+    private val decimator: MicPcmDecimator?
+
+    /** Holds the converted samples, so the listener always sees 16 kHz mono. */
+    private val wireBuf: ByteArray
 
     // Indicates whether mic recording is available on this device
     val isAvailable: Boolean
 
     init {
-        val minSize = AudioRecord.getMinBufferSize(micSampleRate, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT)
-        if (minSize <= 0) {
-            // Device doesn't support the requested audio config (common on API 16)
-            AppLog.w("MicRecorder: getMinBufferSize returned $minSize, mic recording unavailable")
+        val decision = MicCaptureRatePolicy.decide(settings.micSampleRate) { rate ->
+            AudioRecord.getMinBufferSize(rate, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT)
+        }
+        if (decision == null) {
+            // Named in the user's terms because it is the one situation the rate setting exists for,
+            // and because no reporter log has ever shown it.
+            AppLog.w("MicRecorder: this device will not open ${MicCaptureFormat.SAMPLE_RATE_HZ} Hz " +
+                "mono capture, which is the only rate Android Auto accepts, and no whole multiple " +
+                "of it either. The microphone is unavailable")
+            captureRateHz = MicCaptureFormat.SAMPLE_RATE_HZ
             micBufferSize = 0
             micAudioBuf = ByteArray(0)
+            wireBuf = ByteArray(0)
+            decimator = null
             isAvailable = false
         } else {
-            micBufferSize = minSize
-            micAudioBuf = ByteArray(minSize)
+            captureRateHz = decision.captureRateHz
+            // Room for two whole messages, so assembling one never becomes the reason a read
+            // overruns. The minimum the device asks for is often less than half of that.
+            val twoChunks = 2 * MicCaptureFormat.CHUNK_BYTES * decision.decimationFactor
+            micBufferSize = maxOf(decision.minBufferSize, twoChunks)
+            micAudioBuf = ByteArray(micBufferSize)
+            if (decision.isDirect) {
+                decimator = null
+                wireBuf = ByteArray(0)
+            } else {
+                AppLog.w("MicRecorder: ${MicCaptureFormat.SAMPLE_RATE_HZ} Hz capture is unavailable; " +
+                    "capturing at ${decision.captureRateHz} Hz and converting " +
+                    "${decision.decimationFactor}:1 so the phone still receives the rate it was " +
+                    "told about")
+                val converter = MicPcmDecimator(decision.decimationFactor)
+                decimator = converter
+                wireBuf = ByteArray(converter.outputCapacity(micBufferSize))
+            }
             isAvailable = true
         }
     }
@@ -82,10 +119,23 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
         @Volatile
         var holdsCommunicationMode = false
             private set
+
+        /** RECORD_AUDIO is missing, or a ROM has revoked its app-op. */
+        const val ERROR_NO_PERMISSION = -3
+
+        /** No usable capture configuration on this device. */
+        const val ERROR_UNAVAILABLE = -4
+
+        /** AudioRecord would not initialise or start. */
+        const val ERROR_RECORDER_FAILED = -5
     }
 
     interface Listener {
-        fun onMicDataAvailable(mic_buf: ByteArray, mic_audio_len: Int)
+        /**
+         * One read from the microphone. [peak] is this read's loudest sample, already measured
+         * here so the transport does not scan the same bytes a second time.
+         */
+        fun onMicDataAvailable(mic_buf: ByteArray, mic_audio_len: Int, peak: Int)
     }
 
     fun stop() {
@@ -94,6 +144,7 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
         threadMicAudioActive = false
         threadMicAudio?.interrupt()
         threadMicAudio = null
+        decimator?.reset()
 
         // After the thread is told to stop, so the counters are the whole capture.
         if (captureStartedMs != 0L) logCaptureSummary()
@@ -134,11 +185,11 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
      */
     private fun logCaptureSummary() {
         val elapsedMs = SystemClock.elapsedRealtime() - captureStartedMs
-        val expectedBytes = micSampleRate.toLong() * 2L * elapsedMs / 1000L
+        val expectedBytes = captureRateHz.toLong() * 2L * elapsedMs / 1000L
         val percentOfExpected = if (expectedBytes > 0) captureBytes * 100L / expectedBytes else -1L
         AppLog.i(
             "MicRecorder: capture summary | source=${getAudioSourceName(captureSource)} ($captureSource) " +
-                "rate=$micSampleRate elapsed=${elapsedMs}ms bytes=$captureBytes " +
+                "rate=$captureRateHz elapsed=${elapsedMs}ms bytes=$captureBytes " +
                 "($percentOfExpected% of expected) emptyReads=$captureEmptyReads peak=$capturePeak/32767"
         )
         captureStartedMs = 0L
@@ -187,9 +238,21 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
         }
 
         captureBytes += len
-        capturePeak = maxOf(capturePeak, peakAmplitude(aud_buf, len))
 
-        currentListener.onMicDataAvailable(aud_buf, len)
+        val converter = decimator
+        if (converter == null) {
+            val peak = peakAmplitude(aud_buf, len)
+            capturePeak = maxOf(capturePeak, peak)
+            currentListener.onMicDataAvailable(aud_buf, len, peak)
+            return len
+        }
+
+        val wireLen = converter.decimate(aud_buf, len, wireBuf)
+        if (wireLen <= 0) return len
+        // Measured on what the phone will hear, not on what the hardware produced.
+        val peak = peakAmplitude(wireBuf, wireLen)
+        capturePeak = maxOf(capturePeak, peak)
+        currentListener.onMicDataAvailable(wireBuf, wireLen, peak)
         return len
     }
 
@@ -226,26 +289,33 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
     fun start(): Int {
         if (!isAvailable) {
             AppLog.w("MicRecorder: Cannot start, mic not available on this device")
-            return -4
+            return ERROR_UNAVAILABLE
         }
-        
-        if (PermissionChecker.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) != PermissionChecker.PERMISSION_GRANTED) {
-            AppLog.e("MicRecorder: No RECORD_AUDIO permission")
-            return -3
+
+        // Which of the two failed matters: a denied permission is fixable in this app's settings,
+        // a revoked app-op is not and lives in the ROM's own privacy screen. One reporter chased a
+        // granted permission for weeks because this line named only the first.
+        val permission = PermissionChecker.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO)
+        if (permission != PermissionChecker.PERMISSION_GRANTED) {
+            if (permission == PermissionChecker.PERMISSION_DENIED_APP_OP) {
+                AppLog.e("MicRecorder: RECORD_AUDIO is granted but this ROM has revoked the " +
+                    "microphone app-op; it has to be re-enabled in the system's own privacy settings")
+            } else {
+                AppLog.e("MicRecorder: No RECORD_AUDIO permission")
+            }
+            return ERROR_NO_PERMISSION
         }
 
         val configuredSource = getAudioSource(settings.micInputSource)
-        
-        if (configuredSource == SOURCE_BLUETOOTH_SCO) {
+
+        return if (configuredSource == SOURCE_BLUETOOTH_SCO) {
             startScoAndRecord()
         } else {
             startRecording(configuredSource)
         }
-        
-        return 0
     }
 
-    private fun startScoAndRecord() {
+    private fun startScoAndRecord(): Int {
         val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
         
         // Check for BLUETOOTH_CONNECT permission on Android 12+ (API 31+)
@@ -277,8 +347,9 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
                 AppLog.w("MicRecorder: No Bluetooth SCO/BLE headset found in available communication devices.")
             }
             // On API 31+, we can start recording directly on the communication channel
-            startRecording(MediaRecorder.AudioSource.VOICE_COMMUNICATION)
+            val result = startRecording(MediaRecorder.AudioSource.VOICE_COMMUNICATION)
             bluetoothScoStarted = true
+            return result
         } else {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !hasBluetoothPermission) {
                 AppLog.w("MicRecorder: Missing BLUETOOTH_CONNECT permission on API 31+. Falling back to legacy SCO.")
@@ -310,20 +381,24 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
             @Suppress("DEPRECATION")
             audioManager.isBluetoothScoOn = true
             bluetoothScoStarted = true
+            // Capture starts inside the receiver once SCO connects, so all this path can report is
+            // that the link was asked for.
+            return 0
         }
     }
 
-    private fun startRecording(source: Int) {
+    /** Returns 0 once capture is running, or [ERROR_RECORDER_FAILED] if it never started. */
+    private fun startRecording(source: Int): Int {
         try {
-            if (audioRecord != null) return // Already recording
+            if (audioRecord != null) return 0 // Already recording
             
-            AppLog.i("MicRecorder: Initializing AudioRecord with source: ${getAudioSourceName(source)} ($source), SampleRate: $micSampleRate, BufferSize: $micBufferSize")
-            audioRecord = AudioRecord(source, micSampleRate, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT, micBufferSize)
+            AppLog.i("MicRecorder: Initializing AudioRecord with source: ${getAudioSourceName(source)} ($source), SampleRate: $captureRateHz, BufferSize: $micBufferSize")
+            audioRecord = AudioRecord(source, captureRateHz, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT, micBufferSize)
             
             if (audioRecord?.state != AudioRecord.STATE_INITIALIZED) {
                 AppLog.e("MicRecorder: Failed to initialize AudioRecord")
                 audioRecord = null
-                return
+                return ERROR_RECORDER_FAILED
             }
             
             val audioSessionId = audioRecord?.audioSessionId ?: 0
@@ -374,10 +449,12 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
                     micAudioRead(micAudioBuf, micBufferSize)
                 }
             }, "mic_audio").apply { start() }
-            
+
+            return 0
         } catch (e: Exception) {
             AppLog.e("MicRecorder: Error during startRecording", e)
             audioRecord = null
+            return ERROR_RECORDER_FAILED
         }
     }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/MicrophonePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/MicrophonePolicy.kt
@@ -1,0 +1,40 @@
+package com.andrerinas.openheadunit.decoder.audio
+
+/**
+ * Whether this head unit records when the phone asks, and what to say when it will not.
+ *
+ * The announcement is not part of the decision, deliberately. Android Auto's required-service check
+ * refuses a head unit that declares no microphone service - its own list reads "No audio/mic" and
+ * the teardown reason is a missing microphone - so the service is announced unconditionally and the
+ * only thing a user or a broken device can change is whether any PCM follows it.
+ *
+ * The two motorcycle requests get half of what they asked for. The physical microphone stays free
+ * for a Bluetooth helmet intercom, but the phone does not take over: Android Auto picks its recorder
+ * once at session start, and picks its own only for a head unit that declared itself a motorcycle,
+ * which needs a vehicle type nothing here sends. Declining therefore leaves the assistant deaf.
+ *
+ * Pure: no Android, no logging.
+ */
+object MicrophonePolicy {
+
+    /** Why a microphone request will not be honoured, or [Decline.NONE] if it will. */
+    fun declineReason(headUnitMicEnabled: Boolean, recorderAvailable: Boolean): Decline = when {
+        !headUnitMicEnabled -> Decline.USER_SETTING
+        !recorderAvailable -> Decline.NO_MICROPHONE
+        else -> Decline.NONE
+    }
+
+    fun shouldCapture(headUnitMicEnabled: Boolean, recorderAvailable: Boolean): Boolean =
+        declineReason(headUnitMicEnabled, recorderAvailable) == Decline.NONE
+
+    enum class Decline {
+        /** Capture normally. */
+        NONE,
+
+        /** The user handed the microphone to the phone. Not a fault, and the log has to say so. */
+        USER_SETTING,
+
+        /** No usable capture configuration on this device. */
+        NO_MICROPHONE
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/MicrophonePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/audio/MicrophonePolicy.kt
@@ -3,15 +3,14 @@ package com.andrerinas.openheadunit.decoder.audio
 /**
  * Whether this head unit records when the phone asks, and what to say when it will not.
  *
- * The announcement is not part of the decision, deliberately. Android Auto's required-service check
- * refuses a head unit that declares no microphone service - its own list reads "No audio/mic" and
- * the teardown reason is a missing microphone - so the service is announced unconditionally and the
- * only thing a user or a broken device can change is whether any PCM follows it.
+ * The announcement follows the same setting, so a phone that is never offered a microphone service
+ * does not ask. This decides what to say when one asks anyway, which a phone still can.
  *
- * The two motorcycle requests get half of what they asked for. The physical microphone stays free
- * for a Bluetooth helmet intercom, but the phone does not take over: Android Auto picks its recorder
- * once at session start, and picks its own only for a head unit that declared itself a motorcycle,
- * which needs a vehicle type nothing here sends. Declining therefore leaves the assistant deaf.
+ * Declining on its own leaves the assistant deaf, and that is the whole reason the setting drives
+ * the announcement and the vehicle type too: the phone chooses its recorder once at session start,
+ * and takes its own only for a motorcycle that offers it no microphone. Those two go together, and
+ * on the newer of the phone's two car services withholding the service under any other type also
+ * ends connection setup.
  *
  * Pure: no Android, no logging.
  */

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/video/VideoFeedThrottlePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/video/VideoFeedThrottlePolicy.kt
@@ -20,6 +20,12 @@ package com.andrerinas.openheadunit.decoder.video
  *
  * The wait is bounded because a codec can also be wedged rather than slow. Past [WAIT_BUDGET_MS]
  * the frame is shed exactly as before, and the wedge belongs to the sync_stall watchdog.
+ *
+ * **The paced thread carries audio too.** One read thread serves the session, and this budget is the
+ * same order as the audio sink's own depth, so a codec at its ceiling can push audio into the drop
+ * path in [AudioTrackWrapper.write] rather than merely delaying it. Unmeasured, because the units
+ * that stutter are link-starved and never take the wait. Raising this budget spends audio headroom
+ * as well as video latency.
  */
 object VideoFeedThrottlePolicy {
 

--- a/app/src/main/java/com/andrerinas/openheadunit/main/MicSettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/MicSettingsFragment.kt
@@ -155,8 +155,10 @@ class MicSettingsFragment : Fragment() {
         val items = mutableListOf<SettingItem>()
 
         items.add(SettingItem.CategoryHeader("micSettings", R.string.microphone_settings))
+        items.add(SettingItem.InfoBanner("micWireFormat", R.string.mic_wire_format_info))
 
-        // Mic Sample Rate
+        // Mic capture rate. A compatibility control, not a quality one: reporters raised it hoping
+        // for better audio and got a stream the phone could not understand.
         items.add(SettingItem.SettingEntry(
             stableId = "micSampleRate",
             nameResId = R.string.mic_sample_rate,

--- a/app/src/main/java/com/andrerinas/openheadunit/main/MicSettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/MicSettingsFragment.kt
@@ -33,6 +33,7 @@ class MicSettingsFragment : Fragment() {
     private var saveButton: MaterialButton? = null
 
     // Pending states
+    private var pendingUseHeadUnitMicrophone: Boolean? = null
     private var pendingMicSampleRate: Int? = null
     private var pendingMicInputSource: Int? = null
     private var pendingMicEchoCanceler: Boolean? = null
@@ -53,6 +54,7 @@ class MicSettingsFragment : Fragment() {
         settings = App.provide(requireContext()).settings
 
         // Initialize pending state
+        pendingUseHeadUnitMicrophone = settings.useHeadUnitMicrophone
         pendingMicSampleRate = settings.micSampleRate
         pendingMicInputSource = settings.micInputSource
         pendingMicEchoCanceler = settings.micEchoCanceler
@@ -114,6 +116,7 @@ class MicSettingsFragment : Fragment() {
     }
 
     private fun saveSettings() {
+        pendingUseHeadUnitMicrophone?.let { settings.useHeadUnitMicrophone = it }
         pendingMicSampleRate?.let { settings.micSampleRate = it }
         pendingMicInputSource?.let { settings.micInputSource = it }
         pendingMicEchoCanceler?.let { settings.micEchoCanceler = it }
@@ -137,7 +140,8 @@ class MicSettingsFragment : Fragment() {
     }
 
     private fun checkChanges() {
-        val anyChange = pendingMicSampleRate != settings.micSampleRate ||
+        val anyChange = pendingUseHeadUnitMicrophone != settings.useHeadUnitMicrophone ||
+                pendingMicSampleRate != settings.micSampleRate ||
                 pendingMicInputSource != settings.micInputSource ||
                 pendingMicEchoCanceler != settings.micEchoCanceler ||
                 pendingMicNoiseSuppressor != settings.micNoiseSuppressor ||
@@ -155,6 +159,33 @@ class MicSettingsFragment : Fragment() {
         val items = mutableListOf<SettingItem>()
 
         items.add(SettingItem.CategoryHeader("micSettings", R.string.microphone_settings))
+
+        val micEnabled = pendingUseHeadUnitMicrophone != false
+        items.add(SettingItem.ToggleSettingEntry(
+            stableId = "useHeadUnitMicrophone",
+            nameResId = R.string.use_head_unit_microphone,
+            descriptionResId = R.string.use_head_unit_microphone_description,
+            isChecked = micEnabled,
+            onCheckedChanged = { isChecked ->
+                pendingUseHeadUnitMicrophone = isChecked
+                checkChanges()
+                updateSettingsList()
+            }
+        ))
+
+        if (micEnabled) {
+            addMicDetailRows(items)
+        } else {
+            items.add(SettingItem.InfoBanner("micOff", R.string.head_unit_microphone_off_info))
+        }
+
+        settingsAdapter.submitList(items) {
+            scrollState?.let { recyclerView.layoutManager?.onRestoreInstanceState(it) }
+        }
+    }
+
+    /** Everything that only means something while this head unit is the one recording. */
+    private fun addMicDetailRows(items: MutableList<SettingItem>) {
         items.add(SettingItem.InfoBanner("micWireFormat", R.string.mic_wire_format_info))
 
         // Mic capture rate. A compatibility control, not a quality one: reporters raised it hoping
@@ -235,8 +266,5 @@ class MicSettingsFragment : Fragment() {
             }
         ))
 
-        settingsAdapter.submitList(items) {
-            scrollState?.let { recyclerView.layoutManager?.onRestoreInstanceState(it) }
-        }
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -1939,7 +1939,7 @@ class SettingsFragment : Fragment() {
             stableId = "micSettings",
             nameResId = R.string.microphone_settings,
             value = getString(R.string.microphone_settings_description),
-            searchKeywords = kw(R.string.mic_sample_rate),
+            searchKeywords = kw(R.string.mic_sample_rate, R.string.use_head_unit_microphone),
             onClick = { _ ->
                 findNavController().navigate(R.id.action_settingsFragment_to_micSettingsFragment)
             }

--- a/app/src/main/java/com/andrerinas/openheadunit/main/VehicleInfoFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/VehicleInfoFragment.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.R
+import com.andrerinas.openheadunit.aap.VehicleTypePolicy
 import com.andrerinas.openheadunit.main.settings.SettingItem
 import com.andrerinas.openheadunit.main.settings.SettingsAdapter
 import com.andrerinas.openheadunit.utils.Settings
@@ -32,6 +33,7 @@ class VehicleInfoFragment : Fragment() {
     private var pendingVehicleModel: String? = null
     private var pendingVehicleYear: String? = null
     private var pendingVehicleId: String? = null
+    private var pendingVehicleType: Int? = null
     private var pendingRightHandDrive: Boolean? = null
     private var pendingHeadUnitMake: String? = null
     private var pendingHeadUnitModel: String? = null
@@ -53,6 +55,7 @@ class VehicleInfoFragment : Fragment() {
         pendingVehicleModel = settings.vehicleModel
         pendingVehicleYear = settings.vehicleYear
         pendingVehicleId = settings.vehicleId
+        pendingVehicleType = settings.vehicleType
         pendingRightHandDrive = settings.rightHandDrive
         pendingHeadUnitMake = settings.headUnitMake
         pendingHeadUnitModel = settings.headUnitModel
@@ -127,6 +130,7 @@ class VehicleInfoFragment : Fragment() {
         pendingVehicleModel?.let { settings.vehicleModel = it }
         pendingVehicleYear?.let { settings.vehicleYear = it }
         pendingVehicleId?.let { settings.vehicleId = it }
+        pendingVehicleType?.let { settings.vehicleType = it }
         pendingRightHandDrive?.let { settings.rightHandDrive = it }
         pendingHeadUnitMake?.let { settings.headUnitMake = it }
         pendingHeadUnitModel?.let { settings.headUnitModel = it }
@@ -143,6 +147,7 @@ class VehicleInfoFragment : Fragment() {
                 pendingVehicleModel != settings.vehicleModel ||
                 pendingVehicleYear != settings.vehicleYear ||
                 pendingVehicleId != settings.vehicleId ||
+                pendingVehicleType != settings.vehicleType ||
                 pendingRightHandDrive != settings.rightHandDrive ||
                 pendingHeadUnitMake != settings.headUnitMake ||
                 pendingHeadUnitModel != settings.headUnitModel
@@ -233,6 +238,32 @@ class VehicleInfoFragment : Fragment() {
                 }
             }
         ))
+
+        val vehicleTypeOptions = listOf(
+            getString(R.string.vehicle_type_car),
+            getString(R.string.vehicle_type_truck),
+            getString(R.string.vehicle_type_motorcycle)
+        )
+
+        items.add(SettingItem.SegmentedButtonSettingEntry(
+            stableId = "vehicleType",
+            nameResId = R.string.vehicle_type_label,
+            options = vehicleTypeOptions,
+            selectedIndex = VehicleTypePolicy.indexOf(pendingVehicleType ?: VehicleTypePolicy.CAR),
+            onOptionSelected = { index ->
+                pendingVehicleType = VehicleTypePolicy.atIndex(index)
+                checkChanges()
+            }
+        ))
+
+        // The microphone setting overrides this, so say so rather than showing a choice that is
+        // not what goes on the wire.
+        if (!settings.useHeadUnitMicrophone) {
+            items.add(SettingItem.InfoBanner(
+                stableId = "vehicleTypeForcedByMicrophone",
+                textResId = R.string.vehicle_type_forced_by_microphone
+            ))
+        }
 
         items.add(SettingItem.ToggleSettingEntry(
             stableId = "rightHandDrive",

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothAddressSeedPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothAddressSeedPolicy.kt
@@ -1,0 +1,23 @@
+package com.andrerinas.openheadunit.utils
+
+/**
+ * What to show in the Bluetooth address field before the user has typed anything.
+ *
+ * The address is how the phone is told where to connect hands-free, and Android Auto disables
+ * telephony until that link is up - so a blank field is why "calls stay on the phone" on a head
+ * unit that has a perfectly good Bluetooth car kit. BluetoothHelper has resolved the real address
+ * for years and only ever used it to build description strings.
+ *
+ * Never overwrites what the user typed: a hand-entered address is usually there because the
+ * detected one was wrong.
+ *
+ * Pure: no Android.
+ */
+object BluetoothAddressSeedPolicy {
+
+    fun seed(stored: String?, detected: String?): String {
+        val kept = stored?.trim().orEmpty()
+        if (kept.isNotEmpty()) return kept
+        return detected?.trim().orEmpty()
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -11,6 +11,7 @@ import com.andrerinas.openheadunit.input.MediaKeyRoutingPolicy
 import com.andrerinas.openheadunit.decoder.video.VideoFaultInjector
 import com.andrerinas.openheadunit.decoder.video.DeviceMemoryProfile
 import com.andrerinas.openheadunit.decoder.audio.PlaybackFocusPolicy
+import com.andrerinas.openheadunit.aap.VehicleTypePolicy
 import com.andrerinas.openheadunit.aap.protocol.proto.Control
 import com.andrerinas.openheadunit.app.UsbAttachedActivity
 import com.andrerinas.openheadunit.connection.usb.UsbDeviceCompat
@@ -555,6 +556,10 @@ class Settings(private val context: Context) {
     var vehicleId: String
         get() = prefs.getString("vehicle-id", "headlessunit-001")!!
         set(value) { prefs.edit().putString("vehicle-id", value).apply() }
+
+    var vehicleType: Int
+        get() = VehicleTypePolicy.sanitised(prefs.getInt("vehicle-type", VehicleTypePolicy.CAR))
+        set(value) { prefs.edit().putInt("vehicle-type", value).apply() }
 
     var headUnitMake: String
         get() = prefs.getString("head-unit-make", "Google")!!

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -704,6 +704,19 @@ class Settings(private val context: Context) {
         lastConnectionUsbDevice = ""
     }
 
+    /**
+     * Whether the head unit records at all. Off leaves the microphone to the phone.
+     *
+     * Off does not omit the microphone service: Android Auto's required-service check refuses a
+     * head unit that does not declare one. It declares it, declines every request, and sends
+     * nothing, which is what frees the physical microphone for a Bluetooth headset or intercom.
+     */
+    var useHeadUnitMicrophone: Boolean
+        get() = prefs.getBoolean("use-head-unit-microphone", true)
+        set(value) {
+            prefs.edit().putBoolean("use-head-unit-microphone", value).apply()
+        }
+
     var enableAudioSink: Boolean
         get() = prefs.getBoolean("enable-audio-sink", true)
         set(value) { prefs.edit().putBoolean("enable-audio-sink", value).apply() }

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -106,8 +106,20 @@ class Settings(private val context: Context) {
         get() = prefs.getInt("ui-scale-settings-percent", 100)
         set(value) { prefs.edit().putInt("ui-scale-settings-percent", value).apply() }
 
+    /**
+     * The rate the microphone hardware is opened at when 16 kHz cannot be opened. Not what the phone
+     * receives: that is always 16 kHz mono, because Android Auto validates the announced config and
+     * rejects anything outside {16000, 48000} Hz.
+     *
+     * The list used to run 8000 to 48000 and the announcement was hardcoded at 16000, so every other
+     * choice sent the phone PCM at a rate it had never been told about. A stored value from then is
+     * migrated here rather than in a one-shot, since only the two remaining rates convert cleanly.
+     */
     var micSampleRate: Int
-        get() = prefs.getInt("mic-sample-rate", 16000)
+        get() {
+            val stored = prefs.getInt("mic-sample-rate", MicSampleRates.first())
+            return if (stored in MicSampleRates) stored else MicSampleRates.first()
+        }
         set(sampleRate) {
             prefs.edit().putInt("mic-sample-rate", sampleRate).apply()
         }
@@ -1470,7 +1482,11 @@ class Settings(private val context: Context) {
             }
         }
 
-        val MicSampleRates = listOf(8000, 16000, 24000, 32000, 44100, 48000) // Changed to List
+        /**
+         * The two rates Android Auto accepts. 48000 is the fallback because it is a whole multiple
+         * of 16000, so converting it needs no filter; 44100 and the rest were never usable.
+         */
+        val MicSampleRates = listOf(16000, 48000)
 
         fun getNextMicSampleRate(currentRate: Int): Int {
             val currentIndex = MicSampleRates.indexOf(currentRate)

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
@@ -92,6 +92,7 @@ object SettingsBackupManager {
         "vehicle-model" to ValueType.STRING,
         "vehicle-year" to ValueType.STRING,
         "vehicle-id" to ValueType.STRING,
+        "vehicle-type" to ValueType.INT,
         "head-unit-make" to ValueType.STRING,
         "head-unit-model" to ValueType.STRING,
         "wifi-connection-mode" to ValueType.INT,

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
@@ -108,6 +108,7 @@ object SettingsBackupManager {
         // ALWAYS for anything out of range.
         "media-key-routing" to ValueType.INT,
         "separate-audio-streams" to ValueType.BOOLEAN,
+        "use-head-unit-microphone" to ValueType.BOOLEAN,
         "mic-input-source" to ValueType.INT,
         "audio-latency-multiplier" to ValueType.INT,
         "audio-queue-capacity" to ValueType.INT,
@@ -192,6 +193,7 @@ object SettingsBackupManager {
         "software-video-decoder",
         "enable-rotary",
         "enable-audio-sink",
+        "use-head-unit-microphone",
         "static-audio-focus",
         "playback-focus-mode",
         "separate-audio-streams",

--- a/app/src/main/proto/common.proto
+++ b/app/src/main/proto/common.proto
@@ -38,13 +38,24 @@ enum MessageStatus
     STATUS_OUT_OF_MEMORY = -255;
 }
 
+// Numbers taken from Android Auto's own copy of this message, which is the only reader.
+// The previous order put head_unit_make first, so every value arrived under the wrong name:
+// the phone keys its per-head-unit records on make/model/year/vehicle_id and matches vendor
+// workarounds against them.
 message HeadUnitInfo {
-    optional string head_unit_make = 1;
-    optional string head_unit_model = 2;
-    optional string make = 3;
-    optional string model = 4;
-    optional string year = 5;
-    optional string head_unit_software_build = 6;
-    optional string vehicle_id = 7;
+    optional string make = 1;
+    optional string model = 2;
+    optional string year = 3;
+    optional string vehicle_id = 4;
+    optional string head_unit_make = 5;
+    optional string head_unit_model = 6;
+    optional string head_unit_software_build = 7;
     optional string head_unit_software_version = 8;
+    // Android Auto's vehicle type: 0 unspecified, 1 car, 2 truck, 3 motorcycle. An unset field
+    // reads as a car, measured, and the phone's own fallback can only ever guess car or truck from
+    // the model string, so this field is the only way to claim a motorcycle. Only a motorcycle
+    // makes the phone record with its own microphone. The phone stamps the type it has stored for
+    // this head unit over whatever arrives here, so see VehicleIdentityPolicy for how a changed
+    // type gets through.
+    optional int32 vehicle_type = 9;
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -449,6 +449,11 @@
     <string name="vehicle_year_label">السنة</string>
     <string name="vehicle_year_description">سنة المركبة</string>
     <string name="vehicle_id_label">معرف المركبة</string>
+    <string name="vehicle_type_label">نوع المركبة</string>
+    <string name="vehicle_type_car">سيارة</string>
+    <string name="vehicle_type_truck">شاحنة</string>
+    <string name="vehicle_type_motorcycle">دراجة نارية</string>
+    <string name="vehicle_type_forced_by_microphone">ميكروفون الوحدة الرئيسية معطّل، لذا يتم إبلاغ Android Auto بأن هذه دراجة نارية مهما كان الاختيار هنا. وهذا ما يجعل الهاتف يسجّل بنفسه.</string>
     <string name="vehicle_id_description">معرف داخلي فقط. تغييره سيجعل هاتفك يكتشف هذا كمركبة مختلفة، مما يعيد تعيين تفضيلات Android Auto لهذه السيارة.</string>
     <string name="head_unit_make_label">الشركة المصنعة</string>
     <string name="head_unit_make_description">الشركة المصنعة لوحدة الوسائط</string>
@@ -533,7 +538,11 @@
     <string name="loading_screen_tap_fullscreen_hint">انقر على المعاينة لعرضها بملء الشاشة</string>
     <string name="loading_screen_loop_video">تكرار الرسوم المتحركة القصيرة</string>
     <string name="microphone_settings">إعدادات الميكروفون</string>
+    <string name="use_head_unit_microphone">ميكروفون الوحدة الرئيسية</string>
+    <string name="use_head_unit_microphone_description">مفعّل: يسمع Android Auto ميكروفون هذا الجهاز. معطّل: لا يسجّل هذا الجهاز أبدًا ويستخدم الهاتف ميكروفونه الخاص، أو سماعة أو جهاز اتصال داخلي مقترنًا بالهاتف، فيظل المساعد الصوتي يعمل. يتطلب Android 11 أو أحدث على الهاتف.</string>
+    <string name="head_unit_microphone_off_info">ميكروفون الوحدة الرئيسية معطّل، لذا لا ينطبق أي مما يلي. يتم إبلاغ Android Auto بأن هذا الجهاز لا يمكنه التسجيل وأنه دراجة نارية، وهذا ما يجعل الهاتف يسجّل بنفسه. في Android 10 والأقدم ينسى الهاتف ذلك بين الجلسات وقد يتوقف عن الاتصال.</string>
     <string name="microphone_settings_description">تكوين مدخل الميكروفون ومعالجة الصوت.</string>
+    <string name="mic_wire_format_info">يستقبل Android Auto الميكروفون دائمًا بمعدل 16000 هرتز، 16 بت، أحادي. ويرفض أي شيء آخر، لذا تغيّر هذه الإعدادات ما يفعله العتاد، لا ما يُرسل إلى الهاتف.</string>
     <string name="mic_echo_canceler">إلغاء الصدى (AEC)</string>
     <string name="mic_echo_canceler_description">يحاول إزالة الصدى من الميكروفون. قم بتعطيله إذا واجهت صمتاً أو تشويشاً.</string>
     <string name="mic_noise_suppressor">إخماد الضوضاء (NS)</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -449,6 +449,11 @@
     <string name="vehicle_year_label">Rok</string>
     <string name="vehicle_year_description">Rok výroby vozidla</string>
     <string name="vehicle_id_label">ID vozidla</string>
+    <string name="vehicle_type_label">Typ vozidla</string>
+    <string name="vehicle_type_car">Automobil</string>
+    <string name="vehicle_type_truck">Nákladní vůz</string>
+    <string name="vehicle_type_motorcycle">Motocykl</string>
+    <string name="vehicle_type_forced_by_microphone">Mikrofon hlavní jednotky je vypnutý, takže Android Auto dostane informaci, že jde o motocykl, ať se zde zvolí cokoli. Právě to donutí telefon nahrávat samostatně.</string>
     <string name="vehicle_id_description">Pouze interní identifikátor. Jeho změna způsobí, že váš telefon bude toto vozidlo považovat za jiné, čímž se resetují vaše předvolby Android Auto pro toto auto.</string>
     <string name="head_unit_make_label">Výrobce</string>
     <string name="head_unit_make_description">Výrobce autorádia</string>
@@ -533,7 +538,11 @@
     <string name="loading_screen_tap_fullscreen_hint">Klepněte na náhled pro zobrazení na celou obrazovku</string>
     <string name="loading_screen_loop_video">Opakovat krátké animace</string>
     <string name="microphone_settings">Nastavení mikrofonu</string>
+    <string name="use_head_unit_microphone">Mikrofon hlavní jednotky</string>
+    <string name="use_head_unit_microphone_description">Zapnuto: Android Auto slyší mikrofon tohoto zařízení. Vypnuto: toto zařízení nikdy nenahrává a telefon použije vlastní mikrofon, případně náhlavní soupravu nebo interkom spárovaný s telefonem, takže hlasový asistent dál funguje. Vyžaduje Android 11 nebo novější v telefonu.</string>
+    <string name="head_unit_microphone_off_info">Mikrofon hlavní jednotky je vypnutý, takže nic níže neplatí. Android Auto dostane informaci, že toto zařízení nemůže nahrávat a je motocykl, což je právě to, co donutí telefon nahrávat samostatně. V Androidu 10 a starším to telefon mezi relacemi zapomene a může se přestat připojovat.</string>
     <string name="microphone_settings_description">Konfigurace vstupu mikrofonu a zpracování zvuku.</string>
+    <string name="mic_wire_format_info">Android Auto vždy přijímá mikrofon na 16000 Hz, 16 bitů, mono. Cokoli jiného odmítne, takže tato nastavení mění chování hardwaru, nikoli to, co se odesílá do telefonu.</string>
     <string name="mic_echo_canceler">Potlačení ozvěny (AEC)</string>
     <string name="mic_echo_canceler_description">Pokusí se odstranit ozvěnu z mikrofonu. Vypněte, pokud zaznamenáte ticho nebo zkreslení.</string>
     <string name="mic_noise_suppressor">Potlačení šumu (NS)</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -304,7 +304,11 @@
     <string name="assistant_volume_offset">Assistenten-Lautstärke</string>
     <string name="navigation_volume_offset">Navigations-Lautstärke</string>
     <string name="microphone_settings">Mikrofon-Einstellungen</string>
+    <string name="use_head_unit_microphone">Mikrofon der Haupteinheit</string>
+    <string name="use_head_unit_microphone_description">Ein: Android Auto hört das Mikrofon dieses Geräts. Aus: dieses Gerät nimmt nie auf und das Telefon verwendet sein eigenes Mikrofon oder ein mit dem Telefon gekoppeltes Headset bzw. eine Gegensprechanlage, sodass der Sprachassistent weiter funktioniert. Erfordert Android 11 oder neuer auf dem Telefon.</string>
+    <string name="head_unit_microphone_off_info">Das Mikrofon der Haupteinheit ist aus, daher gilt nichts von dem, was darunter steht. Android Auto wird mitgeteilt, dass dieses Gerät nicht aufnehmen kann und ein Motorrad ist, und genau das bringt das Telefon dazu, selbst aufzunehmen. Unter Android 10 und älter vergisst das Telefon das zwischen den Sitzungen und stellt die Verbindung möglicherweise ein.</string>
     <string name="microphone_settings_description">Eingangsquelle und Audio-Verarbeitung konfigurieren.</string>
+    <string name="mic_wire_format_info">Android Auto empfängt das Mikrofon immer mit 16000 Hz, 16 Bit, Mono. Alles andere wird abgelehnt, daher ändern diese Einstellungen das Verhalten der Hardware, nicht das, was an das Telefon gesendet wird.</string>
     <string name="mic_input_source">Mikrofon-Eingangsquelle</string>
     <string name="mic_input_source_description">Wählen Sie die Audioquelle für das Mikrofon.</string>
     <string-array name="mic_input_sources">
@@ -487,6 +491,11 @@
     <string name="vehicle_year_label">Baujahr</string>
     <string name="vehicle_year_description">Baujahr des Fahrzeugs</string>
     <string name="vehicle_id_label">Fahrzeug-ID</string>
+    <string name="vehicle_type_label">Fahrzeugtyp</string>
+    <string name="vehicle_type_car">Auto</string>
+    <string name="vehicle_type_truck">Lkw</string>
+    <string name="vehicle_type_motorcycle">Motorrad</string>
+    <string name="vehicle_type_forced_by_microphone">Das Mikrofon der Haupteinheit ist aus, daher wird Android Auto unabhängig von der Auswahl hier mitgeteilt, dass dies ein Motorrad ist. Genau das bringt das Telefon dazu, selbst aufzunehmen.</string>
     <string name="vehicle_id_description">Nur interne Kennung. Eine Änderung bewirkt, dass Ihr Telefon dies als ein anderes Fahrzeug erkennt und Ihre Android Auto-Einstellungen für dieses Auto zurückgesetzt werden.</string>
     <string name="head_unit_make_label">Hersteller</string>
     <string name="head_unit_make_description">Hersteller des Autoradios</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -449,6 +449,11 @@
     <string name="vehicle_year_label">Año</string>
     <string name="vehicle_year_description">Año del vehículo</string>
     <string name="vehicle_id_label">ID del vehículo</string>
+    <string name="vehicle_type_label">Tipo de vehículo</string>
+    <string name="vehicle_type_car">Coche</string>
+    <string name="vehicle_type_truck">Camión</string>
+    <string name="vehicle_type_motorcycle">Motocicleta</string>
+    <string name="vehicle_type_forced_by_microphone">El micrófono de la unidad está desactivado, así que a Android Auto se le indica que esto es una motocicleta sea cual sea la opción elegida aquí. Eso es lo que hace que el teléfono grabe por sí mismo.</string>
     <string name="vehicle_id_description">Identificador interno únicamente. Cambiarlo hará que tu móvil detecte este como un vehículo diferente, reiniciando las preferencias de Android Auto para este coche.</string>
     <string name="head_unit_make_label">Fabricante</string>
     <string name="head_unit_make_description">Fabricante de la radio</string>
@@ -533,7 +538,11 @@
     <string name="loading_screen_tap_fullscreen_hint">Toca la vista previa para verla en pantalla completa</string>
     <string name="loading_screen_loop_video">Repetir animaciones cortas en bucle</string>
     <string name="microphone_settings">Ajustes del micrófono</string>
+    <string name="use_head_unit_microphone">Micrófono de la unidad</string>
+    <string name="use_head_unit_microphone_description">Activado: Android Auto oye el micrófono de este dispositivo. Desactivado: este dispositivo nunca graba y el teléfono usa su propio micrófono, o unos auriculares o intercomunicador emparejados con el teléfono, de modo que el asistente de voz sigue funcionando. Requiere Android 11 o posterior en el teléfono.</string>
+    <string name="head_unit_microphone_off_info">El micrófono de la unidad está desactivado, así que nada de lo siguiente se aplica. A Android Auto se le indica que este dispositivo no puede grabar y que es una motocicleta, que es lo que hace que el teléfono grabe por sí mismo. En Android 10 y anteriores el teléfono lo olvida entre sesiones y puede dejar de conectarse.</string>
     <string name="microphone_settings_description">Configura la entrada del micrófono y el procesamiento de audio.</string>
+    <string name="mic_wire_format_info">Android Auto siempre recibe el micrófono a 16000 Hz, 16 bits, mono. Rechaza cualquier otra cosa, así que estos ajustes cambian lo que hace el hardware, no lo que se envía al teléfono.</string>
     <string name="mic_echo_canceler">Cancelación de eco (AEC)</string>
     <string name="mic_echo_canceler_description">Intenta eliminar el eco del micrófono. Desactívalo si experimentas silencio o distorsión.</string>
     <string name="mic_noise_suppressor">Supresión de ruido (NS)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -449,6 +449,11 @@
     <string name="vehicle_year_label">Año</string>
     <string name="vehicle_year_description">Año del vehículo</string>
     <string name="vehicle_id_label">ID del vehículo</string>
+    <string name="vehicle_type_label">Tipo de vehículo</string>
+    <string name="vehicle_type_car">Coche</string>
+    <string name="vehicle_type_truck">Camión</string>
+    <string name="vehicle_type_motorcycle">Motocicleta</string>
+    <string name="vehicle_type_forced_by_microphone">El micrófono de la unidad está desactivado, así que a Android Auto se le indica que esto es una motocicleta sea cual sea la opción elegida aquí. Eso es lo que hace que el teléfono grabe por sí mismo.</string>
     <string name="vehicle_id_description">Identificador interno únicamente. Cambiarlo hará que tu teléfono detecte este como un vehículo diferente, reiniciando las preferencias de Android Auto para este auto.</string>
     <string name="head_unit_make_label">Fabricante</string>
     <string name="head_unit_make_description">Fabricante de la radio</string>
@@ -533,7 +538,11 @@
     <string name="loading_screen_tap_fullscreen_hint">Toca la vista previa para verla en pantalla completa</string>
     <string name="loading_screen_loop_video">Repetir animaciones cortas en bucle</string>
     <string name="microphone_settings">Ajustes del micrófono</string>
+    <string name="use_head_unit_microphone">Micrófono de la unidad</string>
+    <string name="use_head_unit_microphone_description">Activado: Android Auto oye el micrófono de este dispositivo. Desactivado: este dispositivo nunca graba y el teléfono usa su propio micrófono, o unos auriculares o intercomunicador emparejados con el teléfono, de modo que el asistente de voz sigue funcionando. Requiere Android 11 o posterior en el teléfono.</string>
+    <string name="head_unit_microphone_off_info">El micrófono de la unidad está desactivado, así que nada de lo siguiente se aplica. A Android Auto se le indica que este dispositivo no puede grabar y que es una motocicleta, que es lo que hace que el teléfono grabe por sí mismo. En Android 10 y anteriores el teléfono lo olvida entre sesiones y puede dejar de conectarse.</string>
     <string name="microphone_settings_description">Configura la entrada del micrófono y el procesamiento de audio.</string>
+    <string name="mic_wire_format_info">Android Auto siempre recibe el micrófono a 16000 Hz, 16 bits, mono. Rechaza cualquier otra cosa, así que estos ajustes cambian lo que hace el hardware, no lo que se envía al teléfono.</string>
     <string name="mic_echo_canceler">Cancelación de eco (AEC)</string>
     <string name="mic_echo_canceler_description">Intenta eliminar el eco del micrófono. Desactívalo si experimentas silencio o distorsión.</string>
     <string name="mic_noise_suppressor">Supresión de ruido (NS)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -473,7 +473,11 @@
     <string name="assistant_volume_offset">Décalage du volume de l\'Assistant</string>
     <string name="navigation_volume_offset">Décalage du volume de la navigation</string>
     <string name="microphone_settings">Paramètres du microphone</string>
+    <string name="use_head_unit_microphone">Microphone de l\'autoradio</string>
+    <string name="use_head_unit_microphone_description">Activé : Android Auto entend le microphone de cet appareil. Désactivé : cet appareil n\'enregistre jamais et le téléphone utilise son propre microphone, ou un casque ou intercom appairé au téléphone, de sorte que l\'assistant vocal fonctionne toujours. Nécessite Android 11 ou plus récent sur le téléphone.</string>
+    <string name="head_unit_microphone_off_info">Le microphone de l\'autoradio est désactivé, donc rien de ce qui suit ne s\'applique. Android Auto est informé que cet appareil ne peut pas enregistrer et qu\'il s\'agit d\'une moto, ce qui pousse le téléphone à enregistrer lui-même. Sous Android 10 et versions antérieures, le téléphone l\'oublie entre les sessions et peut cesser de se connecter.</string>
     <string name="microphone_settings_description">Configurer l\'entrée du micro et le traitement audio.</string>
+    <string name="mic_wire_format_info">Android Auto reçoit toujours le microphone en 16000 Hz, 16 bits, mono. Il refuse tout le reste, donc ces réglages modifient le comportement du matériel, pas ce qui est envoyé au téléphone.</string>
     <string name="mic_input_source">Source d\'entrée du microphone</string>
     <string name="mic_input_source_description">Choisir la source audio pour le microphone.</string>
     <string-array name="mic_input_sources">
@@ -741,6 +745,11 @@
     <string name="vehicle_year_label">Année</string>
     <string name="vehicle_year_description">Année du véhicule</string>
     <string name="vehicle_id_label">ID du véhicule</string>
+    <string name="vehicle_type_label">Type de véhicule</string>
+    <string name="vehicle_type_car">Voiture</string>
+    <string name="vehicle_type_truck">Camion</string>
+    <string name="vehicle_type_motorcycle">Moto</string>
+    <string name="vehicle_type_forced_by_microphone">Le microphone de l\'autoradio est désactivé, donc Android Auto est informé qu\'il s\'agit d\'une moto quel que soit le choix fait ici. C\'est ce qui pousse le téléphone à enregistrer lui-même.</string>
     <string name="vehicle_id_description">Identifiant interne uniquement. Changer ceci amènera ton téléphone à considérer qu\'il s\'agit d\'un véhicule différent, réinitialisant tes préférences Android Auto pour cette voiture.</string>
     <string name="head_unit_make_label">Marque</string>
     <string name="head_unit_make_description">Fabricant de l\'autoradio</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -448,6 +448,11 @@
     <string name="vehicle_year_label">Évjárat</string>
     <string name="vehicle_year_description">Jármű évjárata</string>
     <string name="vehicle_id_label">Jármű-azonosító</string>
+    <string name="vehicle_type_label">Járműtípus</string>
+    <string name="vehicle_type_car">Autó</string>
+    <string name="vehicle_type_truck">Teherautó</string>
+    <string name="vehicle_type_motorcycle">Motorkerékpár</string>
+    <string name="vehicle_type_forced_by_microphone">A fejegység mikrofonja ki van kapcsolva, így az Android Auto azt az információt kapja, hogy ez motorkerékpár, bármi is legyen itt kiválasztva. Éppen ez készteti a telefont saját rögzítésre.</string>
     <string name="vehicle_id_description">Csak belső azonosító. Megváltoztatása azt eredményezi, hogy telefonja ezt más járműként érzékeli, visszaállítva az Android Auto beállításait ehhez az autóhoz.</string>
     <string name="head_unit_make_label">Gyártó</string>
     <string name="head_unit_make_description">Fejegység gyártója</string>
@@ -532,7 +537,11 @@
     <string name="loading_screen_tap_fullscreen_hint">Érintse meg az előnézetet a teljes képernyős megjelenítéshez</string>
     <string name="loading_screen_loop_video">Rövid animációk ismétlése</string>
     <string name="microphone_settings">Mikrofon beállítások</string>
+    <string name="use_head_unit_microphone">Fejegység mikrofonja</string>
+    <string name="use_head_unit_microphone_description">Bekapcsolva: az Android Auto hallja az eszköz mikrofonját. Kikapcsolva: ez az eszköz soha nem rögzít, és a telefon a saját mikrofonját, illetve a telefonhoz párosított fejhallgatót vagy intercomot használja, így a hangasszisztens továbbra is működik. A telefonon Android 11 vagy újabb szükséges.</string>
+    <string name="head_unit_microphone_off_info">A fejegység mikrofonja ki van kapcsolva, így az alábbiak egyike sem érvényes. Az Android Auto azt az információt kapja, hogy ez az eszköz nem tud rögzíteni és motorkerékpár, és éppen ez készteti a telefont saját rögzítésre. Android 10 és régebbi rendszeren a telefon ezt a munkamenetek között elfelejti, és előfordulhat, hogy nem csatlakozik többé.</string>
     <string name="microphone_settings_description">A mikrofonbemenet és a hangfeldolgozás konfigurálása.</string>
+    <string name="mic_wire_format_info">Az Android Auto a mikrofont mindig 16000 Hz, 16 bit, monó formában kapja. Minden mást elutasít, így ezek a beállítások azt módosítják, amit a hardver csinál, nem azt, amit a telefon kap.</string>
     <string name="mic_echo_canceler">Visszhangkioltás (AEC)</string>
     <string name="mic_echo_canceler_description">Megpróbálja eltávolítani a visszhangot a mikrofonból. Kapcsolja ki, ha csendet vagy torzítást tapasztal.</string>
     <string name="mic_noise_suppressor">Zajcsökkentés (NS)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -454,6 +454,11 @@
     <string name="vehicle_year_label">Anno</string>
     <string name="vehicle_year_description">Anno del veicolo</string>
     <string name="vehicle_id_label">ID Veicolo</string>
+    <string name="vehicle_type_label">Tipo di veicolo</string>
+    <string name="vehicle_type_car">Auto</string>
+    <string name="vehicle_type_truck">Camion</string>
+    <string name="vehicle_type_motorcycle">Motocicletta</string>
+    <string name="vehicle_type_forced_by_microphone">Il microfono dell\'unità è disattivato, quindi ad Android Auto viene detto che questa è una motocicletta qualunque cosa venga scelta qui. È questo a far registrare il telefono da solo.</string>
     <string name="vehicle_id_description">Solo identificatore interno. Modificandolo, il telefono tratterà questo come un veicolo diverso, ripristinando le preferenze di Android Auto per questa auto.</string>
     <string name="head_unit_make_label">Marca</string>
     <string name="head_unit_make_description">Produttore della head unit</string>
@@ -540,7 +545,11 @@
     <string name="loading_screen_tap_fullscreen_hint">Tocca l\'anteprima per vederla a schermo intero</string>
     <string name="loading_screen_loop_video">Ripeti animazioni brevi in loop</string>
     <string name="microphone_settings">Impostazioni Microfono</string>
+    <string name="use_head_unit_microphone">Microfono dell\'unità</string>
+    <string name="use_head_unit_microphone_description">Attivo: Android Auto sente il microfono di questo dispositivo. Disattivo: questo dispositivo non registra mai e il telefono usa il proprio microfono, o un auricolare o interfono associato al telefono, così l\'assistente vocale continua a funzionare. Richiede Android 11 o successivo sul telefono.</string>
+    <string name="head_unit_microphone_off_info">Il microfono dell\'unità è disattivato, quindi nulla di quanto segue si applica. Ad Android Auto viene detto che questo dispositivo non può registrare ed è una motocicletta, ed è questo a far registrare il telefono da solo. Su Android 10 e precedenti il telefono se ne dimentica tra una sessione e l\'altra e potrebbe smettere di connettersi.</string>
     <string name="microphone_settings_description">Configura l\'ingresso del microfono e l\'elaborazione audio.</string>
+    <string name="mic_wire_format_info">Android Auto riceve sempre il microfono a 16000 Hz, 16 bit, mono. Rifiuta qualsiasi altro formato, quindi queste impostazioni cambiano ciò che fa l\'hardware, non ciò che viene inviato al telefono.</string>
     <string name="mic_echo_canceler">Cancellazione dell\'eco (AEC)</string>
     <string name="mic_echo_canceler_description">Tenta di rimuovere l\'eco dal microfono. Disabilita se riscontri silenzio o distorsione.</string>
     <string name="mic_noise_suppressor">Soppressione del rumore (NS)</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -455,6 +455,11 @@
     <string name="vehicle_year_label">年</string>
     <string name="vehicle_year_description">車両年式</string>
     <string name="vehicle_id_label">車両ID</string>
+    <string name="vehicle_type_label">車両タイプ</string>
+    <string name="vehicle_type_car">乗用車</string>
+    <string name="vehicle_type_truck">トラック</string>
+    <string name="vehicle_type_motorcycle">バイク</string>
+    <string name="vehicle_type_forced_by_microphone">ヘッドユニットのマイクがオフのため、ここで何を選んでも Android Auto にはバイクとして伝えられます。これによりスマートフォンが自身で録音するようになります。</string>
     <string name="vehicle_id_description">内部識別子としてのみ使用されます。これを変更すると、お使いのスマートフォンはこの車両を別の車両として認識し、この車両に関するAndroid Autoの設定がリセットされます。</string>
     <string name="head_unit_make_label">メーカー</string>
     <string name="head_unit_make_description">車載機メーカー</string>
@@ -541,7 +546,11 @@
     <string name="loading_screen_tap_fullscreen_hint">プレビューをタップしてフルスクリーンで表示</string>
     <string name="loading_screen_loop_video">短いアニメーションをループ再生</string>
     <string name="microphone_settings">マイク設定</string>
+    <string name="use_head_unit_microphone">ヘッドユニットのマイク</string>
+    <string name="use_head_unit_microphone_description">オン: Android Auto がこの端末のマイクを使用します。オフ: この端末は録音せず、スマートフォンが自身のマイク、またはスマートフォンにペアリングされたヘッドセットやインカムを使用するため、音声アシスタントは引き続き利用できます。スマートフォン側に Android 11 以降が必要です。</string>
+    <string name="head_unit_microphone_off_info">ヘッドユニットのマイクがオフのため、以下の設定は適用されません。Android Auto にはこの端末が録音できないこと、そしてバイクであることが伝えられ、これによりスマートフォンが自身で録音するようになります。Android 10 以前ではスマートフォンがセッション間でこれを忘れるため、接続できなくなる場合があります。</string>
     <string name="microphone_settings_description">マイク入力とオーディオ処理の設定を行います。</string>
+    <string name="mic_wire_format_info">Android Auto は常に 16000 Hz、16 ビット、モノラルでマイクを受け取ります。それ以外は拒否されるため、これらの設定はハードウェアの動作を変えるだけで、スマートフォンに送られる内容は変わりません。</string>
     <string name="mic_echo_canceler">エコーキャンセラー (AEC)</string>
     <string name="mic_echo_canceler_description">マイクからのエコーを除去します。無音になったり音が歪んだりする場合は無効にしてください。</string>
     <string name="mic_noise_suppressor">ノイズサプレッサー (NS)</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -281,7 +281,11 @@
     <string name="assistant_volume_offset">ასისტენტის ხმის ოფსეტი</string>
     <string name="navigation_volume_offset">ნავიგაციის ხმის ოფსეტი</string>
     <string name="microphone_settings">მიკროფონის პარამეტრები</string>
+    <string name="use_head_unit_microphone">მონიტორის მიკროფონი</string>
+    <string name="use_head_unit_microphone_description">ჩართული: Android Auto ისმენს ამ მოწყობილობის მიკროფონს. გამორთული: ეს მოწყობილობა არასოდეს იწერს და ტელეფონი იყენებს საკუთარ მიკროფონს, ან ტელეფონთან დაწყვილებულ ყურსასმენს ან ინტერკომს, ასე რომ ხმოვანი ასისტენტი კვლავ მუშაობს. ტელეფონზე საჭიროა Android 11 ან უფრო ახალი.</string>
+    <string name="head_unit_microphone_off_info">მონიტორის მიკროფონი გამორთულია, ამიტომ ქვემოთ მოცემული არაფერი მოქმედებს. Android Auto-ს ეუბნებიან, რომ ეს მოწყობილობა ვერ იწერს და მოტოციკლია, სწორედ ეს აიძულებს ტელეფონს თავად ჩაწეროს. Android 10-ზე და უფრო ძველზე ტელეფონი ამას სესიებს შორის ივიწყებს და შეიძლება შეწყვიტოს დაკავშირება.</string>
     <string name="microphone_settings_description">მიკროფონის შეყვანისა და აუდიო დამუშავების კონფიგურაცია.</string>
+    <string name="mic_wire_format_info">Android Auto მიკროფონს ყოველთვის იღებს 16000 ჰც, 16 ბიტი, მონო ფორმატში. ყველაფერ დანარჩენს უარყოფს, ამიტომ ეს პარამეტრები ცვლის იმას, რასაც აპარატურა აკეთებს და არა იმას, რაც ტელეფონს ეგზავნება.</string>
     <string name="mic_input_source">მიკროფონის შეყვანის წყარო</string>
     <string name="mic_input_source_description">აირჩიეთ აუდიო წყარო მიკროფონისთვის.</string>
     <string-array name="mic_input_sources">
@@ -486,6 +490,11 @@
     <string name="vehicle_year_label">წელი</string>
     <string name="vehicle_year_description">ავტომობილის გამოშვების წელი</string>
     <string name="vehicle_id_label">ავტომობილის ID</string>
+    <string name="vehicle_type_label">ავტომობილის ტიპი</string>
+    <string name="vehicle_type_car">მანქანა</string>
+    <string name="vehicle_type_truck">სატვირთო</string>
+    <string name="vehicle_type_motorcycle">მოტოციკლი</string>
+    <string name="vehicle_type_forced_by_microphone">მონიტორის მიკროფონი გამორთულია, ამიტომ Android Auto-ს ეუბნებიან, რომ ეს მოტოციკლია, რაც არ უნდა იყოს აქ არჩეული. სწორედ ეს აიძულებს ტელეფონს თავად ჩაწეროს.</string>
     <string name="vehicle_id_description">მხოლოდ შიდა იდენტიფიკატორი. ამის შეცვლა აიძულებს ტელეფონს ჩათვალოს ეს სხვა ავტომობილად, რაც ჩამოყრის თქვენს Android Auto-ს პარამეტრებს ამ მანქანისთვის.</string>
     <string name="head_unit_make_label">მონიტორის მარკა</string>
     <string name="head_unit_make_description">მონიტორის მწარმოებელი</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -290,7 +290,11 @@
     <string name="assistant_volume_offset">어시스턴트 볼륨 보정</string>
     <string name="navigation_volume_offset">내비게이션 볼륨 보정</string>
     <string name="microphone_settings">마이크 설정</string>
+    <string name="use_head_unit_microphone">헤드유닛 마이크</string>
+    <string name="use_head_unit_microphone_description">켜짐: Android Auto가 이 기기의 마이크를 사용합니다. 꺼짐: 이 기기는 녹음하지 않으며 휴대전화가 자체 마이크나 휴대전화에 페어링된 헤드셋 또는 인터콤을 사용하므로 음성 어시스턴트는 계속 작동합니다. 휴대전화에 Android 11 이상이 필요합니다.</string>
+    <string name="head_unit_microphone_off_info">헤드유닛 마이크가 꺼져 있어 아래 항목은 적용되지 않습니다. Android Auto에는 이 기기가 녹음할 수 없으며 오토바이라고 전달되고, 바로 이것이 휴대전화가 스스로 녹음하게 만듭니다. Android 10 이하에서는 휴대전화가 세션 사이에 이를 잊어버려 연결이 중단될 수 있습니다.</string>
     <string name="microphone_settings_description">마이크 입력 및 오디오 처리를 설정합니다.</string>
+    <string name="mic_wire_format_info">Android Auto는 항상 16000 Hz, 16비트, 모노로 마이크를 받습니다. 그 외에는 모두 거부하므로 이 설정은 하드웨어의 동작을 바꿀 뿐 휴대전화로 전송되는 내용을 바꾸지 않습니다.</string>
     <string name="mic_input_source">마이크 입력 소스</string>
     <string name="mic_input_source_description">마이크 입력에 사용할 오디오 소스를 선택합니다.</string>
     <string-array name="mic_input_sources">
@@ -507,6 +511,11 @@
     <string name="vehicle_year_label">연식</string>
     <string name="vehicle_year_description">차량 연식</string>
     <string name="vehicle_id_label">차량 ID</string>
+    <string name="vehicle_type_label">차량 유형</string>
+    <string name="vehicle_type_car">승용차</string>
+    <string name="vehicle_type_truck">트럭</string>
+    <string name="vehicle_type_motorcycle">오토바이</string>
+    <string name="vehicle_type_forced_by_microphone">헤드유닛 마이크가 꺼져 있어 여기서 무엇을 선택하든 Android Auto에는 오토바이라고 전달됩니다. 바로 이것이 휴대전화가 스스로 녹음하게 만듭니다.</string>
     <string name="vehicle_id_description">내부 식별자로만 사용됩니다. 이 값을 변경하면 휴대폰이 다른 차량으로 인식하여 이 차량의 Android Auto 설정이 초기화됩니다.</string>
     <string name="head_unit_make_label">제조사</string>
     <string name="head_unit_make_description">헤드유닛 제조사</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -446,6 +446,11 @@
     <string name="vehicle_year_label">Bouwjaar</string>
     <string name="vehicle_year_description">Bouwjaar van het voertuig</string>
     <string name="vehicle_id_label">Voertuig-ID</string>
+    <string name="vehicle_type_label">Voertuigtype</string>
+    <string name="vehicle_type_car">Auto</string>
+    <string name="vehicle_type_truck">Vrachtwagen</string>
+    <string name="vehicle_type_motorcycle">Motorfiets</string>
+    <string name="vehicle_type_forced_by_microphone">De microfoon van de hoofdunit staat uit, dus Android Auto krijgt te horen dat dit een motorfiets is, wat hier ook wordt gekozen. Dat is wat de telefoon zelf laat opnemen.</string>
     <string name="vehicle_id_description">Alleen interne identificatie. Wijzigen zorgt ervoor dat uw telefoon dit als een ander voertuig detecteert, waardoor uw Android Auto-voorkeuren voor deze auto worden gereset.</string>
     <string name="head_unit_make_label">Merk</string>
     <string name="head_unit_make_description">Fabrikant van de headunit</string>
@@ -533,7 +538,11 @@
     <string name="loading_screen_tap_fullscreen_hint">Tik op het voorbeeld om het op volledig scherm te zien</string>
     <string name="loading_screen_loop_video">Korte animaties herhalen</string>
     <string name="microphone_settings">Microfooninstellingen</string>
+    <string name="use_head_unit_microphone">Microfoon van hoofdunit</string>
+    <string name="use_head_unit_microphone_description">Aan: Android Auto hoort de microfoon van dit apparaat. Uit: dit apparaat neemt nooit op en de telefoon gebruikt zijn eigen microfoon, of een headset of intercom die met de telefoon is gekoppeld, zodat de spraakassistent blijft werken. Vereist Android 11 of nieuwer op de telefoon.</string>
+    <string name="head_unit_microphone_off_info">De microfoon van de hoofdunit staat uit, dus niets hieronder is van toepassing. Android Auto krijgt te horen dat dit apparaat niet kan opnemen en een motorfiets is, en dat is wat de telefoon zelf laat opnemen. Op Android 10 en ouder vergeet de telefoon dat tussen sessies en maakt hij mogelijk geen verbinding meer.</string>
     <string name="microphone_settings_description">Microfooningang en audioverwerking configureren.</string>
+    <string name="mic_wire_format_info">Android Auto ontvangt de microfoon altijd op 16000 Hz, 16-bits, mono. Al het andere wordt geweigerd, dus deze instellingen veranderen wat de hardware doet, niet wat naar de telefoon wordt gestuurd.</string>
     <string name="mic_echo_canceler">Echonderdrukking (AEC)</string>
     <string name="mic_echo_canceler_description">Probeert echo van de microfoon te verwijderen. Schakel dit uit als u stilte of vervorming ervaart.</string>
     <string name="mic_noise_suppressor">Ruisonderdrukking (NS)</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -447,6 +447,11 @@
     <string name="vehicle_year_label">Rok</string>
     <string name="vehicle_year_description">Rok produkcji pojazdu</string>
     <string name="vehicle_id_label">ID pojazdu</string>
+    <string name="vehicle_type_label">Typ pojazdu</string>
+    <string name="vehicle_type_car">Samochód</string>
+    <string name="vehicle_type_truck">Ciężarówka</string>
+    <string name="vehicle_type_motorcycle">Motocykl</string>
+    <string name="vehicle_type_forced_by_microphone">Mikrofon jednostki głównej jest wyłączony, więc Android Auto jest informowany, że to motocykl, niezależnie od wyboru dokonanego tutaj. To właśnie sprawia, że telefon nagrywa samodzielnie.</string>
     <string name="vehicle_id_description">Tylko wewnętrzny identyfikator. Jego zmiana spowoduje, że telefon potraktuje to jako inny pojazd, resetując preferencje Android Auto dla tego samochodu.</string>
     <string name="head_unit_make_label">Producent</string>
     <string name="head_unit_make_description">Producent radia</string>
@@ -534,7 +539,11 @@
     <string name="loading_screen_tap_fullscreen_hint">Dotknij podglądu, aby zobaczyć na pełnym ekranie</string>
     <string name="loading_screen_loop_video">Powtarzaj krótkie animacje</string>
     <string name="microphone_settings">Ustawienia mikrofonu</string>
+    <string name="use_head_unit_microphone">Mikrofon jednostki głównej</string>
+    <string name="use_head_unit_microphone_description">Włączone: Android Auto słyszy mikrofon tego urządzenia. Wyłączone: to urządzenie nigdy nie nagrywa, a telefon używa własnego mikrofonu albo zestawu słuchawkowego lub interkomu sparowanego z telefonem, więc asystent głosowy nadal działa. Wymaga Androida 11 lub nowszego na telefonie.</string>
+    <string name="head_unit_microphone_off_info">Mikrofon jednostki głównej jest wyłączony, więc nic poniżej nie ma zastosowania. Android Auto jest informowany, że to urządzenie nie może nagrywać i jest motocyklem, co sprawia, że telefon nagrywa samodzielnie. W Androidzie 10 i starszym telefon zapomina o tym między sesjami i może przestać się łączyć.</string>
     <string name="microphone_settings_description">Skonfiguruj wejście mikrofonu i przetwarzanie dźwięku.</string>
+    <string name="mic_wire_format_info">Android Auto zawsze odbiera mikrofon w 16000 Hz, 16 bitów, mono. Odrzuca wszystko inne, więc te ustawienia zmieniają to, co robi sprzęt, a nie to, co jest wysyłane do telefonu.</string>
     <string name="mic_echo_canceler">Usuwanie echa (AEC)</string>
     <string name="mic_echo_canceler_description">Próbuje usunąć echo z mikrofonu. Wyłącz, jeśli doświadczasz ciszy lub zniekształceń.</string>
     <string name="mic_noise_suppressor">Tłumienie szumów (NS)</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -447,6 +447,11 @@
     <string name="vehicle_year_label">Ano</string>
     <string name="vehicle_year_description">Ano do veículo</string>
     <string name="vehicle_id_label">ID do veículo</string>
+    <string name="vehicle_type_label">Tipo de veículo</string>
+    <string name="vehicle_type_car">Carro</string>
+    <string name="vehicle_type_truck">Caminhão</string>
+    <string name="vehicle_type_motorcycle">Motocicleta</string>
+    <string name="vehicle_type_forced_by_microphone">O microfone da central está desligado, então o Android Auto é informado de que isto é uma motocicleta, qualquer que seja a opção escolhida aqui. É isso que faz o telefone gravar por conta própria.</string>
     <string name="vehicle_id_description">Apenas identificador interno. Alterá-lo fará com que seu celular detecte este como um veículo diferente, redefinindo as preferências do Android Auto para este carro.</string>
     <string name="head_unit_make_label">Fabricante</string>
     <string name="head_unit_make_description">Fabricante da central multimídia</string>
@@ -534,7 +539,11 @@
     <string name="loading_screen_tap_fullscreen_hint">Toque na pré-visualização para vê-la em tela cheia</string>
     <string name="loading_screen_loop_video">Repetir animações curtas em loop</string>
     <string name="microphone_settings">Configurações do microfone</string>
+    <string name="use_head_unit_microphone">Microfone da central</string>
+    <string name="use_head_unit_microphone_description">Ligado: o Android Auto ouve o microfone deste dispositivo. Desligado: este dispositivo nunca grava e o telefone usa o próprio microfone, ou um fone ou intercomunicador pareado ao telefone, de modo que o assistente de voz continua funcionando. Requer Android 11 ou mais recente no telefone.</string>
+    <string name="head_unit_microphone_off_info">O microfone da central está desligado, então nada abaixo se aplica. O Android Auto é informado de que este dispositivo não pode gravar e é uma motocicleta, e é isso que faz o telefone gravar por conta própria. No Android 10 e anteriores o telefone esquece isso entre as sessões e pode parar de conectar.</string>
     <string name="microphone_settings_description">Configurar entrada de microfone e processamento de áudio.</string>
+    <string name="mic_wire_format_info">O Android Auto sempre recebe o microfone em 16000 Hz, 16 bits, mono. Ele rejeita qualquer outra coisa, então estas configurações mudam o que o hardware faz, não o que é enviado ao telefone.</string>
     <string name="mic_echo_canceler">Cancelamento de eco (AEC)</string>
     <string name="mic_echo_canceler_description">Tenta remover o eco do microfone. Desative se houver silêncio ou distorção.</string>
     <string name="mic_noise_suppressor">Supressão de ruído (NS)</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -447,6 +447,11 @@
     <string name="vehicle_year_label">An</string>
     <string name="vehicle_year_description">Anul vehiculului</string>
     <string name="vehicle_id_label">ID vehicul</string>
+    <string name="vehicle_type_label">Tip de vehicul</string>
+    <string name="vehicle_type_car">Automobil</string>
+    <string name="vehicle_type_truck">Camion</string>
+    <string name="vehicle_type_motorcycle">Motocicletă</string>
+    <string name="vehicle_type_forced_by_microphone">Microfonul unității este dezactivat, așa că Android Auto este informat că acesta este o motocicletă, indiferent ce se alege aici. Asta face telefonul să înregistreze singur.</string>
     <string name="vehicle_id_description">Doar identificator intern. Schimbarea acestuia va face ca telefonul dvs. să detecteze acesta ca un vehicul diferit, resetând preferințele Android Auto pentru această mașină.</string>
     <string name="head_unit_make_label">Producător</string>
     <string name="head_unit_make_description">Producătorul unității principale</string>
@@ -534,7 +539,11 @@
     <string name="loading_screen_tap_fullscreen_hint">Atingeți previzualizarea pentru a o vedea pe tot ecranul</string>
     <string name="loading_screen_loop_video">Repetă animațiile scurte în buclă</string>
     <string name="microphone_settings">Setări microfon</string>
+    <string name="use_head_unit_microphone">Microfonul unității</string>
+    <string name="use_head_unit_microphone_description">Activat: Android Auto aude microfonul acestui dispozitiv. Dezactivat: acest dispozitiv nu înregistrează niciodată, iar telefonul folosește propriul microfon sau o cască ori un interfon asociat telefonului, astfel încât asistentul vocal continuă să funcționeze. Necesită Android 11 sau mai nou pe telefon.</string>
+    <string name="head_unit_microphone_off_info">Microfonul unității este dezactivat, așa că nimic din ce urmează nu se aplică. Android Auto este informat că acest dispozitiv nu poate înregistra și că este o motocicletă, iar asta face telefonul să înregistreze singur. Pe Android 10 și mai vechi telefonul uită acest lucru între sesiuni și s-ar putea să nu se mai conecteze.</string>
     <string name="microphone_settings_description">Configurați intrarea microfonului și procesarea audio.</string>
+    <string name="mic_wire_format_info">Android Auto primește întotdeauna microfonul la 16000 Hz, 16 biți, mono. Respinge orice altceva, așa că aceste setări schimbă ce face hardware-ul, nu ce se trimite către telefon.</string>
     <string name="mic_echo_canceler">Anularea ecoului (AEC)</string>
     <string name="mic_echo_canceler_description">Încearcă să elimine ecoul din microfon. Dezactivați dacă întâmpinați tăcere sau distorsiuni.</string>
     <string name="mic_noise_suppressor">Suprimarea zgomotului (NS)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -453,6 +453,11 @@
     <string name="vehicle_year_label">Год</string>
     <string name="vehicle_year_description">Год выпуска автомобиля</string>
     <string name="vehicle_id_label">ID автомобиля</string>
+    <string name="vehicle_type_label">Тип транспортного средства</string>
+    <string name="vehicle_type_car">Автомобиль</string>
+    <string name="vehicle_type_truck">Грузовик</string>
+    <string name="vehicle_type_motorcycle">Мотоцикл</string>
+    <string name="vehicle_type_forced_by_microphone">Микрофон головного устройства выключен, поэтому Android Auto сообщается, что это мотоцикл, независимо от выбора здесь. Именно это заставляет телефон записывать самостоятельно.</string>
     <string name="vehicle_id_description">Только внутренний идентификатор. Его изменение приведёт к тому, что телефон определит это как другой автомобиль, сбросив настройки Android Auto для этой машины.</string>
     <string name="head_unit_make_label">Производитель</string>
     <string name="head_unit_make_description">Производитель головного устройства</string>
@@ -536,7 +541,11 @@
     <string name="media_action_next">Следующий</string>
     <string name="error_usb_permission_failed">Системная ошибка: Не удалось запросить диалоговое окно разрешения USB.</string>
     <string name="microphone_settings">Настройки микрофона</string>
+    <string name="use_head_unit_microphone">Микрофон головного устройства</string>
+    <string name="use_head_unit_microphone_description">Включено: Android Auto слышит микрофон этого устройства. Выключено: это устройство никогда не записывает, а телефон использует собственный микрофон либо гарнитуру или интерком, сопряжённые с телефоном, поэтому голосовой помощник продолжает работать. Требуется Android 11 или новее на телефоне.</string>
+    <string name="head_unit_microphone_off_info">Микрофон головного устройства выключен, поэтому ничего из указанного ниже не применяется. Android Auto сообщается, что это устройство не может записывать и является мотоциклом, — именно это заставляет телефон записывать самостоятельно. На Android 10 и старее телефон забывает это между сеансами и может перестать подключаться.</string>
     <string name="microphone_settings_description">Настройка входа микрофона и обработки звука.</string>
+    <string name="mic_wire_format_info">Android Auto всегда получает микрофон с частотой 16000 Гц, 16 бит, моно. Всё остальное отклоняется, поэтому эти настройки меняют работу оборудования, а не то, что отправляется на телефон.</string>
     <string name="mic_echo_canceler">Эхоподавление (AEC)</string>
     <string name="mic_echo_canceler_description">Попытка удалить эхо из микрофона. Отключите, если слышите тишину или искажения.</string>
     <string name="mic_noise_suppressor">Шумоподавление (NS)</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -445,6 +445,11 @@
     <string name="vehicle_year_label">Yıl</string>
     <string name="vehicle_year_description">Araç yılı</string>
     <string name="vehicle_id_label">Araç ID</string>
+    <string name="vehicle_type_label">Araç türü</string>
+    <string name="vehicle_type_car">Otomobil</string>
+    <string name="vehicle_type_truck">Kamyon</string>
+    <string name="vehicle_type_motorcycle">Motosiklet</string>
+    <string name="vehicle_type_forced_by_microphone">Ana ünite mikrofonu kapalı, bu yüzden burada ne seçilirse seçilsin Android Auto\'ya bunun bir motosiklet olduğu bildirilir. Telefonun kendi başına kayıt yapmasını sağlayan da budur.</string>
     <string name="vehicle_id_description">Sadece dahili tanımlayıcıdır. Bunu değiştirmek, telefonunuzun bu aracı farklı bir araç olarak görmesine neden olur ve bu araba için Android Auto tercihlerinizi sıfırlar.</string>
     <string name="head_unit_make_label">Marka</string>
     <string name="head_unit_make_description">Multimedya sistemi üreticisi</string>
@@ -507,7 +512,11 @@
     <string name="media_action_next">Sonraki</string>
     <string name="error_usb_permission_failed">Sistem hatası: USB izin iletişim kutusu istenemedi.</string>
     <string name="microphone_settings">Mikrofon Ayarları</string>
+    <string name="use_head_unit_microphone">Ana ünite mikrofonu</string>
+    <string name="use_head_unit_microphone_description">Açık: Android Auto bu cihazın mikrofonunu duyar. Kapalı: bu cihaz asla kayıt yapmaz ve telefon kendi mikrofonunu ya da telefona eşleştirilmiş bir kulaklık veya interkomu kullanır, böylece sesli asistan çalışmaya devam eder. Telefonda Android 11 veya daha yenisi gerekir.</string>
+    <string name="head_unit_microphone_off_info">Ana ünite mikrofonu kapalı, bu yüzden aşağıdakilerin hiçbiri geçerli değil. Android Auto\'ya bu cihazın kayıt yapamadığı ve bir motosiklet olduğu bildirilir; telefonun kendi başına kayıt yapmasını sağlayan da budur. Android 10 ve öncesinde telefon bunu oturumlar arasında unutur ve bağlanmayı bırakabilir.</string>
     <string name="microphone_settings_description">Mikrofon girişini ve ses işlemeyi yapılandırın.</string>
+    <string name="mic_wire_format_info">Android Auto mikrofonu her zaman 16000 Hz, 16 bit, mono olarak alır. Başka her şeyi reddeder, bu nedenle bu ayarlar donanımın ne yaptığını değiştirir, telefona ne gönderildiğini değil.</string>
     <string name="mic_echo_canceler">Yankı giderme (AEC)</string>
     <string name="mic_echo_canceler_description">Mikrofondaki yankıyı gidermeye çalışır. Sessizlik veya bozulma yaşıyorsanız bunu devre dışı bırakın.</string>
     <string name="mic_noise_suppressor">Gürültü bastırma (NS)</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -447,6 +447,11 @@
     <string name="vehicle_year_label">Рік</string>
     <string name="vehicle_year_description">Рік випуску автомобіля</string>
     <string name="vehicle_id_label">ID автомобіля</string>
+    <string name="vehicle_type_label">Тип транспортного засобу</string>
+    <string name="vehicle_type_car">Автомобіль</string>
+    <string name="vehicle_type_truck">Вантажівка</string>
+    <string name="vehicle_type_motorcycle">Мотоцикл</string>
+    <string name="vehicle_type_forced_by_microphone">Мікрофон головного пристрою вимкнено, тож Android Auto повідомляється, що це мотоцикл, незалежно від вибору тут. Саме це змушує телефон записувати самостійно.</string>
     <string name="vehicle_id_description">Лише внутрішній ідентифікатор. Його зміна призведе до того, що телефон визначить це як інший автомобіль, скинувши налаштування Android Auto для цієї машини.</string>
     <string name="head_unit_make_label">Виробник</string>
     <string name="head_unit_make_description">Виробник головного пристрою</string>
@@ -534,7 +539,11 @@
     <string name="loading_screen_tap_fullscreen_hint">Натисніть на попередній перегляд для повноекранного режиму</string>
     <string name="loading_screen_loop_video">Повторювати короткі анімації</string>
     <string name="microphone_settings">Налаштування мікрофона</string>
+    <string name="use_head_unit_microphone">Мікрофон головного пристрою</string>
+    <string name="use_head_unit_microphone_description">Увімкнено: Android Auto чує мікрофон цього пристрою. Вимкнено: цей пристрій ніколи не записує, а телефон використовує власний мікрофон або гарнітуру чи інтерком, спарені з телефоном, тож голосовий помічник продовжує працювати. Потрібен Android 11 або новіший на телефоні.</string>
+    <string name="head_unit_microphone_off_info">Мікрофон головного пристрою вимкнено, тож ніщо з наведеного нижче не застосовується. Android Auto повідомляється, що цей пристрій не може записувати і є мотоциклом, — саме це змушує телефон записувати самостійно. На Android 10 і старіших телефон забуває це між сеансами й може перестати підключатися.</string>
     <string name="microphone_settings_description">Налаштування входу мікрофона та обробки звуку.</string>
+    <string name="mic_wire_format_info">Android Auto завжди отримує мікрофон із частотою 16000 Гц, 16 біт, моно. Усе інше відхиляється, тож ці налаштування змінюють роботу обладнання, а не те, що надсилається на телефон.</string>
     <string name="mic_echo_canceler">Ехоподавлення (AEC)</string>
     <string name="mic_echo_canceler_description">Спроба видалити ехо з мікрофона. Вимкніть, якщо чуєте тишу або спотворення.</string>
     <string name="mic_noise_suppressor">Шумоподавлення (NS)</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -271,7 +271,11 @@
     <string name="assistant_volume_offset">Bù âm lượng trợ lý</string>
     <string name="navigation_volume_offset">Bù âm lượng điều hướng</string>
     <string name="microphone_settings">Cài đặt micro</string>
+    <string name="use_head_unit_microphone">Micro của đầu máy</string>
+    <string name="use_head_unit_microphone_description">Bật: Android Auto nghe micro của thiết bị này. Tắt: thiết bị này không bao giờ ghi âm và điện thoại dùng micro của chính nó, hoặc tai nghe hay bộ đàm đã ghép nối với điện thoại, nên trợ lý giọng nói vẫn hoạt động. Cần Android 11 trở lên trên điện thoại.</string>
+    <string name="head_unit_microphone_off_info">Micro của đầu máy đang tắt nên không có mục nào bên dưới được áp dụng. Android Auto được thông báo rằng thiết bị này không thể ghi âm và là một xe máy, đó chính là điều khiến điện thoại tự ghi âm. Trên Android 10 trở xuống, điện thoại quên điều này giữa các phiên và có thể ngừng kết nối.</string>
     <string name="microphone_settings_description">Cấu hình đầu vào micro và xử lý âm thanh.</string>
+    <string name="mic_wire_format_info">Android Auto luôn nhận micro ở 16000 Hz, 16 bit, đơn kênh. Mọi định dạng khác đều bị từ chối, nên các cài đặt này thay đổi cách phần cứng hoạt động chứ không thay đổi những gì được gửi tới điện thoại.</string>
     <string name="mic_input_source">Nguồn vào micro</string>
     <string name="mic_input_source_description">Chọn nguồn âm thanh cho micro.</string>
     <string-array name="mic_input_sources">
@@ -460,6 +464,11 @@
     <string name="vehicle_year_label">Năm</string>
     <string name="vehicle_year_description">Năm sản xuất xe</string>
     <string name="vehicle_id_label">ID xe</string>
+    <string name="vehicle_type_label">Loại xe</string>
+    <string name="vehicle_type_car">Ô tô</string>
+    <string name="vehicle_type_truck">Xe tải</string>
+    <string name="vehicle_type_motorcycle">Xe máy</string>
+    <string name="vehicle_type_forced_by_microphone">Micro của đầu máy đang tắt nên dù chọn gì ở đây, Android Auto vẫn được thông báo rằng đây là một xe máy. Đó chính là điều khiến điện thoại tự ghi âm.</string>
     <string name="vehicle_id_description">Định danh nội bộ. Đổi giá trị này sẽ khiến điện thoại coi đây là xe khác và đặt lại tuỳ chỉnh Android Auto cho xe này.</string>
     <string name="head_unit_make_label">Hãng</string>
     <string name="head_unit_make_description">Hãng sản xuất headunit</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -446,6 +446,11 @@
     <string name="vehicle_year_label">年份</string>
     <string name="vehicle_year_description">車輛年份</string>
     <string name="vehicle_id_label">車輛 ID</string>
+    <string name="vehicle_type_label">車輛類型</string>
+    <string name="vehicle_type_car">汽車</string>
+    <string name="vehicle_type_truck">卡車</string>
+    <string name="vehicle_type_motorcycle">機車</string>
+    <string name="vehicle_type_forced_by_microphone">主機麥克風已關閉，因此無論在此選擇什麼，系統都會告訴 Android Auto 這是機車。這正是讓手機自行錄音的原因。</string>
     <string name="vehicle_id_description">僅為內部識別碼。更改此項將導致您的手機將此視為不同的車輛，重置此車的 Android Auto 偏好設定。</string>
     <string name="head_unit_make_label">製造商</string>
     <string name="head_unit_make_description">車機製造商</string>
@@ -533,7 +538,11 @@
     <string name="loading_screen_tap_fullscreen_hint">點擊預覽以全螢幕顯示</string>
     <string name="loading_screen_loop_video">循環播放短動畫</string>
     <string name="microphone_settings">麥克風設定</string>
+    <string name="use_head_unit_microphone">主機麥克風</string>
+    <string name="use_head_unit_microphone_description">開啟：Android Auto 會使用本裝置的麥克風。關閉：本裝置不會錄音，改由手機使用自己的麥克風，或與手機配對的耳機或對講機，語音助理仍可正常運作。手機需為 Android 11 以上。</string>
+    <string name="head_unit_microphone_off_info">主機麥克風已關閉，因此以下設定皆不適用。系統會告訴 Android Auto 本裝置無法錄音且為機車，這正是讓手機自行錄音的原因。在 Android 10 以下，手機會在工作階段之間忘記這項資訊，可能因此無法連線。</string>
     <string name="microphone_settings_description">設定麥克風輸入和音訊處理。</string>
+    <string name="mic_wire_format_info">Android Auto 一律以 16000 Hz、16 位元、單聲道接收麥克風。其他格式一概拒絕，因此這些設定改變的是硬體的行為，而非傳送給手機的內容。</string>
     <string name="mic_echo_canceler">回音消除 (AEC)</string>
     <string name="mic_echo_canceler_description">嘗試消除麥克風回音。若遇到無聲或音訊失真，請停用此功能。</string>
     <string name="mic_noise_suppressor">雜音抑制 (NS)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -502,6 +502,9 @@
     <string name="assistant_volume_offset">Assistant Volume Offset</string>
     <string name="navigation_volume_offset">Navigation Volume Offset</string>
     <string name="microphone_settings">Microphone Settings</string>
+    <string name="use_head_unit_microphone">Head unit microphone</string>
+    <string name="use_head_unit_microphone_description">On: Android Auto hears this device\'s microphone. Off: this device never records, so a Bluetooth headset or intercom keeps the microphone, but Android Auto\'s voice assistant and calls will not hear you at all.</string>
+    <string name="head_unit_microphone_off_info">The head unit microphone is off, so nothing below applies. Android Auto is still told a microphone exists, because it refuses to connect otherwise, but no audio is sent, so the voice assistant will not answer and callers will not hear you.</string>
     <string name="microphone_settings_description">Configure microphone input and audio processing.</string>
     <string name="mic_wire_format_info">Android Auto always receives the microphone at 16000 Hz, 16-bit, mono. It rejects anything else, so these settings change what the hardware does, not what the phone is sent.</string>
     <string name="mic_input_source">Microphone Input Source</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -503,8 +503,8 @@
     <string name="navigation_volume_offset">Navigation Volume Offset</string>
     <string name="microphone_settings">Microphone Settings</string>
     <string name="use_head_unit_microphone">Head unit microphone</string>
-    <string name="use_head_unit_microphone_description">On: Android Auto hears this device\'s microphone. Off: this device never records, so a Bluetooth headset or intercom keeps the microphone, but Android Auto\'s voice assistant and calls will not hear you at all.</string>
-    <string name="head_unit_microphone_off_info">The head unit microphone is off, so nothing below applies. Android Auto is still told a microphone exists, because it refuses to connect otherwise, but no audio is sent, so the voice assistant will not answer and callers will not hear you.</string>
+    <string name="use_head_unit_microphone_description">On: Android Auto hears this device\'s microphone. Off: this device never records and the phone uses its own microphone, or a headset or intercom paired to the phone, so the voice assistant still works. Needs Android 11 or newer on the phone.</string>
+    <string name="head_unit_microphone_off_info">The head unit microphone is off, so nothing below applies. Android Auto is told this device cannot record and is a motorcycle, which is what makes the phone record for itself. On Android 10 and older the phone forgets that between sessions and may stop connecting.</string>
     <string name="microphone_settings_description">Configure microphone input and audio processing.</string>
     <string name="mic_wire_format_info">Android Auto always receives the microphone at 16000 Hz, 16-bit, mono. It rejects anything else, so these settings change what the hardware does, not what the phone is sent.</string>
     <string name="mic_input_source">Microphone Input Source</string>
@@ -776,6 +776,11 @@
     <string name="vehicle_year_label">Year</string>
     <string name="vehicle_year_description">Vehicle year</string>
     <string name="vehicle_id_label">Vehicle ID</string>
+    <string name="vehicle_type_label">Vehicle Type</string>
+    <string name="vehicle_type_car">Car</string>
+    <string name="vehicle_type_truck">Truck</string>
+    <string name="vehicle_type_motorcycle">Motorcycle</string>
+    <string name="vehicle_type_forced_by_microphone">The head unit microphone is off, so Android Auto is told this is a motorcycle whatever is picked here. That is what makes the phone record for itself.</string>
     <string name="vehicle_id_description">Internal identifier only. Changing this will cause your phone to treat this as a different vehicle, resetting your Android Auto preferences for this car.</string>
     <string name="head_unit_make_label">Make</string>
     <string name="head_unit_make_description">Head unit manufacturer</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,7 +195,7 @@
     <string name="wifi">WiFi</string>
     <string name="dpi">Pixel density (DPI)</string>
     <string name="pixel_aspect_ratio">Pixel aspect ratio</string>
-    <string name="mic_sample_rate">Mic sample rate</string>
+    <string name="mic_sample_rate">Mic capture rate</string>
     <string name="keymap">Keymap</string>
     <string name="night_mode">Dark Mode (Android Auto)</string>
     <string name="night_mode_threshold">Night Mode Threshold</string>
@@ -503,6 +503,7 @@
     <string name="navigation_volume_offset">Navigation Volume Offset</string>
     <string name="microphone_settings">Microphone Settings</string>
     <string name="microphone_settings_description">Configure microphone input and audio processing.</string>
+    <string name="mic_wire_format_info">Android Auto always receives the microphone at 16000 Hz, 16-bit, mono. It rejects anything else, so these settings change what the hardware does, not what the phone is sent.</string>
     <string name="mic_input_source">Microphone Input Source</string>
     <string name="mic_input_source_description">Choose the audio source for the microphone.</string>
     <string-array name="mic_input_sources">
@@ -515,9 +516,9 @@
     <string name="mic_echo_canceler">Echo cancellation (AEC)</string>
     <string name="mic_echo_canceler_description">Attempts to remove echo from the microphone. Disable if you experience silence or distortion.</string>
     <string name="mic_noise_suppressor">Noise suppression (NS)</string>
-    <string name="mic_noise_suppressor_description">Attempts to reduce background noise. Disable if your voice sounds muffled.</string>
+    <string name="mic_noise_suppressor_description">Attempts to reduce background noise. Android Auto expects this off on a single microphone and does its own processing. Disable if your voice sounds muffled.</string>
     <string name="mic_auto_gain_control">Automatic gain control (AGC)</string>
-    <string name="mic_auto_gain_control_description">Automatically adjusts microphone volume. Disable if the volume is unstable.</string>
+    <string name="mic_auto_gain_control_description">Automatically adjusts microphone volume. Android Auto expects this off and applies its own gain control; the two together usually sound worse. Disable if the volume is unstable.</string>
     <string name="mic_feature_unsupported">This feature is not supported on your device.</string>
 
     <!-- Info Settings -->

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/LinkGapMonitorTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/LinkGapMonitorTest.kt
@@ -430,4 +430,41 @@ class LinkGapMonitorTest {
         assertTrue("a link this quiet must still print, got $reports", reports.isNotEmpty())
         assertTrue(reports.any { it.deadPercent > LinkGapMonitor.MAX_DEAD_PERCENT_MEDIA })
     }
+
+    @Test
+    fun `an expected silence is excluded without discarding the window`() {
+        // Android Auto stops the media sink for every assistant session and every pause. Counting
+        // those as outages read one measured window at 36% dead when all of it was a deliberate
+        // stop; resetting instead would restart the window on every cycle and report nothing.
+        val monitor = LinkGapMonitor(
+            LinkGapMonitor.SUBJECT_AUDIO,
+            LinkGapMonitor.MIN_GAPS_MEDIA,
+            LinkGapMonitor.MAX_DEAD_PERCENT_MEDIA
+        )
+        var now = 0L
+        monitor.onMessage(now)
+
+        // Two real gaps, measured.
+        now += 2_000; assertNull(monitor.onMessage(now))
+        now += 100; assertNull(monitor.onMessage(now))
+        now += 2_000; assertNull(monitor.onMessage(now))
+
+        // A fourteen-second sink stop, skipped.
+        now += 14_000
+        monitor.skipExpectedGap(now)
+
+        // The window still closes, and on live time rather than wall clock.
+        now += 100
+        var report: LinkGapMonitor.Report? = null
+        while (report == null && now < 120_000) {
+            now += 1_000
+            report = monitor.onMessage(now)
+        }
+        assertNotNull(report)
+        // The two real gaps survived the skip; the deliberate one was not counted.
+        assertEquals(2, report!!.gaps)
+        assertEquals(4_000L, report.deadMs)
+        // And the window is live time, so the skipped fourteen seconds are not diluting it.
+        assertTrue(report.windowMs < 30_000 + 14_000)
+    }
 }

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/MicUplinkFrameTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/MicUplinkFrameTest.kt
@@ -1,0 +1,108 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.protocol.Channel
+import com.andrerinas.openheadunit.aap.protocol.MsgType
+import com.andrerinas.openheadunit.aap.protocol.proto.Media
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The record of the microphone frame's layout, and of the one rule it kept breaking: flags 0x0b
+ * promises a 2-byte message type and the uplink never wrote one.
+ */
+class MicUplinkFrameTest {
+
+    private val pcm = byteArrayOf(
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x78.toByte()
+    )
+
+    private fun build(timestampUs: Long = 1L, data: ByteArray = pcm): Pair<ByteArray, Int> {
+        val into = ByteArray(MicUplinkFrame.size(data.size))
+        val length = MicUplinkFrame.build(timestampUs, data, 0, data.size, into)
+        return into to length
+    }
+
+    @Test
+    fun `a frame is the payload plus fourteen bytes`() {
+        // Two more than dc039351 wrote and four more than 42fcd389: both omitted the message type.
+        assertEquals(14, MicUplinkFrame.size(0))
+        assertEquals(4110, MicUplinkFrame.size(4096))
+        assertEquals(MicUplinkFrame.size(pcm.size), build().second)
+    }
+
+    @Test
+    fun `the offsets agree with the message the transport builds around them`() {
+        assertEquals(AapMessage.HEADER_SIZE, MicUplinkFrame.HEADER_SIZE)
+        assertEquals(MsgType.SIZE, MicUplinkFrame.TYPE_SIZE)
+        assertEquals(AapMessage.HEADER_SIZE + MsgType.SIZE, MicUplinkFrame.TIMESTAMP_OFFSET)
+    }
+
+    @Test
+    fun `the header names the channel and promises a message type`() {
+        val (frame, _) = build()
+        assertEquals(Channel.ID_MIC.toByte(), frame[0])
+        assertEquals(0x0b.toByte(), frame[1])
+        // The whole bug in one assertion: this flag byte is what obliges the frame to carry a type.
+        assertTrue(AapMessageFraming.carriesMessageType(frame[1].toInt()))
+    }
+
+    @Test
+    fun `the length field is left for the encrypt step`() {
+        // sendEncryptedMessage writes the ciphertext length here; anything we put would be lost.
+        val (frame, _) = build()
+        assertEquals(0, frame[2].toInt())
+        assertEquals(0, frame[3].toInt())
+    }
+
+    @Test
+    fun `the message type is the first thing the phone decrypts`() {
+        val (frame, _) = build()
+        val type = ((frame[4].toInt() and 0xFF) shl 8) or (frame[5].toInt() and 0xFF)
+        assertEquals(Media.MsgType.MEDIA_MESSAGE_DATA_VALUE, type)
+    }
+
+    @Test
+    fun `the timestamp is eight big-endian bytes and survives a non-zero top byte`() {
+        // The regression guard. Both historical layouts shifted these bytes, which went unnoticed
+        // because a millisecond elapsedRealtime never fills the top two.
+        val (frame, _) = build(timestampUs = 0x0102030405060708L)
+        assertArrayEquals(
+            byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08),
+            frame.copyOfRange(MicUplinkFrame.TIMESTAMP_OFFSET, MicUplinkFrame.PCM_OFFSET)
+        )
+    }
+
+    @Test
+    fun `every PCM byte survives, including the first sample`() {
+        // dc039351 fed the phone's timestamp read the first sample; 42fcd389 fed it the first two.
+        val (frame, length) = build()
+        assertArrayEquals(pcm, frame.copyOfRange(MicUplinkFrame.PCM_OFFSET, length))
+    }
+
+    @Test
+    fun `a slice of a reused capture buffer is copied, not the whole buffer`() {
+        val reused = byteArrayOf(-1, -1, 0x0a, 0x0b, 0x0c, 0x0d, -1, -1)
+        val into = ByteArray(MicUplinkFrame.size(4))
+        val length = MicUplinkFrame.build(1L, reused, 2, 4, into)
+        assertArrayEquals(
+            byteArrayOf(0x0a, 0x0b, 0x0c, 0x0d),
+            into.copyOfRange(MicUplinkFrame.PCM_OFFSET, length)
+        )
+    }
+
+    @Test
+    fun `the phone reads it back with the rules this app uses inbound`() {
+        // The tie between the sender and the receiver we already trust. AapMessageIncoming takes
+        // the type from payload offset 0 and AapAudio.process takes media data from offset 10.
+        val (frame, length) = build(timestampUs = 987_654_321L)
+        val payload = frame.copyOfRange(MicUplinkFrame.HEADER_SIZE, length)
+
+        // Decoded here rather than through Utils.bytesToInt, which drags AppLog and android.util.Log
+        // into a JVM test; the arithmetic is that method's, two bytes big-endian.
+        val type = ((payload[0].toInt() and 0xFF) shl 8) or (payload[1].toInt() and 0xFF)
+        assertEquals(Media.MsgType.MEDIA_MESSAGE_DATA_VALUE, type)
+        assertArrayEquals(pcm, payload.copyOfRange(10, payload.size))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/MicUplinkMonitorTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/MicUplinkMonitorTest.kt
@@ -1,0 +1,108 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** A replayed microphone session, which is the only way to measure one without a head unit. */
+class MicUplinkMonitorTest {
+
+    private val monitor = MicUplinkMonitor()
+
+    /** Feed [seconds] of audio at exactly the announced rate, in 4096-byte frames. */
+    private fun feedNominal(seconds: Int, peak: Int = 1000) {
+        val framesPerSecond = MicUplinkMonitor.BYTES_PER_SECOND / 4096.0
+        val frames = (framesPerSecond * seconds).toInt()
+        val stepMs = (1000L * seconds) / frames
+        for (i in 0 until frames) monitor.onFrame(4096, peak, i * stepMs)
+    }
+
+    @Test
+    fun `a session with no frames says nothing`() {
+        // Which is itself the finding: the phone asked for the microphone and nothing left.
+        assertFalse(monitor.isOpen)
+        assertNull(monitor.onSessionEnd(1_000L))
+    }
+
+    @Test
+    fun `the first frame opens the session and only the first`() {
+        assertTrue(monitor.onFrame(1280, 500, 0L))
+        assertFalse(monitor.onFrame(1280, 500, 40L))
+        assertTrue(monitor.isOpen)
+    }
+
+    @Test
+    fun `a session at the announced rate scores about a hundred percent`() {
+        feedNominal(seconds = 4)
+        val report = monitor.onSessionEnd(4_000L)!!
+        assertTrue("was ${report.percentOfExpected}%", report.percentOfExpected in 95..105)
+    }
+
+    @Test
+    fun `a session at half the byte rate scores about half`() {
+        // 16000 bytes over one second against a 32000 bytes-per-second budget.
+        for (i in 0 until 10) monitor.onFrame(1600, 900, i * 100L)
+        val report = monitor.onSessionEnd(1_000L)!!
+        assertTrue("was ${report.percentOfExpected}%", report.percentOfExpected in 45..55)
+    }
+
+    @Test
+    fun `the report carries the loudest sample and the frame extremes`() {
+        monitor.onFrame(1280, 12, 0L)
+        monitor.onFrame(4096, 8214, 100L)
+        monitor.onFrame(2048, 300, 200L)
+        val report = monitor.onSessionEnd(300L)!!
+        assertEquals(3, report.frames)
+        assertEquals(1280L + 4096L + 2048L, report.bytes)
+        assertEquals(8214, report.peak)
+        assertEquals(4096, report.largest)
+        assertEquals(1280, report.smallest)
+    }
+
+    @Test
+    fun `a silent microphone reports a zero peak rather than nothing`() {
+        feedNominal(seconds = 2, peak = 0)
+        val report = monitor.onSessionEnd(2_000L)!!
+        assertEquals(0, report.peak)
+        assertTrue(report.frames > 0)
+    }
+
+    @Test
+    fun `acks are only counted while a session is open`() {
+        monitor.onAck()
+        monitor.onFrame(4096, 100, 0L)
+        monitor.onAck()
+        monitor.onAck()
+        assertEquals(2, monitor.onSessionEnd(200L)!!.acks)
+    }
+
+    @Test
+    fun `a session that ends leaves nothing behind for the next one`() {
+        // The transport outlives a session and is re-armed, so every field has to be restored.
+        monitor.onFrame(4096, 9999, 0L)
+        monitor.onSessionEnd(200L)
+        assertFalse(monitor.isOpen)
+
+        monitor.onFrame(1280, 5, 1_000L)
+        val second = monitor.onSessionEnd(1_100L)!!
+        assertEquals(1, second.frames)
+        assertEquals(5, second.peak)
+        assertEquals(100L, second.elapsedMs)
+    }
+
+    @Test
+    fun `reset abandons an open session`() {
+        monitor.onFrame(4096, 100, 0L)
+        monitor.reset()
+        assertFalse(monitor.isOpen)
+        assertNull(monitor.onSessionEnd(500L))
+    }
+
+    @Test
+    fun `a zero-length session reports an unknown percentage rather than dividing by zero`() {
+        monitor.onFrame(4096, 100, 500L)
+        assertEquals(-1, monitor.onSessionEnd(500L)!!.percentOfExpected)
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/VehicleIdentityPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/VehicleIdentityPolicyTest.kt
@@ -1,0 +1,35 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/** One announced id per vehicle type, so the phone records each type under its own entry. */
+class VehicleIdentityPolicyTest {
+
+    @Test
+    fun `a car announces the id the user set`() {
+        assertEquals("hu-1", VehicleIdentityPolicy.vehicleId("hu-1", VehicleTypePolicy.CAR))
+    }
+
+    @Test
+    fun `every type announces a different id`() {
+        val ids = VehicleTypePolicy.SELECTABLE.map { VehicleIdentityPolicy.vehicleId("hu-1", it) }
+        assertEquals(ids.size, ids.toSet().size)
+    }
+
+    @Test
+    fun `the id is stable, so each type is recorded once and reconnects cleanly`() {
+        val first = VehicleIdentityPolicy.vehicleId("hu-1", VehicleTypePolicy.MOTORCYCLE)
+        assertEquals(first, VehicleIdentityPolicy.vehicleId("hu-1", VehicleTypePolicy.MOTORCYCLE))
+        assertNotEquals(first, VehicleIdentityPolicy.vehicleId("hu-1", VehicleTypePolicy.CAR))
+    }
+
+    @Test
+    fun `a different base id stays different`() {
+        assertNotEquals(
+            VehicleIdentityPolicy.vehicleId("hu-1", VehicleTypePolicy.TRUCK),
+            VehicleIdentityPolicy.vehicleId("hu-2", VehicleTypePolicy.TRUCK)
+        )
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/VehicleTypePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/VehicleTypePolicyTest.kt
@@ -1,0 +1,47 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Which vehicle this head unit claims to be, and why the microphone setting can override the user. */
+class VehicleTypePolicyTest {
+
+    @Test
+    fun `a head unit that records announces what the user picked`() {
+        assertEquals(VehicleTypePolicy.CAR, VehicleTypePolicy.vehicleType(VehicleTypePolicy.CAR, true))
+        assertEquals(VehicleTypePolicy.TRUCK, VehicleTypePolicy.vehicleType(VehicleTypePolicy.TRUCK, true))
+        assertEquals(VehicleTypePolicy.MOTORCYCLE, VehicleTypePolicy.vehicleType(VehicleTypePolicy.MOTORCYCLE, true))
+    }
+
+    @Test
+    fun `a head unit that will not record claims to be a motorcycle whatever the user picked`() {
+        // Any other claim is refused by the phone once the microphone service is withheld.
+        assertEquals(VehicleTypePolicy.MOTORCYCLE, VehicleTypePolicy.vehicleType(VehicleTypePolicy.CAR, false))
+        assertEquals(VehicleTypePolicy.MOTORCYCLE, VehicleTypePolicy.vehicleType(VehicleTypePolicy.TRUCK, false))
+    }
+
+    @Test
+    fun `a stored value that is not one of ours reads as a car`() {
+        assertEquals(VehicleTypePolicy.CAR, VehicleTypePolicy.sanitised(0))
+        assertEquals(VehicleTypePolicy.CAR, VehicleTypePolicy.sanitised(9))
+        assertEquals(VehicleTypePolicy.CAR, VehicleTypePolicy.vehicleType(0, true))
+    }
+
+    @Test
+    fun `the picker maps both ways`() {
+        VehicleTypePolicy.SELECTABLE.forEachIndexed { index, type ->
+            assertEquals(index, VehicleTypePolicy.indexOf(type))
+            assertEquals(type, VehicleTypePolicy.atIndex(index))
+        }
+        assertEquals(VehicleTypePolicy.CAR, VehicleTypePolicy.atIndex(-1))
+        assertEquals(VehicleTypePolicy.CAR, VehicleTypePolicy.atIndex(3))
+    }
+
+    @Test
+    fun `the numbers are Android Auto's own`() {
+        // Its enum is UNSPECIFIED, CAR, TRUCK, MOTORCYCLE. An absent field reads as a car, measured.
+        assertEquals(1, VehicleTypePolicy.CAR)
+        assertEquals(2, VehicleTypePolicy.TRUCK)
+        assertEquals(3, VehicleTypePolicy.MOTORCYCLE)
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/app/ForegroundServiceTypePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/app/ForegroundServiceTypePolicyTest.kt
@@ -1,0 +1,77 @@
+package com.andrerinas.openheadunit.app
+
+import android.content.pm.ServiceInfo
+import android.os.Build
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The two rules: what the service starts with, and what it adds while capturing.
+ *
+ * The one that matters is the first. The microphone type is while-in-use, so a background start
+ * that claims it is refused even with the permission granted, and this service starts from boot,
+ * USB and Bluetooth receivers where a refusal means no session at all.
+ */
+class ForegroundServiceTypePolicyTest {
+
+    private val u = Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+
+    private val base = ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE or
+        ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+
+    private val mic = ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+
+    // --- what the service starts with ---
+
+    @Test
+    fun `the start never claims the microphone type, whatever the permission and the setting say`() {
+        assertEquals(base, ForegroundServiceTypePolicy.baseTypeMask(u))
+    }
+
+    @Test
+    fun `before Q the start takes no types at all`() {
+        assertEquals(0, ForegroundServiceTypePolicy.baseTypeMask(Build.VERSION_CODES.P))
+    }
+
+    // --- what it adds while capturing ---
+
+    @Test
+    fun `capture claims the microphone type with the permission and the setting`() {
+        assertEquals(base or mic, ForegroundServiceTypePolicy.withMicrophone(u, true, true))
+    }
+
+    @Test
+    fun `a denied permission never claims it`() {
+        assertEquals(base, ForegroundServiceTypePolicy.withMicrophone(u, false, true))
+    }
+
+    @Test
+    fun `a head unit that hands the microphone to the phone never claims it`() {
+        assertEquals(base, ForegroundServiceTypePolicy.withMicrophone(u, true, false))
+    }
+
+    @Test
+    fun `neither claims it`() {
+        assertEquals(base, ForegroundServiceTypePolicy.withMicrophone(u, false, false))
+    }
+
+    @Test
+    fun `before Q capture takes no types either`() {
+        assertEquals(0, ForegroundServiceTypePolicy.withMicrophone(
+            Build.VERSION_CODES.P, true, true))
+    }
+
+    // --- the relationship between the two ---
+
+    @Test
+    fun `capture only ever adds to the start mask, never removes from it`() {
+        for (granted in listOf(true, false)) {
+            for (enabled in listOf(true, false)) {
+                val withMic = ForegroundServiceTypePolicy.withMicrophone(u, granted, enabled)
+                assertEquals(
+                    "withMicrophone($granted, $enabled) dropped a type the start had",
+                    base, withMic and base)
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/audio/AudioPrerollPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/audio/AudioPrerollPolicyTest.kt
@@ -1,0 +1,104 @@
+package com.andrerinas.openheadunit.decoder.audio
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the target on both a deep and a shallow buffer, and the two ways the wait must end early: a
+ * stream too short to reach the target, and a chunk whose write would deadlock the thread that
+ * starts playback.
+ */
+class AudioPrerollPolicyTest {
+
+    private val mediaRate = 48_000
+    private val speechRate = 16_000
+
+    /** 48 kHz stereo, the multiplier-8 media buffer measured on the reporter's unit. */
+    private val mediaBufferFrames = 33_536
+
+    @Test
+    fun `the target is the time ceiling on an ordinarily deep buffer`() {
+        // 48000 * 200ms = 9600 frames, well inside three quarters of 33536.
+        assertEquals(9_600, AudioPrerollPolicy.targetFrames(mediaRate, mediaBufferFrames))
+    }
+
+    @Test
+    fun `a shallow buffer caps the target below the time ceiling`() {
+        // Multiplier 1 at 16 kHz mono: 1408 frames. The time ceiling of 3200 exceeds the track, so
+        // the fill share has to win or the target is unreachable.
+        val target = AudioPrerollPolicy.targetFrames(speechRate, 1_408)
+        assertEquals(1_056, target)
+        assertTrue(target < 1_408)
+    }
+
+    @Test
+    fun `the target always leaves room for the write that triggers it`() {
+        // The write that starts playback must still fit. A target at capacity would block in
+        // write() waiting for room only play() can make, from the same thread.
+        for (frames in intArrayOf(64, 512, 1_408, 4_192, 33_536)) {
+            val target = AudioPrerollPolicy.targetFrames(mediaRate, frames)
+            assertTrue("target $target must stay under capacity $frames", target < frames)
+        }
+    }
+
+    @Test
+    fun `a nonsense capacity still yields a playable target`() {
+        assertTrue(AudioPrerollPolicy.targetFrames(mediaRate, 0) > 0)
+        assertTrue(AudioPrerollPolicy.targetFrames(mediaRate, -1) > 0)
+        assertTrue(AudioPrerollPolicy.targetFrames(0, mediaBufferFrames) > 0)
+    }
+
+    @Test
+    fun `an empty track does not start`() {
+        // The whole point: this is the state that underran on every media start.
+        assertFalse(AudioPrerollPolicy.shouldStart(0, 0, 9_600, 0))
+    }
+
+    @Test
+    fun `a partly filled track does not start before its target`() {
+        assertFalse(AudioPrerollPolicy.shouldStart(9_000, 0, 9_600, 10))
+    }
+
+    @Test
+    fun `reaching the target starts playback`() {
+        assertTrue(AudioPrerollPolicy.shouldStart(9_600, 0, 9_600, 10))
+    }
+
+    @Test
+    fun `the pending chunk counts toward the target`() {
+        // Decided before the write, so the frames about to land are part of the decision.
+        assertFalse(AudioPrerollPolicy.shouldStart(9_000, 0, 9_600, 10))
+        assertTrue(AudioPrerollPolicy.shouldStart(9_000, 600, 9_600, 10))
+    }
+
+    @Test
+    fun `a stream too short for the target starts on the deadline`() {
+        // A notification blip can be the whole message; waiting for an unreachable target would
+        // silence it.
+        assertFalse(AudioPrerollPolicy.shouldStart(500, 0, 9_600, AudioPrerollPolicy.MAX_WAIT_MS - 1))
+        assertTrue(AudioPrerollPolicy.shouldStart(500, 0, 9_600, AudioPrerollPolicy.MAX_WAIT_MS))
+    }
+
+    @Test
+    fun `the deadline never starts a track nothing has been written to`() {
+        // A stream that has not begun, not a short one. Starting here reintroduces the bug.
+        assertFalse(AudioPrerollPolicy.shouldStart(0, 0, 9_600, AudioPrerollPolicy.MAX_WAIT_MS * 10))
+    }
+
+    @Test
+    fun `an ordinary stream reaches its target by fill and not by deadline`() {
+        // Audio arrives at real time, so the target takes its own worth of wall clock. A deadline
+        // inside that would decide every start and the banked depth would be arbitrary.
+        assertTrue(AudioPrerollPolicy.MAX_WAIT_MS > AudioPrerollPolicy.TARGET_MS)
+    }
+
+    @Test
+    fun `the banked depth is what the latency multiplier was asked to buy`() {
+        // Below the ~87 ms device minimum the setting cannot cushion anything.
+        assertTrue(AudioPrerollPolicy.TARGET_MS > 87)
+        // Above ~250 ms a resume stops feeling attached to the press that caused it.
+        assertTrue(AudioPrerollPolicy.TARGET_MS <= 250)
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/audio/MicCaptureRatePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/audio/MicCaptureRatePolicyTest.kt
@@ -1,0 +1,62 @@
+package com.andrerinas.openheadunit.decoder.audio
+
+import com.andrerinas.openheadunit.aap.protocol.MicCaptureFormat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Which rate the microphone opens at, given that only 16 kHz ever reaches the phone. */
+class MicCaptureRatePolicyTest {
+
+    /** A device that supports exactly the rates listed. */
+    private fun device(vararg supported: Int): (Int) -> Int =
+        { rate -> if (rate in supported) rate / 8 else -2 }
+
+    @Test
+    fun `the announced rate is preferred and needs no conversion`() {
+        val decision = MicCaptureRatePolicy.decide(48000, device(16000, 44100, 48000))!!
+        assertEquals(MicCaptureFormat.SAMPLE_RATE_HZ, decision.captureRateHz)
+        assertTrue(decision.isDirect)
+        assertEquals(1, decision.decimationFactor)
+    }
+
+    @Test
+    fun `a device that refuses 16 kHz falls back and converts three to one`() {
+        val decision = MicCaptureRatePolicy.decide(48000, device(48000))!!
+        assertEquals(48000, decision.captureRateHz)
+        assertEquals(3, decision.decimationFactor)
+        assertEquals(48000 / 8, decision.minBufferSize)
+    }
+
+    @Test
+    fun `the fallback is taken even when the setting names something else`() {
+        // The setting is a preference, not a licence: only whole multiples of 16 kHz are usable.
+        val decision = MicCaptureRatePolicy.decide(16000, device(48000))!!
+        assertEquals(48000, decision.captureRateHz)
+    }
+
+    @Test
+    fun `a rate that is not a whole multiple is never chosen`() {
+        // 44100 to 16000 would need a low-pass filter, which is why the picker no longer offers it.
+        assertNull(MicCaptureRatePolicy.decide(44100, device(44100)))
+    }
+
+    @Test
+    fun `a rate below the announced one is never chosen`() {
+        // 8000 was in the old picker and could only ever have sent half-speed audio.
+        assertNull(MicCaptureRatePolicy.decide(8000, device(8000)))
+    }
+
+    @Test
+    fun `a device that opens nothing usable has no microphone`() {
+        assertNull(MicCaptureRatePolicy.decide(48000, device()))
+    }
+
+    @Test
+    fun `the announced rate is probed before anything else`() {
+        val probed = mutableListOf<Int>()
+        MicCaptureRatePolicy.decide(48000) { rate -> probed.add(rate); rate / 8 }
+        assertEquals(listOf(MicCaptureFormat.SAMPLE_RATE_HZ), probed)
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/audio/MicChunkAccumulatorTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/audio/MicChunkAccumulatorTest.kt
@@ -1,0 +1,127 @@
+package com.andrerinas.openheadunit.decoder.audio
+
+import com.andrerinas.openheadunit.aap.protocol.MicCaptureFormat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Driven by the read sizes reporter logs actually showed - 640 and 768 frames - because those are
+ * the sizes that never lined up with the 2048 the protocol asks for.
+ */
+class MicChunkAccumulatorTest {
+
+    private val accumulator = MicChunkAccumulator()
+
+    private class Emitted(val bytes: ByteArray, val timestampUs: Long, val peak: Int)
+
+    private val emitted = mutableListOf<Emitted>()
+
+    private fun offer(src: ByteArray, capturedAtUs: Long = 0L, peak: Int = 0) {
+        accumulator.offer(src, src.size, capturedAtUs, peak) { chunk, length, tsUs, chunkPeak ->
+            emitted.add(Emitted(chunk.copyOf(length), tsUs, chunkPeak))
+        }
+    }
+
+    private fun read(bytes: Int, fill: Byte = 7) = ByteArray(bytes) { fill }
+
+    @Test
+    fun `640-frame reads still produce whole messages`() {
+        repeat(16) { offer(read(1280)) }
+        assertEquals(5, emitted.size)
+        assertTrue(emitted.all { it.bytes.size == MicCaptureFormat.CHUNK_BYTES })
+        assertEquals(20480 - 5 * 4096, accumulator.residueBytes)
+    }
+
+    @Test
+    fun `768-frame reads still produce whole messages`() {
+        repeat(8) { offer(read(1536)) }
+        assertEquals(3, emitted.size)
+        assertTrue(emitted.all { it.bytes.size == MicCaptureFormat.CHUNK_BYTES })
+        assertEquals(12288 - 3 * 4096, accumulator.residueBytes)
+    }
+
+    @Test
+    fun `a read larger than a chunk emits more than one`() {
+        offer(read(9000))
+        assertEquals(2, emitted.size)
+        assertEquals(9000 - 2 * 4096, accumulator.residueBytes)
+    }
+
+    @Test
+    fun `a short read is held, not dropped`() {
+        // The old sender discarded anything of 64 bytes or fewer outright, which made a short read
+        // a hole in the audio rather than a wait.
+        offer(read(48))
+        assertEquals(0, emitted.size)
+        assertEquals(48, accumulator.residueBytes)
+    }
+
+    @Test
+    fun `nothing is lost and nothing is duplicated`() {
+        // The assertion that says the drop is really gone: everything fed comes back out, in order.
+        val fed = ByteArray(4096 * 3 + 700) { (it % 251).toByte() }
+        var offset = 0
+        while (offset < fed.size) {
+            val len = minOf(1280, fed.size - offset)
+            accumulator.offer(fed.copyOfRange(offset, offset + len), len, 0L, 0) { chunk, length, _, _ ->
+                emitted.add(Emitted(chunk.copyOf(length), 0L, 0))
+            }
+            offset += len
+        }
+        val reassembled = emitted.fold(ByteArray(0)) { acc, e -> acc + e.bytes }
+        assertArrayEquals(fed.copyOfRange(0, reassembled.size), reassembled)
+        assertEquals(fed.size, reassembled.size + accumulator.residueBytes)
+    }
+
+    @Test
+    fun `a chunk is stamped when its first byte was captured, not when it completed`() {
+        // A chunk is 128 ms long; stamping at the end would put every message that far out.
+        offer(read(1280), capturedAtUs = 1_000_000L)
+        offer(read(1280), capturedAtUs = 1_040_000L)
+        offer(read(1280), capturedAtUs = 1_080_000L)
+        offer(read(1280), capturedAtUs = 1_120_000L)
+        assertEquals(1, emitted.size)
+        assertEquals(1_000_000L, emitted[0].timestampUs)
+    }
+
+    @Test
+    fun `a chunk starting mid-read is stamped from inside that read`() {
+        offer(read(8192), capturedAtUs = 0L)
+        assertEquals(2, emitted.size)
+        assertEquals(0L, emitted[0].timestampUs)
+        // 4096 bytes at 32000 bytes per second is 128 ms.
+        assertEquals(128_000L, emitted[1].timestampUs)
+    }
+
+    @Test
+    fun `a chunk carries the loudest read that fed it`() {
+        offer(read(1280), peak = 10)
+        offer(read(1280), peak = 9000)
+        offer(read(1280), peak = 40)
+        offer(read(1280), peak = 12)
+        assertEquals(9000, emitted[0].peak)
+    }
+
+    @Test
+    fun `the peak does not leak into the next chunk`() {
+        offer(read(4096), peak = 30000)
+        offer(read(4096), peak = 5)
+        assertEquals(30000, emitted[0].peak)
+        assertEquals(5, emitted[1].peak)
+    }
+
+    @Test
+    fun `reset reports the tail it drops and starts clean`() {
+        // Discarded, never padded: zero padding would inject silence the microphone never heard.
+        offer(read(1280))
+        assertEquals(1280, accumulator.reset())
+        assertEquals(0, accumulator.residueBytes)
+        assertEquals(0, accumulator.reset())
+
+        offer(read(4096), capturedAtUs = 500L)
+        assertEquals(1, emitted.size)
+        assertEquals(500L, emitted[0].timestampUs)
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/audio/MicPcmDecimatorTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/audio/MicPcmDecimatorTest.kt
@@ -1,0 +1,104 @@
+package com.andrerinas.openheadunit.decoder.audio
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** The 48 kHz fallback's conversion, on mono 16-bit little-endian PCM. */
+class MicPcmDecimatorTest {
+
+    private fun pcm(vararg samples: Int): ByteArray {
+        val out = ByteArray(samples.size * 2)
+        samples.forEachIndexed { i, s ->
+            out[i * 2] = (s and 0xFF).toByte()
+            out[i * 2 + 1] = ((s shr 8) and 0xFF).toByte()
+        }
+        return out
+    }
+
+    private fun samples(buf: ByteArray, len: Int): List<Int> =
+        (0 until len step 2).map {
+            ((buf[it + 1].toInt() shl 8) or (buf[it].toInt() and 0xFF)).toShort().toInt()
+        }
+
+    @Test
+    fun `three samples become their mean`() {
+        val decimator = MicPcmDecimator(3)
+        val src = pcm(30, 60, 90, -30, -60, -90)
+        val dst = ByteArray(decimator.outputCapacity(src.size))
+        val len = decimator.decimate(src, src.size, dst)
+        assertEquals(listOf(60, -60), samples(dst, len))
+    }
+
+    @Test
+    fun `a partial group is carried into the next read`() {
+        // The reason this is stateful: a read is not a whole number of groups, and dropping the
+        // tail would lose a sample at every read boundary.
+        val decimator = MicPcmDecimator(3)
+        val dst = ByteArray(64)
+
+        val first = pcm(30, 60)
+        assertEquals(0, decimator.decimate(first, first.size, dst))
+
+        val second = pcm(90, 300)
+        val len = decimator.decimate(second, second.size, dst)
+        assertEquals(listOf(60), samples(dst, len))
+    }
+
+    @Test
+    fun `the whole stream is preserved across many reads`() {
+        val decimator = MicPcmDecimator(3)
+        val dst = ByteArray(4096)
+        val produced = mutableListOf<Int>()
+        // 300 samples fed in reads of 7, which never aligns with a group of 3.
+        var next = 0
+        while (next < 300) {
+            val count = minOf(7, 300 - next)
+            val src = pcm(*IntArray(count) { 3 }) // every sample the same, so every mean is 3
+            next += count
+            val len = decimator.decimate(src, src.size, dst)
+            produced.addAll(samples(dst, len))
+        }
+        assertEquals(100, produced.size)
+        assertEquals(List(100) { 3 }, produced)
+    }
+
+    @Test
+    fun `an odd trailing byte is not read as a sample`() {
+        val decimator = MicPcmDecimator(3)
+        val src = pcm(10, 20, 30) + byteArrayOf(0x7f)
+        val dst = ByteArray(32)
+        val len = decimator.decimate(src, src.size, dst)
+        assertEquals(listOf(20), samples(dst, len))
+    }
+
+    @Test
+    fun `reset drops the partial group so the next session starts aligned`() {
+        val decimator = MicPcmDecimator(3)
+        val dst = ByteArray(32)
+        val leading = pcm(1000, 1000)
+        decimator.decimate(leading, leading.size, dst)
+        decimator.reset()
+
+        val src = pcm(30, 60, 90)
+        val len = decimator.decimate(src, src.size, dst)
+        assertEquals(listOf(60), samples(dst, len))
+    }
+
+    @Test
+    fun `a factor of one passes every sample through`() {
+        val decimator = MicPcmDecimator(1)
+        val src = pcm(1, -1, 32767, -32768)
+        val dst = ByteArray(decimator.outputCapacity(src.size))
+        val len = decimator.decimate(src, src.size, dst)
+        assertEquals(listOf(1, -1, 32767, -32768), samples(dst, len))
+    }
+
+    @Test
+    fun `the output buffer is large enough for the largest read`() {
+        val decimator = MicPcmDecimator(3)
+        val src = pcm(*IntArray(1536) { 100 })
+        val dst = ByteArray(decimator.outputCapacity(src.size))
+        val len = decimator.decimate(src, src.size, dst)
+        assertEquals(1536 / 3 * 2, len)
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/audio/MicrophonePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/audio/MicrophonePolicyTest.kt
@@ -1,0 +1,36 @@
+package com.andrerinas.openheadunit.decoder.audio
+
+import com.andrerinas.openheadunit.decoder.audio.MicrophonePolicy.Decline
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** The four combinations, and which of them is a fault. */
+class MicrophonePolicyTest {
+
+    @Test
+    fun `a working microphone the user wants is used`() {
+        assertEquals(Decline.NONE, MicrophonePolicy.declineReason(true, true))
+        assertTrue(MicrophonePolicy.shouldCapture(true, true))
+    }
+
+    @Test
+    fun `the setting wins over a working microphone`() {
+        assertEquals(Decline.USER_SETTING, MicrophonePolicy.declineReason(false, true))
+        assertFalse(MicrophonePolicy.shouldCapture(false, true))
+    }
+
+    @Test
+    fun `a device with no usable capture declines for its own reason`() {
+        assertEquals(Decline.NO_MICROPHONE, MicrophonePolicy.declineReason(true, false))
+        assertFalse(MicrophonePolicy.shouldCapture(true, false))
+    }
+
+    @Test
+    fun `the setting is reported ahead of the hardware`() {
+        // Both are true at once on a device with no microphone whose owner also turned it off. The
+        // setting is the one the user can act on, so it is the one named.
+        assertEquals(Decline.USER_SETTING, MicrophonePolicy.declineReason(false, false))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/utils/BluetoothAddressSeedPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/utils/BluetoothAddressSeedPolicyTest.kt
@@ -1,0 +1,27 @@
+package com.andrerinas.openheadunit.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BluetoothAddressSeedPolicyTest {
+
+    @Test
+    fun `a blank field takes the detected address`() {
+        assertEquals("AA:BB:CC:DD:EE:FF", BluetoothAddressSeedPolicy.seed("", "AA:BB:CC:DD:EE:FF"))
+        assertEquals("AA:BB:CC:DD:EE:FF", BluetoothAddressSeedPolicy.seed(null, "AA:BB:CC:DD:EE:FF"))
+        assertEquals("AA:BB:CC:DD:EE:FF", BluetoothAddressSeedPolicy.seed("   ", "AA:BB:CC:DD:EE:FF"))
+    }
+
+    @Test
+    fun `what the user typed is never overwritten`() {
+        // A hand-entered address is usually there because the detected one was wrong.
+        assertEquals("11:22:33:44:55:66",
+            BluetoothAddressSeedPolicy.seed("11:22:33:44:55:66", "AA:BB:CC:DD:EE:FF"))
+    }
+
+    @Test
+    fun `nothing detected leaves the field blank`() {
+        assertEquals("", BluetoothAddressSeedPolicy.seed("", null))
+        assertEquals("", BluetoothAddressSeedPolicy.seed(null, null))
+    }
+}


### PR DESCRIPTION
Stacked on #905, so it shows those three commits too until that one merges. The five below are this PR's.

## What this does

- Fixes the microphone uplink, which has never been quite right: the message carried no type byte, so the phone read our timestamp's leading zeros as one and started every session's audio a sample late. The announced sample rate and the rate we actually captured at could also disagree, which handed the phone 48 kHz audio under a 16 kHz declaration.
- Answers `MicrophoneRequest` and honours a stop, neither of which happened before, and sends whole 2048-frame messages instead of whatever `AudioRecord` handed back.
- Adds a **Head unit microphone** switch. Turned off, this device never opens its microphone and Android Auto uses the phone's own, or a headset or intercom paired to the phone. That is what a motorcycle rider with a helmet intercom needs, and what someone running Self Mode on a phone with a better microphone than the head unit wants.
- Making that work means announcing the vehicle as a **motorcycle** while the switch is off. Android Auto picks its recorder once, at projection start, and takes the phone's own only when the head unit says motorcycle. Nothing sent later can move that choice. So the switch drives the claim, and a banner on the settings screen says so.
- Adds a Car / Truck / Motorcycle picker in Vehicle Information, since the vehicle type is now sent either way.
- **Needs Android 11 or newer on the phone.** Android 10 and older never store the vehicle type, so the claim survives the first session only. Stated in the settings copy and in the log.
- Also here because they sit in the same files: the audio track is filled before playback starts rather than after, the teardown drain can actually finish, the microphone foreground-service type is claimed only while capture is open, and the Bluetooth address is filled in from hardware instead of waiting to be typed.

## Issues

- **Closes #818** (Use phone/Bluetooth mic when Audio Sink is disabled). This is the requested feature, and the exact topology it describes, an intercom paired to the phone, was measured working on hardware.
- **Finishes #776.** That PR moved the mic timestamp to byte 4 so the SSL layer stopped eating it. The message type was still never written, so the phone read the timestamp's two leading zero bytes as the type and consumed a PCM sample as timestamp. Same packet, the other half.
- **Helps #784** (Option to disable mic capture during handshake). The mechanism it asks for does not exist, since nothing opens the microphone until the phone sends a `MicrophoneRequest`, but the symptom is real and the switch here is what addresses it. Which half helps depends on where their intercom is paired, and they have not said.
- **May help #270** (microphone not working). The announced rate and the captured rate could disagree, `MicrophoneRequest` was never answered, and short reads were dropped silently. Any of the three fits a microphone that does nothing, but their log has not been re-read against this build.
- **May help #503** (Bluetooth headset mic not working for the assistant, in Self Mode). Turning the switch off leaves the recorder to the phone, which is where their earbuds are paired. Closed, and not retested.

## Verification

- `./gradlew :app:testGithubDebugUnitTest`: **943 tests, 0 failures**.
- Measured on hardware, UNISOC MT50 head unit with a Motorola edge 30 neo, Android Auto 17.5.663204, without ever forgetting the car on the phone. With the switch off the session forms, the recorder moves to the phone and the assistant answers through a helmet intercom. With it back on the head unit microphone works as before.
- Android Auto's own behaviour here was read out of its bytecode, not guessed: one recorder decision site, one strict test against the motorcycle vehicle type, and no other route to the phone microphone.
