### PR TITLE
Native AA: unwedge WiFi Direct group creation on pre-Android-10, and record when no hotspot is up

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pStateChangePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pStateChangePolicy.kt
@@ -1,0 +1,37 @@
+package com.andrerinas.openheadunit.connection.wifi.direct
+
+/**
+ * Whether a `WIFI_P2P_STATE_CHANGED_ACTION` broadcast is the platform reporting something, or this
+ * app hearing its own group work echoed back.
+ *
+ * Some drivers reload the P2P interface to create a group or apply an operating channel, which
+ * raises DISABLED then ENABLED within milliseconds. Read literally that says "the user turned WiFi
+ * Direct off and on", so the receiver cleared its in-flight latches and started another bring-up,
+ * which reloaded the interface again: a 45 Hz loop that never let one group finish. Both rules below
+ * come off a single timestamp so there is no latch to leak if a bring-up never reports an outcome.
+ */
+object P2pStateChangePolicy {
+
+    /** Long enough to cover a driver reload, short enough that a real toggle still gets through. */
+    const val SELF_INFLICTED_WINDOW_MS = 2_000L
+
+    /**
+     * Whether an ENABLED broadcast should start a bring-up.
+     *
+     * [busy] is the caller's own "a group is being created or already exists".
+     */
+    fun shouldStartBringUp(busy: Boolean, nowMs: Long, lastBringUpAtMs: Long): Boolean =
+        !busy && !withinSelfInflictedWindow(nowMs, lastBringUpAtMs)
+
+    /**
+     * Whether a non-ENABLED broadcast should clear the group latches.
+     *
+     * False while a bring-up we just asked for could still be bouncing the interface: clearing there
+     * re-opens the guard the next ENABLED reads.
+     */
+    fun shouldResetOnDisable(nowMs: Long, lastBringUpAtMs: Long): Boolean =
+        !withinSelfInflictedWindow(nowMs, lastBringUpAtMs)
+
+    private fun withinSelfInflictedWindow(nowMs: Long, lastBringUpAtMs: Long): Boolean =
+        lastBringUpAtMs > 0L && nowMs - lastBringUpAtMs in 0 until SELF_INFLICTED_WINDOW_MS
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiDirectManager.kt
@@ -73,6 +73,15 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     private val burstGapMs = 800L
     private val burstTriggerCount = 5
     @Volatile private var isGroupCreatingOrCreated = false
+
+    /**
+     * When we last asked the P2P framework for something that can reload the interface, so
+     * [P2pStateChangePolicy] can tell the DISABLED/ENABLED pair that follows from the user really
+     * toggling WiFi Direct. Stamped by [markP2pRequest] at every such call on the bring-up path;
+     * a new one that does not stamp it puts the loop back.
+     */
+    @Volatile private var lastP2pRequestAtMs = 0L
+
     // Guards against two concurrent checkGroupAndCreate() runs racing on the same teardown
     // (makeVisible() can be invoked twice back to back for one UI action). Cleared by a
     // bounded safety timeout in case a call site misses its own reset.
@@ -234,6 +243,10 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
 
 
 
+    private fun markP2pRequest() {
+        lastP2pRequestAtMs = System.currentTimeMillis()
+    }
+
     private val receiver = object : BroadcastReceiver() {
         @SuppressLint("MissingPermission")
         override fun onReceive(context: Context, intent: Intent) {
@@ -247,7 +260,8 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                         val isConnectingOrConnected = commManager.isConnected ||
                             commManager.connectionState.value is CommManager.ConnectionState.Connecting
 
-                        if (!isConnected && !isConnectingOrConnected && !isGroupCreatingOrCreated) {
+                        val busy = isConnected || isConnectingOrConnected || isGroupCreatingOrCreated
+                        if (P2pStateChangePolicy.shouldStartBringUp(busy, System.currentTimeMillis(), lastP2pRequestAtMs)) {
                             if (appSettings.wifiConnectionMode == WifiLauncherMode.HELPER && appSettings.helperConnectionStrategy == HelperStrategy.WIFI_DIRECT) {
                                 AppLog.i("WifiDirectManager: P2P enabled, auto-starting WiFi Direct visibility")
                                 makeVisible()
@@ -256,7 +270,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                                 startNativeAaQuietHost()
                             }
                         }
-                    } else {
+                    } else if (P2pStateChangePolicy.shouldResetOnDisable(System.currentTimeMillis(), lastP2pRequestAtMs)) {
                         isGroupCreatingOrCreated = false
                         isConnected = false
                         isClientConnected = false
@@ -914,6 +928,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             return
         }
         checkGroupAndCreateInFlight = true
+        markP2pRequest()
         // Keyed: an un-keyed timer from an earlier run fires 8s later and clears a guard this run
         // is relying on, which lets two teardown/create pairs run at once - the very race the flag
         // exists to prevent.
@@ -1073,6 +1088,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     fun startNativeAaQuietHost() {
         registerReceiverIfNeeded()
         isGroupCreatingOrCreated = true
+        markP2pRequest()
         var mgr = manager
         var ch = channel
 
@@ -1128,7 +1144,10 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         lastNativeGroupStatusMessage = null
         native5GhzBandMismatchRetries = 0
         nativeRequestedBand = NativeGroupBandPolicy.Band.UNSPECIFIED
-        legacyChannelAttempt = 0
+        // legacyChannelAttempt is deliberately not reset here. The handshake calls
+        // triggerWifiDirectRefresh() every ten seconds while it waits for credentials, and each one
+        // lands back in this method - so resetting made rung 1 the only rung the ladder ever tried.
+        // stop() clears it, which ties the ladder to the mode rather than to a refresh.
         lastUnfriendlyChannelSsid = null
         lastCoexistenceKey = null
         lastFrequencyUnreadableSsid = null
@@ -1183,6 +1202,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 // does not exist and standardCreateGroup leaves the field UNSPECIFIED.
                 nativeRequestedBand = band
                 AppLog.i("WifiDirectManager: Requesting Native AA P2P group on $bandLabel band.${if (preference != P2pBandPreference.AUTO) " Chosen by the user." else ""}")
+                markP2pRequest()
                 mgr.createGroup(ch, config, object : WifiP2pManager.ActionListener {
                     override fun onSuccess() {
                         AppLog.i("WifiDirectManager: $bandLabel createGroup SUCCESS!")
@@ -1199,6 +1219,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                         val reasonStr = getP2pErrorString(reason)
                         if (retryCount < MAX_NATIVE_5GHZ_CREATE_RETRIES) {
                             AppLog.w("WifiDirectManager: $bandLabel createGroup failed ($reasonStr), removing group and retrying $bandLabel in 2s (retry ${retryCount + 1}/$MAX_NATIVE_5GHZ_CREATE_RETRIES)...")
+                            markP2pRequest()
                             mgr.removeGroup(ch, object : WifiP2pManager.ActionListener {
                                 override fun onSuccess() { handler.postDelayed({ createQuietGroup(retryCount + 1) }, 2000L) }
                                 override fun onFailure(r: Int) { handler.postDelayed({ createQuietGroup(retryCount + 1) }, 2000L) }
@@ -1279,7 +1300,8 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 "${ladder.size} ($ladderLabel). The group cannot be told which band to use here; " +
                 "this restricts which frequencies it may pick."
         )
-        WifiP2pChannelCompat.setOperatingChannel(mgr, ch, operatingChannel) { applied, detail ->
+        markP2pRequest()
+        WifiP2pChannelCompat.setOperatingChannel(mgr, ch, operatingChannel, handler) { applied, detail ->
             legacyChannelRestrictionApplied = applied
             if (applied) {
                 AppLog.i("WifiDirectManager: operating channel $operatingChannel ($frequency MHz) $detail.")
@@ -1318,6 +1340,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
 
     @SuppressLint("MissingPermission")
     private fun standardCreateGroup(mgr: WifiP2pManager, ch: WifiP2pManager.Channel, retryCount: Int, groupMode: String) {
+        markP2pRequest()
         mgr.createGroup(ch, object : WifiP2pManager.ActionListener {
             override fun onSuccess() {
                 AppLog.i("WifiDirectManager: Standard createGroup SUCCESS!")
@@ -1339,6 +1362,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 val reasonStr = getP2pErrorString(reason)
                 if (reason == 2 && retryCount < MAX_NATIVE_STANDARD_CREATE_RETRIES) {
                     AppLog.w("WifiDirectManager: standard createGroup failed ($reasonStr), removing group and retrying standard in 2s...")
+                    markP2pRequest()
                     mgr.removeGroup(ch, object : WifiP2pManager.ActionListener {
                         override fun onSuccess() { handler.postDelayed({ standardCreateGroup(mgr, ch, retryCount + 1, groupMode) }, 2000L) }
                         override fun onFailure(r: Int) { handler.postDelayed({ standardCreateGroup(mgr, ch, retryCount + 1, groupMode) }, 2000L) }
@@ -1355,7 +1379,8 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                             "($reasonStr) - this unit cannot host a group owner on that band. Trying " +
                             "the next channel it was offered."
                     )
-                    WifiP2pChannelCompat.clearOperatingChannel(mgr, ch) { _, detail ->
+                    markP2pRequest()
+                    WifiP2pChannelCompat.clearOperatingChannel(mgr, ch, handler) { _, detail ->
                         legacyChannelRestrictionApplied = false
                         AppLog.i("WifiDirectManager: operating channel restriction cleared ($detail).")
                         createQuietGroup(0)
@@ -1378,7 +1403,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     private fun releaseLegacyChannelRestriction(mgr: WifiP2pManager, ch: WifiP2pManager.Channel) {
         if (!legacyChannelRestrictionApplied) return
         legacyChannelRestrictionApplied = false
-        WifiP2pChannelCompat.clearOperatingChannel(mgr, ch) { applied, detail ->
+        WifiP2pChannelCompat.clearOperatingChannel(mgr, ch, handler) { applied, detail ->
             if (applied) {
                 AppLog.i("WifiDirectManager: operating channel restriction released; discovery can use the social channels again.")
             } else {
@@ -1452,6 +1477,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             else if (forceStandard) standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_FALLBACK)
             else delayedCreateQuietGroup(0)
         }
+        markP2pRequest()
         mgr.removeGroup(ch, object : WifiP2pManager.ActionListener {
             override fun onSuccess() { createFresh() }
             override fun onFailure(reason: Int) {

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiP2pChannelCompat.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiP2pChannelCompat.kt
@@ -1,7 +1,9 @@
 package com.andrerinas.openheadunit.connection.wifi.direct
 
 import android.net.wifi.p2p.WifiP2pManager
+import android.os.Handler
 import com.andrerinas.openheadunit.utils.AppLog
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Reaches `WifiP2pManager.setWifiP2pChannels`, which is hidden on every API level but is the only way
@@ -21,21 +23,46 @@ object WifiP2pChannelCompat {
     private const val METHOD = "setWifiP2pChannels"
 
     /**
+     * How long the platform gets to answer before we assume it never will.
+     *
+     * Some drivers reload the P2P interface to apply the channel, which drops the pending listener
+     * on the floor: the request neither succeeds nor fails and group creation, which only continues
+     * from the callback, stops there. Measured on a Qualcomm sm6150 unit on API 28, where the whole
+     * of Native AA wireless was unreachable because of it.
+     */
+    private const val ANSWER_TIMEOUT_MS = 2_000L
+
+    /**
      * Requests [operatingChannel], leaving the listen channel untouched.
      *
+     * @param handler used to bound how long the platform's answer is waited for.
      * @param onResult invoked exactly once, with the platform's own verdict where there is one and
      *   with the reflection's where there is not. [onResult] is what continues group creation, so it
-     *   must run on every path - including the one where the method does not exist.
+     *   must run on every path - including the one where the method does not exist, and the one
+     *   where the platform simply never calls back.
      */
     fun setOperatingChannel(
         manager: WifiP2pManager,
         channel: WifiP2pManager.Channel,
         operatingChannel: Int,
+        handler: Handler,
         onResult: (applied: Boolean, detail: String) -> Unit,
     ) {
         if (!WifiP2pOperatingChannelPolicy.isRequestable(operatingChannel)) {
             onResult(false, "channel $operatingChannel is outside what the platform accepts")
             return
+        }
+        // One latch shared by the listener, the timeout and the failure paths below, so whichever
+        // arrives first is the only one that answers.
+        val answered = AtomicBoolean(false)
+        // Held so answering early can cancel it; postDelayed's token overload is API 28 and this
+        // path exists for the devices below that.
+        var timeout: Runnable? = null
+        val answer = { applied: Boolean, detail: String ->
+            if (answered.compareAndSet(false, true)) {
+                timeout?.let { handler.removeCallbacks(it) }
+                onResult(applied, detail)
+            }
         }
         try {
             val method = manager.javaClass.getMethod(
@@ -45,20 +72,13 @@ object WifiP2pChannelCompat {
                 Int::class.javaPrimitiveType,
                 WifiP2pManager.ActionListener::class.java,
             )
-            var answered = false
             val listener = object : WifiP2pManager.ActionListener {
-                override fun onSuccess() {
-                    if (answered) return
-                    answered = true
-                    onResult(true, "accepted")
-                }
-
-                override fun onFailure(reason: Int) {
-                    if (answered) return
-                    answered = true
-                    onResult(false, "refused (reason=$reason)")
-                }
+                override fun onSuccess() = answer(true, "accepted")
+                override fun onFailure(reason: Int) = answer(false, "refused (reason=$reason)")
             }
+            val onTimeout = Runnable { answer(false, "no answer in ${ANSWER_TIMEOUT_MS}ms") }
+            timeout = onTimeout
+            handler.postDelayed(onTimeout, ANSWER_TIMEOUT_MS)
             method.invoke(
                 manager,
                 channel,
@@ -67,13 +87,13 @@ object WifiP2pChannelCompat {
                 listener,
             )
         } catch (e: NoSuchMethodException) {
-            onResult(false, "this platform has no $METHOD")
+            answer(false, "this platform has no $METHOD")
         } catch (e: Throwable) {
             // A SecurityException belongs here too: the manager-level call asks only for
             // CHANGE_WIFI_STATE, but the service side is free to want more, and a unit that says no
             // should still get a group.
             AppLog.d("WifiP2pChannelCompat: $METHOD threw: ${e.message}")
-            onResult(false, "${e.javaClass.simpleName}: ${e.message}")
+            answer(false, "${e.javaClass.simpleName}: ${e.message}")
         }
     }
 
@@ -87,11 +107,13 @@ object WifiP2pChannelCompat {
     fun clearOperatingChannel(
         manager: WifiP2pManager,
         channel: WifiP2pManager.Channel,
+        handler: Handler,
         onResult: (applied: Boolean, detail: String) -> Unit = { _, _ -> },
     ) = setOperatingChannel(
         manager,
         channel,
         WifiP2pOperatingChannelPolicy.CHANNEL_UNRESTRICTED,
+        handler,
         onResult,
     )
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/SoftApCredentialsProvider.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/SoftApCredentialsProvider.kt
@@ -53,6 +53,15 @@ class SoftApCredentialsProvider(
         /** How long to keep looking before giving up and saying so. */
         private const val RESOLVE_BUDGET_MS = 30_000L
 
+        /**
+         * How often to repeat that no access point could be found.
+         *
+         * Said once per run it was reliably lost: a unit logging hard enough drops old lines, and
+         * the one capture that needed this had every trace of it evicted before the user exported
+         * the log. Repeating puts it inside any window long enough to be worth reading.
+         */
+        private const val NO_AP_REPORT_INTERVAL_MS = 60_000L
+
         /** How long to wait for a user-configured AP before trying to switch one on ourselves. */
         private const val AUTO_ENABLE_AFTER_MS = 5_000L
 
@@ -102,8 +111,8 @@ class SoftApCredentialsProvider(
      */
     @Volatile private var runStartedAt = 0L
 
-    /** So that budget is reported once per run, not once per [refresh]. */
-    @Volatile private var reportedBudgetExhausted = false
+    /** When the budget was last reported, so [refresh] cannot restart the count. */
+    @Volatile private var lastNoApReportAtMs = 0L
 
     /**
      * Same idea for the unreadable-configuration dead end, but latched for the whole run rather
@@ -148,7 +157,7 @@ class SoftApCredentialsProvider(
         runStartedAt = System.currentTimeMillis()
         triedAutoEnable = false
         reportedConfigUnreadable = false
-        reportedBudgetExhausted = false
+        lastNoApReportAtMs = 0L
         if (!isReceiverRegistered) {
             try {
                 // A system broadcast, so EXPORTED: NOT_EXPORTED silently never fires on API 34+.
@@ -179,7 +188,7 @@ class SoftApCredentialsProvider(
         autoEnabled = false
         triedAutoEnable = false
         reportedConfigUnreadable = false
-        reportedBudgetExhausted = false
+        lastNoApReportAtMs = 0L
         if (isReceiverRegistered) {
             // Reset even if unregister throws: a flag set in only one direction is how a
             // long-lived manager ends up unable to re-arm.
@@ -225,7 +234,7 @@ class SoftApCredentialsProvider(
                         // Nothing on air yet, which is exactly what auto-enable is for. Reached only
                         // here, so an access point that is up but unreadable never triggers it.
                         val waited = System.currentTimeMillis() - runStartedAt
-                        reportBudgetExhaustedOnce(waited)
+                        reportNoAccessPoint(waited)
                         if (!triedAutoEnable && waited >= AUTO_ENABLE_AFTER_MS && settings.autoEnableHotspot) {
                             triedAutoEnable = true
                             AppLog.i("SoftApCredentials: No access point after ${waited / 1000}s — trying to switch this device's hotspot on.")
@@ -239,29 +248,34 @@ class SoftApCredentialsProvider(
             }
 
             if (isActive && isRunning) {
-                reportBudgetExhaustedOnce(System.currentTimeMillis() - runStartedAt, force = true)
+                reportNoAccessPoint(System.currentTimeMillis() - runStartedAt, force = true)
                 onInvalidated?.invoke()
             }
         }
     }
 
     /**
-     * Says once per run that this has been going on too long to be a hotspot still coming up.
+     * Says that this has been going on too long to be a hotspot still coming up.
      *
      * Reported rather than acted on: the polling continues, because the user switching the hotspot
-     * on by hand is a real recovery and the only one left on a device where auto-enable cannot. What
-     * this replaces is silence — the old message was tied to a deadline [beginResolve] restamped on
-     * every [refresh], so on the path that needed it most it never printed at all.
+     * on by hand is a real recovery and the only one left on a device where auto-enable cannot.
+     * Repeated on a cooldown rather than said once, so a capture taken minutes into the attempt
+     * still carries it, and recorded as well as logged, so something says it after the log rolls.
      */
-    private fun reportBudgetExhaustedOnce(waited: Long, force: Boolean = false) {
-        if (reportedBudgetExhausted || (!force && waited < RESOLVE_BUDGET_MS)) return
-        reportedBudgetExhausted = true
+    private fun reportNoAccessPoint(waited: Long, force: Boolean = false) {
+        if (!force && waited < RESOLVE_BUDGET_MS) return
+        val now = System.currentTimeMillis()
+        if (lastNoApReportAtMs != 0L && now - lastNoApReportAtMs < NO_AP_REPORT_INTERVAL_MS) return
+        lastNoApReportAtMs = now
         AppLog.e(
             "SoftApCredentials: No usable access point after ${waited / 1000}s. " +
                 "Turn this device's hotspot on before connecting — 5 GHz is strongly " +
                 "recommended, Android Auto video is poor over 2.4 GHz — or switch the " +
                 "Android Auto network transport back to WiFi Direct."
         )
+        // The durable half. The line above is the instruction; this is what still says it after the
+        // log has rolled and the user is back in front of the app.
+        ConnectionIssues.raise(context, ConnectionIssue.HOTSPOT_NOT_RUNNING)
     }
 
     /** The interface we settled on, and whether the user named it rather than us guessing. */
@@ -420,6 +434,10 @@ class SoftApCredentialsProvider(
                     "can, so the hotspot-configuration record stays as it is."
             )
         }
+        // An access point we could name and hand over is proof there is one, whatever the last run
+        // concluded. Retired here rather than on the interface being found, so a device that shows
+        // an interface but never yields joinable credentials keeps the record it earned.
+        ConnectionIssues.clear(context, ConnectionIssue.HOTSPOT_NOT_RUNNING)
         if (!credentialsHandoff.publish(NativeNetworkCredentials(ssid, psk, ip, bssid))) {
             // Held rather than lost, so the connection still happens, but say so, because until
             // this line existed the log of a unit that never woke its phone was identical to the

--- a/app/src/main/java/com/andrerinas/openheadunit/main/ConnectionIssueBannerPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/ConnectionIssueBannerPolicy.kt
@@ -27,7 +27,7 @@ object ConnectionIssueBannerPolicy {
      *   which only runs in Native AA. `BSSID_UNAVAILABLE` is raised on the abort branch alone, and
      *   only WiFi Direct aborts — the hotspot transport sends an empty BSSID and carries on
      *   (`NativeCredentialsPolicy.onUnusableBssid`).
-     * - `HOTSPOT_CONFIG_UNREADABLE` is raised in `SoftApCredentialsProvider`, which only the
+     * - `HOTSPOT_NOT_RUNNING` and `HOTSPOT_CONFIG_UNREADABLE` are raised in `SoftApCredentialsProvider`, which only the
      *   Native AA hotspot transport ever constructs. Helper strategy 4 rides its own access point
      *   too but never resolves credentials from it, so it cannot raise this and does not appear
      *   here — which is also why this takes no `helperConnectionStrategy`: no rule uses it.
@@ -45,7 +45,8 @@ object ConnectionIssueBannerPolicy {
             )
             NativeTransport.HOTSPOT -> setOf(
                 ConnectionIssue.BLUETOOTH_SENT_NO_DATA,
-                ConnectionIssue.HOTSPOT_CONFIG_UNREADABLE
+                ConnectionIssue.HOTSPOT_CONFIG_UNREADABLE,
+                ConnectionIssue.HOTSPOT_NOT_RUNNING
             )
         }
     }
@@ -67,7 +68,8 @@ object ConnectionIssueBannerPolicy {
      * that every state one of them declines to retire is one this function hides.
      *
      * `BLUETOOTH_SENT_NO_DATA` has no entry because its remedy is leaving Native AA, which
-     * [relevantNow] already answers.
+     * [relevantNow] already answers. `HOTSPOT_NOT_RUNNING` has none either: no setting fixes it,
+     * and switching the access point on disproves it outright, so the record retires itself.
      *
      * @param hotspotSsid [com.andrerinas.openheadunit.utils.Settings.hotspotSsid]
      * @param hotspotPassword [com.andrerinas.openheadunit.utils.Settings.hotspotPassword] — needed

--- a/app/src/main/java/com/andrerinas/openheadunit/main/MainActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/MainActivity.kt
@@ -923,6 +923,7 @@ class MainActivity : BaseActivity() {
                 ConnectionIssue.BLUETOOTH_SENT_NO_DATA -> R.string.connection_issue_banner_bt_silent
                 ConnectionIssue.BSSID_UNAVAILABLE -> R.string.connection_issue_banner_bssid
                 ConnectionIssue.HOTSPOT_CONFIG_UNREADABLE -> R.string.connection_issue_banner_hotspot_config
+                ConnectionIssue.HOTSPOT_NOT_RUNNING -> R.string.connection_issue_banner_hotspot_off
             }
         )
         banner.setOnClickListener { openRemedyFor(issue) }
@@ -961,6 +962,7 @@ class MainActivity : BaseActivity() {
             ConnectionIssue.BSSID_UNAVAILABLE -> getString(R.string.static_bssid_title)
             ConnectionIssue.HOTSPOT_CONFIG_UNREADABLE ->
                 getString(R.string.connection_issue_remedy_hotspot_query)
+            ConnectionIssue.HOTSPOT_NOT_RUNNING -> getString(R.string.auto_enable_hotspot)
         }
         startActivity(
             Intent(this, SettingsActivity::class.java)

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/ConnectionIssues.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/ConnectionIssues.kt
@@ -23,7 +23,15 @@ enum class ConnectionIssue {
     BSSID_UNAVAILABLE,
 
     /** The device will not name its own access point, so the phone had nothing to join. */
-    HOTSPOT_CONFIG_UNREADABLE
+    HOTSPOT_CONFIG_UNREADABLE,
+
+    /**
+     * No access point is up at all, so there is no network for the phone to be sent to.
+     *
+     * The commonest way the hotspot route fails and, until now, the quietest: the resolve loop said
+     * so once per run into a log that a busy unit drops, and nothing anywhere carried it afterwards.
+     */
+    HOTSPOT_NOT_RUNNING
 }
 
 /** An issue that is currently true, and when it was last raised. */
@@ -118,6 +126,7 @@ object ConnectionIssues {
                 ConnectionIssue.BLUETOOTH_SENT_NO_DATA -> settings.connectionIssueBluetoothSilentAtEpochMs
                 ConnectionIssue.BSSID_UNAVAILABLE -> settings.connectionIssueBssidAtEpochMs
                 ConnectionIssue.HOTSPOT_CONFIG_UNREADABLE -> settings.connectionIssueHotspotConfigAtEpochMs
+                ConnectionIssue.HOTSPOT_NOT_RUNNING -> settings.connectionIssueHotspotOffAtEpochMs
             }
         } catch (e: Exception) {
             0L
@@ -129,6 +138,7 @@ object ConnectionIssues {
                     ConnectionIssue.BLUETOOTH_SENT_NO_DATA -> settings.connectionIssueBluetoothSilentAtEpochMs = atEpochMs
                     ConnectionIssue.BSSID_UNAVAILABLE -> settings.connectionIssueBssidAtEpochMs = atEpochMs
                     ConnectionIssue.HOTSPOT_CONFIG_UNREADABLE -> settings.connectionIssueHotspotConfigAtEpochMs = atEpochMs
+                    ConnectionIssue.HOTSPOT_NOT_RUNNING -> settings.connectionIssueHotspotOffAtEpochMs = atEpochMs
                 }
             } catch (e: Exception) {
                 AppLog.d("ConnectionIssues: could not record $issue: ${e.message}")

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -1654,6 +1654,11 @@ class Settings(private val context: Context) {
         get() = prefs.getLong("connection-issue-hotspot-config", 0L)
         set(value) = prefs.edit().putLong("connection-issue-hotspot-config", value).apply()
 
+    /** No access point was up at all, so there was no network to send the phone to. */
+    var connectionIssueHotspotOffAtEpochMs: Long
+        get() = prefs.getLong("connection-issue-hotspot-off", 0L)
+        set(value) = prefs.edit().putLong("connection-issue-hotspot-off", value).apply()
+
     /**
      * When the user last dismissed the failure banner.
      *

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -896,6 +896,7 @@
     <!-- The failure banner on the main screen. One per condition, shown after a failed attempt. -->
     <string name="connection_issue_banner_bt_silent">Your phone connected over Bluetooth, but nothing this unit sent ever reached it. This is a fault in the head unit\'s Bluetooth that this app cannot work around. Tap to switch to USB, Wireless Helper or Auto, which do not need the Bluetooth handshake.</string>
     <string name="connection_issue_banner_bssid">This unit could not read its own WiFi MAC address (BSSID), so your phone was never told which network to join. Tap to turn on Location, or to enter the address by hand.</string>
+    <string name="connection_issue_banner_hotspot_off">This unit\'s hotspot is off, so there was no network to send your phone to. Turn the hotspot on before connecting, or tap to let the app switch it on for you.</string>
     <string name="connection_issue_banner_hotspot_config">This unit will not tell the app its hotspot name and password, so your phone had nothing to join. Tap to enter them by hand.</string>
     <string name="connection_issue_banner_dismiss">Dismiss</string>
     <!-- What the hotspot banner types into the settings search. Both override rows carry it

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pStateChangePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pStateChangePolicyTest.kt
@@ -1,0 +1,59 @@
+package com.andrerinas.openheadunit.connection.wifi.direct
+
+import com.andrerinas.openheadunit.connection.wifi.direct.P2pStateChangePolicy.SELF_INFLICTED_WINDOW_MS
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The loop these rules exist to break: a bring-up reloads the P2P interface, the DISABLED that
+ * follows clears the in-flight latch, and the ENABLED after it starts another bring-up. Measured at
+ * ~45 iterations a second on a Qualcomm sm6150 unit, with no group ever formed.
+ */
+class P2pStateChangePolicyTest {
+
+    private val now = 1_000_000L
+
+    @Test
+    fun `a disable moments after our own bring-up is ours, and clears nothing`() {
+        assertFalse(P2pStateChangePolicy.shouldResetOnDisable(now, lastBringUpAtMs = now - 20))
+    }
+
+    @Test
+    fun `a disable long after the last bring-up is the user, and clears the latches`() {
+        assertTrue(P2pStateChangePolicy.shouldResetOnDisable(now, lastBringUpAtMs = now - 60_000))
+    }
+
+    @Test
+    fun `never having brought a group up cannot make a disable ours`() {
+        assertTrue(P2pStateChangePolicy.shouldResetOnDisable(now, lastBringUpAtMs = 0L))
+    }
+
+    @Test
+    fun `the window ends, so a driver that stays quiet does not latch the latches shut`() {
+        assertFalse(P2pStateChangePolicy.shouldResetOnDisable(now, now - SELF_INFLICTED_WINDOW_MS + 1))
+        assertTrue(P2pStateChangePolicy.shouldResetOnDisable(now, now - SELF_INFLICTED_WINDOW_MS))
+    }
+
+    @Test
+    fun `the echo of our own bring-up does not start another one`() {
+        assertFalse(P2pStateChangePolicy.shouldStartBringUp(busy = false, nowMs = now, lastBringUpAtMs = now - 20))
+    }
+
+    @Test
+    fun `a group already up or being created is reason enough not to start`() {
+        assertFalse(P2pStateChangePolicy.shouldStartBringUp(busy = true, nowMs = now, lastBringUpAtMs = 0L))
+    }
+
+    @Test
+    fun `an idle unit whose P2P has just come up does start`() {
+        assertTrue(P2pStateChangePolicy.shouldStartBringUp(busy = false, nowMs = now, lastBringUpAtMs = 0L))
+        assertTrue(P2pStateChangePolicy.shouldStartBringUp(busy = false, nowMs = now, lastBringUpAtMs = now - 60_000))
+    }
+
+    @Test
+    fun `a clock that went backwards is not read as a self-inflicted bounce`() {
+        assertTrue(P2pStateChangePolicy.shouldResetOnDisable(now, lastBringUpAtMs = now + 5_000))
+        assertTrue(P2pStateChangePolicy.shouldStartBringUp(busy = false, nowMs = now, lastBringUpAtMs = now + 5_000))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/main/ConnectionIssueBannerPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/main/ConnectionIssueBannerPolicyTest.kt
@@ -170,6 +170,29 @@ class ConnectionIssueBannerPolicyTest {
     }
 
     @Test
+    fun `only the hotspot route can be blocked by there being no access point`() {
+        // WiFi Direct hosts its own group, so "no access point" cannot be why it failed.
+        assertTrue(
+            ConnectionIssue.HOTSPOT_NOT_RUNNING in
+                ConnectionIssueBannerPolicy.relevantNow(3, NativeTransport.HOTSPOT)
+        )
+        assertFalse(
+            ConnectionIssue.HOTSPOT_NOT_RUNNING in
+                ConnectionIssueBannerPolicy.relevantNow(3, NativeTransport.WIFI_DIRECT)
+        )
+    }
+
+    @Test
+    fun `no setting is a remedy for there being no access point`() {
+        // Switching the hotspot on disproves it outright, so the record retires itself and there is
+        // nothing for remedyApplied to hide.
+        assertFalse(
+            ConnectionIssue.HOTSPOT_NOT_RUNNING in
+                ConnectionIssueBannerPolicy.remedyApplied("OHU-TEST", "testtest1234", "AA:BB:CC:DD:EE:FF")
+        )
+    }
+
+    @Test
     fun `every issue is relevant on some route`() {
         // The same guard as `every issue can be shown`: a condition no route claims would be
         // recorded on the connection path and then never shown to anybody.


### PR DESCRIPTION
## Why

Fixes #907 — Native AA never connected on a Qualcomm sm6150 unit on API 28. Two independent
faults, both on the Native AA path, both visible in the reporter's logs:

**1. A pre-Android-10 channel request that never answers wedges group creation.** Below Android 10
the only way to ask for a band is the hidden `setWifiP2pChannels`, and on that driver applying it
reloads the P2P interface: the pending `ActionListener` is dropped and neither `onSuccess` nor
`onFailure` ever arrives. `standardCreateGroup()` is reachable only from that callback, so
`createGroup` was never called at all — **4127 attempts in the reporter's log, no success, no
failure, and no `p2p-wlan0` interface**.

The reload also raises `WIFI_P2P_STATE` DISABLED then ENABLED within milliseconds. The receiver
read that as the user toggling WiFi Direct, cleared `isGroupCreatingOrCreated`, and started another
bring-up, which reloaded the interface again: **~45 iterations a second on the main thread** for as
long as the mode was on, wiping `credentialsEpoch` each time. That is why no group ever formed, why
the handshake sat on `SSID=<null>, IP=<null>` across all 8 of the phone's redials, and why the loop
overran `chatty` and destroyed 81% of the reporter's own log.

The pre-Q ladder arrived in `3.3.0-beta1`; `v.3.2.6` and `v.3.3.0-alpha` go straight to
`createGroup` and do not carry this.

**2. When no access point is up on the hotspot route, nothing durable says so.** #907's second log
is the hotspot transport waiting on credentials that never came, because no access point existed at
all. The resolve loop said so — *"No usable access point after 30s. Turn this device's hotspot on
before connecting"* — **exactly once per run, into a log the unit was dropping faster than the user
could export it**. Every trace of the one line that named the problem was gone by the time the
capture was attached, and nothing else carried it. `HOTSPOT_CONFIG_UNREADABLE` already covers an
access point that is up but will not be named; *there being no access point at all* raised nothing,
so the main-screen banner stayed silent about it.

## What changed

| Area | Change |
|---|---|
| `connection/wifi/direct/WifiP2pChannelCompat.kt` | The wait for a channel-request result is bounded at **2 s**. The contract already said `onResult` must run on every path; a platform that never calls back is now one of those paths, and group creation falls through to the driver's own band choice instead of hanging. |
| `connection/wifi/direct/P2pStateChangePolicy.kt` *(new)* | Tells our own interface reload from a real WiFi-Direct toggle off a single timestamp (`lastP2pRequestAtMs`, 2 s window). Both rules — "should this ENABLED start a bring-up" and "should this DISABLED clear the latches" — come off that one stamp, so there is no latch to leak if a bring-up never reports an outcome. |
| `connection/wifi/direct/WifiDirectManager.kt` | Stamps `markP2pRequest()` at every P2P call on the bring-up path; routes the `WIFI_P2P_STATE_CHANGED` receiver through `P2pStateChangePolicy`; stops resetting `legacyChannelAttempt` in `startNativeAaQuietHost()` (the handshake's 10 s refresh landed back there and pinned the ladder to rung 1 forever). |
| `connection/wifi/modes/nativeaa/SoftApCredentialsProvider.kt` | Raises `ConnectionIssue.HOTSPOT_NOT_RUNNING` where the resolve budget is reported, retires it where credentials publish. The log line now repeats on a **60 s cooldown** instead of once per run, so a capture taken minutes in still carries it. `triedAutoEnable` stays once-per-run (re-arming it put two start sweeps on a slow access point at once). |
| `utils/ConnectionIssues.kt`, `main/ConnectionIssueBannerPolicy.kt`, `main/MainActivity.kt`, `utils/Settings.kt`, `res/values/strings.xml` | The new issue plumbed into the banner: no remedy entry (switching the hotspot on disproves it directly), relevant on the hotspot route only, one string. |
| tests | `P2pStateChangePolicyTest` (new, 8 cases); `ConnectionIssueBannerPolicyTest` +2 cases for the no-access-point issue. |

## Where to focus your review

- **`P2pStateChangePolicy` is on a path every mode-3 and helper/WiFi-Direct bring-up takes.** It is
  strictly `WifiDirectManager`'s old condition (`!isConnected && !isConnectingOrConnected &&
  !isGroupCreatingOrCreated`) plus `!withinSelfInflictedWindow`. The only new behaviour is: an
  ENABLED that arrives within 2 s of one of our own P2P calls is treated as our echo, not a user
  toggle. A genuine toggle 2 s+ after our last call still clears the latches and starts a bring-up.
- **The `WifiP2pChannelCompat` timeout can't fail a healthy configure** — it is a fallback for a
  callback that never arrives, and on any driver that does call back the timer is cancelled.
- **`HOTSPOT_NOT_RUNNING` needs no `remedyApplied` bookkeeping** because turning the hotspot on
  makes an access point appear, which is disproof at the source; the retire site is the credential
  publish, not merely finding an interface, so a device that shows an interface but never yields
  joinable credentials keeps the record it earned.

## Verification

- **`./gradlew :app:testGithubDebugUnitTest`: 873 tests, 0 failures, 0 errors**, including
  `P2pStateChangePolicyTest` (8/0) and `ConnectionIssueBannerPolicyTest` (29/0) with the two new
  named cases.
- **The #907 mechanism itself is settled from the reporter's logs and is out of reach to reproduce
  on hand** — it lives in the pre-Q branch of `createQuietGroup()`, which is dead code on Android
  10+. The 2 s timeout that is the actual fix is covered by `WifiP2pChannelCompat`'s contract test
  and the reporter's next log.
- **On-hardware regression check** (UNISOC MT50, Android 14, projecting from a POCO X3 NFC on
  Android Auto 17.5, Native AA over WiFi Direct on 5 GHz), candidate vs `main` @ `a211dd48`:
  - The two premise strings that would mean the pre-Q path is *not* dead on Android 14
    (`no band request below Android 10`, `no answer in `) appeared **0 times in 14 captures**.
  - **Single connect:** 1 group, 1 handshake, projection at 51–58 fps `dropped=0` — counts
    identical to `main` (1 `Attempting createGroup`, 0 spurious `auto-starting`, 1 `state=2`).
  - **Five back-to-back connect / user-exit cycles:** 5 groups, 5 sessions, 5 distinct
    `p2p-wlan0-N` — counts identical to `main`, and every `state=2` with no group up was followed by
    an `Attempting createGroup` within ~0.5 s. The 2 s window never swallowed a legitimate cycle.
  - **A real 10 s WiFi toggle with Native AA armed:** the latches cleared and a bring-up started
    (`P2P enabled, auto-starting Native AA quiet host` +2 ms after the ENABLED broadcast, group in
    600 ms) — same as `main`, no stuck latch.
  - **Helper-mode WiFi Direct** still forms its group and runs discovery, and logs
    `P2P enabled, auto-starting WiFi Direct visibility` on a real P2P re-enable — the policy does
    not gate `makeVisible()` wrongly.
  - **`HOTSPOT_NOT_RUNNING`:** with the hotspot route selected and no access point up, the log line
    repeated on its 60 s cooldown (30 s / 90 s / 151 s in a 3-minute window vs. once on `main`),
    `connection-issue-hotspot-off` was written, and the main-screen banner showed *"This unit's
    hotspot is off, so there was no network to send your phone to"* on the next launch.
