### PR TITLE
Support for BYD Steering wheel keys

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/AppComponent.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/AppComponent.kt
@@ -4,7 +4,6 @@ import android.app.NotificationManager
 import android.content.Context
 import android.net.wifi.WifiManager
 import com.andrerinas.openheadunit.connection.CommManager
-import com.andrerinas.openheadunit.connection.carkey.CarKeysManager
 import com.andrerinas.openheadunit.decoder.audio.AudioDecoder
 import com.andrerinas.openheadunit.decoder.video.DeviceMemoryProfile
 import com.andrerinas.openheadunit.decoder.video.VideoDecoder
@@ -29,6 +28,4 @@ class AppComponent(private val app: App) {
     val commManager = CommManager(app, settings, audioDecoder, videoDecoder)
 
     val suExecutor = SUExecutor()
-
-    val carKeysManager = CarKeysManager()
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -42,6 +42,7 @@ import com.andrerinas.openheadunit.utils.ToastUtils
 import com.andrerinas.openheadunit.aap.protocol.messages.NightModeEvent
 import com.andrerinas.openheadunit.aap.protocol.proto.MediaPlayback
 import com.andrerinas.openheadunit.connection.CommManager
+import com.andrerinas.openheadunit.connection.carkey.CarKeysManager
 import com.andrerinas.openheadunit.connection.wifi.NetworkDiscovery
 import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.MediaMetadataCompat
@@ -112,6 +113,7 @@ class AapService : Service() {
     private val wifiLauncherManager = WifiLauncherManager(this)
     private val usbLauncherManager = UsbLauncherManager(this)
     private val selfLauncherManager = SelfLauncherManager(this, wifiLauncherManager)
+    private val carKeysManager = CarKeysManager()
 
     /**
      * Set when a link-loss teardown closed the session because station WiFi was going away.
@@ -784,6 +786,7 @@ class AapService : Service() {
         setupNightMode()
         observeConnectionState()
         registerReceivers()
+        carKeysManager.registerReceivers(this)
 
         // Handle immediate WiFi auto-start check (e.g. if already connected on boot/wake)
         WifiAutoStartReceiver.checkAndStart(this)
@@ -1025,9 +1028,6 @@ class AapService : Service() {
 
         // Silent audio hack removed to prevent mixing/resampling stuttering issues
 
-        // Register the comprehensive steering wheel key receiver
-        App.provide(this).carKeysManager.registerReceivers(this)
-
         // Reactivate the existing MediaSession (created in onCreate, kept alive across disconnects)
         safeMediaSessionCall { it.isActive = true }
         updateMediaSessionState(true)
@@ -1198,7 +1198,6 @@ class AapService : Service() {
 
         // Release any permanent audio focus we may have requested when connected
         releasePermanentAudioFocus()
-        App.provide(this).carKeysManager.unregisterReceivers()
 
         if (!isDestroying) updateNotification()
         mediaMetadataDecodeJob?.cancel()
@@ -1882,7 +1881,7 @@ class AapService : Service() {
         usbLauncherManager.unregister()
         try { unregisterReceiver(mediaButtonReceiver) } catch (_: Exception) {}
         try { unregisterReceiver(wakeDetectReceiver) } catch (_: Exception) {}
-        try { App.provide(this).carKeysManager.unregisterReceivers() } catch (e: Exception) { AppLog.w("AapService: Error unregistering carKeysManager: ${e.message}") }
+        try { carKeysManager.unregisterReceivers() } catch (e: Exception) { AppLog.w("AapService: Error unregistering carKeysManager: ${e.message}") }
         try { wifiAutoStartReceiver?.let { unregisterReceiver(it) } } catch (_: Exception) {}
         try {
             if (::uiModeManager.isInitialized) {

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/carkey/CarKeyReceiver.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/carkey/CarKeyReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.view.KeyEvent
 import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.connection.CommManager
+import com.andrerinas.openheadunit.connection.carkey.byd.CarBydReceiver
 import com.andrerinas.openheadunit.connection.carkey.fyt.CarFYTReceiver
 import com.andrerinas.openheadunit.contract.KeyIntent
 import com.andrerinas.openheadunit.utils.AppLog
@@ -16,6 +17,7 @@ interface CarKeyReceiver {
         fun newDefaultReceivers(): Array<CarKeyReceiver> {
             return arrayOf(
                 CarKeyBroadcastReceiver(),
+                CarBydReceiver(),
                 CarFYTReceiver(),
             )
         }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/carkey/byd/CarBydReceiver.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/carkey/byd/CarBydReceiver.kt
@@ -1,0 +1,122 @@
+package com.andrerinas.openheadunit.connection.carkey.byd
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.view.KeyEvent
+import androidx.core.content.ContextCompat
+import com.andrerinas.openheadunit.connection.carkey.CarKeyReceiver
+import com.andrerinas.openheadunit.input.BydPanelKey
+import com.andrerinas.openheadunit.utils.AppLog
+
+/**
+ * Panel and steering-wheel keys on a BYD head unit.
+ *
+ * These units deliver their media buttons as raw byte frames on an unprotected broadcast from
+ * `com.byd.multimediaservice`, never as Android key events — see [BydPanelKey] for why the standard
+ * path cannot see them at all. That makes this the one car-key receiver that has to decode a
+ * payload rather than read a key code out of an extra, which is why it lives apart from
+ * [com.andrerinas.openheadunit.connection.carkey.CarKeyBroadcastReceiver] and its table of OEM
+ * actions.
+ *
+ * The frame carries a press with no matching release, so each one becomes a full click.
+ * `CommManager` de-duplicates and decides whether the key reaches Android Auto at all, including
+ * dropping every one of these while nothing is projecting — which is this app's version of the
+ * gating the stock player does when another audio source owns the unit.
+ */
+class CarBydReceiver : BroadcastReceiver(), CarKeyReceiver {
+
+    companion object {
+        /** The service that broadcasts the frames, for the diagnostic line in [register]. */
+        private const val MULTIMEDIA_PACKAGE = "com.byd.multimediaservice"
+    }
+
+    private var context: Context? = null
+
+    /**
+     * Always registered, unlike the FYT receiver's system-property probe.
+     *
+     * There is no reliable BYD marker to test: the units this was captured on are a Freescale board
+     * running Android 4.4 with no vendor property naming the manufacturer, and probing for
+     * [MULTIMEDIA_PACKAGE] would silently disable the feature on any firmware variant that renamed
+     * it — a false negative here is a head unit whose media buttons do nothing, which is far worse
+     * than an idle receiver on a unit that never sends the action. Registering costs one
+     * `IntentFilter` with one vendor-specific action that no other head unit broadcasts, and
+     * [BydPanelKey.panelKeyCode] rejects anything that is not a well-formed key frame, so a stray
+     * broadcast of the same name cannot inject a key.
+     */
+    override val isSupported = true
+
+    override val isSUNeeded = false
+
+    override fun register(context: Context) {
+        this.context = context
+
+        // Exported because the sender is another app. This matches how the app already receives
+        // MEDIA_BUTTON and the OEM key actions.
+        ContextCompat.registerReceiver(
+            context,
+            this,
+            IntentFilter(BydPanelKey.ACTION),
+            ContextCompat.RECEIVER_EXPORTED,
+        )
+
+        val installed = runCatching {
+            context.packageManager.getPackageInfo(MULTIMEDIA_PACKAGE, 0)
+        }.isSuccess
+        AppLog.i(
+            "CarKeyReceiver: Listening for BYD panel keys on ${BydPanelKey.ACTION} " +
+                "($MULTIMEDIA_PACKAGE ${if (installed) "present" else "not found"})",
+        )
+    }
+
+    override fun unregister() {
+        this.context?.unregisterReceiver(this)
+        this.context = null
+    }
+
+    override fun onReceive(context: Context, intent: Intent?) {
+        if (intent?.action != BydPanelKey.ACTION) return
+
+        // Read the payload once and check its type, rather than reaching for a typed getter that
+        // might not match. `getIntArrayExtra` on a `byte[]` makes the framework log a warning and a
+        // full stack trace for every frame, and this channel is busy — in the original capture that
+        // mistake produced 67 of 69 logcat lines.
+        val payload = intent.extras?.get(BydPanelKey.EXTRA_FRAME)
+        if (payload !is ByteArray) return
+
+        val panelCode = BydPanelKey.panelKeyCode(payload)
+        if (panelCode == BydPanelKey.NO_KEY) {
+            // Source changes, ACC state, launcher metadata and the service's echo of what other
+            // apps send it all share this action. None of it is ours.
+            return
+        }
+
+        val keyCode = BydPanelKey.toKeyCode(panelCode)
+        // A virtual key code gets its own name; a confirmed one already has a platform name. Always
+        // with the raw frame, so a button nobody has catalogued yet is recoverable from a user's log.
+        AppLog.i(
+            "CarKeyReceiver: BYD panel key 0x%02X -> %s [%s]".format(
+                panelCode,
+                BydPanelKey.label(keyCode) ?: KeyEvent.keyCodeToString(keyCode),
+                BydPanelKey.hex(payload),
+            ),
+        )
+
+        // Feed the keymap screen's debugger, the way the OEM broadcast receiver does, so an
+        // uncatalogued button is visible before it is mapped.
+        context.sendBroadcast(
+            Intent("com.andrerinas.openheadunit.DEBUG_KEY").apply {
+                setPackage(context.packageName)
+                putExtra("action", BydPanelKey.ACTION)
+                putExtra("keyCode", keyCode)
+                putExtra("byd_panel_code", "0x%02X".format(panelCode))
+                putExtra("byd_frame", BydPanelKey.hex(payload))
+            },
+        )
+
+        // One frame per press, with no release to follow, so the click is synthesised here.
+        handleClick(context, keyCode)
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/carkey/byd/CarBydReceiver.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/carkey/byd/CarBydReceiver.kt
@@ -4,7 +4,6 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.view.KeyEvent
 import androidx.core.content.ContextCompat
 import com.andrerinas.openheadunit.connection.carkey.CarKeyReceiver
 import com.andrerinas.openheadunit.input.BydPanelKey
@@ -42,9 +41,16 @@ class CarBydReceiver : BroadcastReceiver(), CarKeyReceiver {
      * [MULTIMEDIA_PACKAGE] would silently disable the feature on any firmware variant that renamed
      * it — a false negative here is a head unit whose media buttons do nothing, which is far worse
      * than an idle receiver on a unit that never sends the action. Registering costs one
-     * `IntentFilter` with one vendor-specific action that no other head unit broadcasts, and
-     * [BydPanelKey.panelKeyCode] rejects anything that is not a well-formed key frame, so a stray
-     * broadcast of the same name cannot inject a key.
+     * `IntentFilter` with one vendor-specific action that no other head unit broadcasts.
+     *
+     * Note what this does *not* protect against. The channel is unprotected in both directions: any
+     * installed app can `sendBroadcast` a well-formed frame, and a receiver cannot tell an injected
+     * one from a real press. [BydPanelKey.panelKeyCode] bounds that to the panel key space rather
+     * than preventing it, and `CommManager` will only forward while a projection is actually running
+     * — but within those bounds an injected frame is indistinguishable from a button press. The same
+     * is already true of every action
+     * [com.andrerinas.openheadunit.connection.carkey.CarKeyBroadcastReceiver] listens on, including
+     * `MEDIA_BUTTON`.
      */
     override val isSupported = true
 
@@ -94,12 +100,14 @@ class CarBydReceiver : BroadcastReceiver(), CarKeyReceiver {
         }
 
         val keyCode = BydPanelKey.toKeyCode(panelCode)
-        // A virtual key code gets its own name; a confirmed one already has a platform name. Always
-        // with the raw frame, so a button nobody has catalogued yet is recoverable from a user's log.
+        // Name the button and the code it will be learned as, always with the raw frame. This is the
+        // line a user reads to find out which button they just pressed, so it has to be useful for a
+        // code the catalogue has never heard of too.
         AppLog.i(
-            "CarKeyReceiver: BYD panel key 0x%02X -> %s [%s]".format(
+            "CarKeyReceiver: BYD panel key %s 0x%02X -> keycode %d [%s]".format(
+                BydPanelKey.nameOf(panelCode) ?: "unnamed",
                 panelCode,
-                BydPanelKey.label(keyCode) ?: KeyEvent.keyCodeToString(keyCode),
+                keyCode,
                 BydPanelKey.hex(payload),
             ),
         )
@@ -116,7 +124,9 @@ class CarBydReceiver : BroadcastReceiver(), CarKeyReceiver {
             },
         )
 
-        // One frame per press, with no release to follow, so the click is synthesised here.
+        // One frame per press, with no release to follow, so the click is synthesised here. Both
+        // edges are broadcast for the keymap screen to learn from; CommManager then drops the key
+        // unless the user has bound it, so an unbound button is inert rather than unpredictable.
         handleClick(context, keyCode)
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/input/BydPanelKey.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/input/BydPanelKey.kt
@@ -1,11 +1,11 @@
 package com.andrerinas.openheadunit.input
 
-import android.view.KeyEvent
 import java.util.Locale
 
 /**
  * Decodes the panel / steering-wheel key frames a BYD head unit broadcasts, and maps them onto the
  * key codes the rest of this app speaks.
+ * Information onf how steering wheel keys are handled decoded by reverse engineering BYD system apps
  *
  * On these units the media buttons are **not Android `KeyEvent`s** — not merely unhandled ones, but
  * events that never exist in that form at all. The button reaches the MCU, the MCU reaches
@@ -30,13 +30,6 @@ import java.util.Locale
  * two-byte header with unrelated meanings (the Bluetooth one puts ASCII device names behind `02 03`),
  * which is why [ACTION] is the single action worth registering for and every other channel is left
  * alone.
- *
- * Only three codes are confirmed — they are the three the stock player implements and the two that
- * were captured live. The rest become learnable virtual key codes rather than guesses; see
- * [toKeyCode].
- *
- * Pure and unit-tested; the registration and the send live in
- * [com.andrerinas.openheadunit.connection.carkey.byd.CarBydReceiver].
  */
 object BydPanelKey {
 
@@ -53,15 +46,6 @@ object BydPanelKey {
     /** Not a panel key frame. */
     const val NO_KEY = -1
 
-    // ── Panel key codes ──────────────────────────────────────────────────────────────────────────
-    // Confirmed: implemented in the stock player's `onPanelKeyDown`, and NEXT/PREV were also
-    // captured live on a real unit.
-    const val CODE_PLAY_PAUSE = 0x02
-    const val CODE_NEXT = 0x03
-    const val CODE_PREV = 0x04
-    const val CODE_PHONE = 0x5E
-    const val CODE_MENU = 0x5F
-
     /**
      * Base for the virtual key codes given to panel keys with no confirmed meaning, so a user can
      * learn them in the keymap. Follows the convention the other proprietary receivers already use
@@ -75,11 +59,44 @@ object BydPanelKey {
     val VIRTUAL_RANGE = VIRTUAL_BASE until (VIRTUAL_BASE + 256)
 
     /**
+     * The catalogue, for logs and for the keymap screen. Twenty panel buttons from the factory test
+     * app plus the three steering-wheel codes.
+     *
+     * `Next` appears twice on purpose — `0x03` on the wheel, `0x84` on the panel — as does the pair
+     * `Prev`/`Pre`. They are separate buttons in separate ranges that happen to do the same thing.
+     */
+    private val NAMES = mapOf(
+        0x02 to "PlayPause",
+        0x03 to "Next",
+        0x04 to "Prev",
+        0x10 to "VolumeDown",
+        0x11 to "VolumeUp",
+        0x43 to "TurnUp",
+        0x44 to "TurnDown",
+        0x45 to "Aux",
+        0x53 to "Phone",
+        0x54 to "SD",
+        0x5D to "Voice",
+        0x5E to "Connect",
+        0x5F to "Drop",
+        0x7E to "USB",
+        0x81 to "Mode",
+        0x82 to "Pre",
+        0x84 to "Next",
+        0x86 to "RightFront",
+        0x88 to "Power",
+        0x8D to "Radio",
+        0x9C to "Music",
+        0x9D to "Video",
+        0x9E to "ScreenOff",
+    )
+
+    /**
      * The panel key code carried by [frame], or [NO_KEY] when this frame is not a key press.
      *
-     * The channel is busy with source changes, ACC state, launcher metadata and the service's own
-     * echo of what other apps send it, so the group/sub check is what keeps all of that out. It also
-     * means a stray broadcast of this very generic action name cannot inject an arbitrary key.
+     * The channel is busy with source changes, ACC state, camera control, launcher metadata and the
+     * service's own echo of what other apps send it, so the group/sub check is what keeps all of that
+     * out.
      */
     fun panelKeyCode(frame: ByteArray?): Int {
         if (frame == null || frame.size < 3) return NO_KEY
@@ -90,41 +107,35 @@ object BydPanelKey {
     /**
      * The key code to hand to `CarKeyReceiver.handleClick` for a panel key code.
      *
-     * The three confirmed codes become the real Android media key codes, so play/pause, next and
-     * previous work on a BYD unit with nothing configured. Everything else becomes a virtual code:
-     * sending a guess would be worse than sending nothing, because a wrong guess is a button that
-     * does the wrong thing every time and reads as a bug, whereas a virtual code shows up in the
-     * keymap screen ready to be assigned to whichever Android Auto action the user finds it should
-     * do.
+     * **Every** panel key becomes a virtual code — none is mapped to an Android key code here, not
+     * even the three the stock player implements. Nothing this channel produces reaches Android Auto
+     * until the user binds it in the keymap screen.
+     *
+     * `CommManager.sendKey` drops an unmapped code at or above 1000 rather than sending nonsense to
+     * the phone, so an unbound button is inert rather than unpredictable. [nameOf] is what makes
+     * binding it practical: the keymap screen shows the button by name instead of a bare number.
      */
-    fun toKeyCode(panelCode: Int): Int = when (panelCode) {
-        CODE_PLAY_PAUSE -> KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE
-        CODE_NEXT -> KeyEvent.KEYCODE_MEDIA_NEXT
-        CODE_PREV -> KeyEvent.KEYCODE_MEDIA_PREVIOUS
-        else -> VIRTUAL_BASE + panelCode
-    }
+    fun toKeyCode(panelCode: Int): Int = VIRTUAL_BASE + panelCode
+
     /** The panel key code behind a virtual key code, or null when [keyCode] is not one of ours. */
     fun panelCodeOf(keyCode: Int): Int? =
         if (keyCode in VIRTUAL_RANGE) keyCode - VIRTUAL_BASE else null
 
+    /** The catalogued name of a panel code, or null for one nobody has identified. */
+    fun nameOf(panelCode: Int): String? = NAMES[panelCode]
+
     /**
      * A name for one of our virtual key codes, for the keymap screen — `KeyEvent.keyCodeToString`
      * renders these as a bare number, which tells a user nothing about which button they just
-     * pressed. Null for any key code that is not ours.
+     * pressed. Null for any key code that is not ours, including the panel codes that map to real
+     * Android key codes and so already have a platform name.
      *
-     * Deliberately not translated, like the `keyCodeToString` names it appears alongside: this
-     * names a piece of hardware, and the hex is what a user quotes in a bug report. The question
-     * mark on the phone button is not decoration — that reading is an inference from correlated
-     * Bluetooth traffic, never confirmed at the unit.
+     * Deliberately not translated, like the `keyCodeToString` names it appears alongside: this names
+     * a piece of hardware, and the hex is what a user quotes in a bug report.
      */
     fun label(keyCode: Int): String? {
         val panelCode = panelCodeOf(keyCode) ?: return null
-        val name = when (panelCode) {
-            CODE_PHONE -> "PHONE"
-            CODE_MENU -> "MENU"
-            else -> "KEY"
-        }
-        return String.format(Locale.US, "BYD %s (0x%02X)", name, panelCode)
+        return String.format(Locale.US, "BYD %s (0x%02X)", nameOf(panelCode) ?: "key", panelCode)
     }
 
     /** Hex rendering of a frame, so an unrecognised one stays recoverable from a user's log. */

--- a/app/src/main/java/com/andrerinas/openheadunit/input/BydPanelKey.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/input/BydPanelKey.kt
@@ -1,0 +1,135 @@
+package com.andrerinas.openheadunit.input
+
+import android.view.KeyEvent
+import java.util.Locale
+
+/**
+ * Decodes the panel / steering-wheel key frames a BYD head unit broadcasts, and maps them onto the
+ * key codes the rest of this app speaks.
+ *
+ * On these units the media buttons are **not Android `KeyEvent`s** — not merely unhandled ones, but
+ * events that never exist in that form at all. The button reaches the MCU, the MCU reaches
+ * `com.byd.multimediaservice` over a serial link, and that userspace service broadcasts a raw byte
+ * frame. Nothing writes to `/dev/input/event*`, so `InputReader` never runs and there is no
+ * `KeyEvent` for [com.andrerinas.openheadunit.connection.carkey.CarKeyBroadcastReceiver] to pick out
+ * of a `MEDIA_BUTTON` intent — the stock player's own `MEDIA_BUTTON` registration on this firmware
+ * points at a class that is not in its APK, because there is nothing on the other end of that path.
+ * Measured directly: three confirmed key presses inside a window where an activity's
+ * `dispatchKeyEvent` was logging every event produced zero dispatches.
+ *
+ * So the only way to see these buttons is to decode the frame, which is what this object does.
+ *
+ * Frame layout, from the stock player's `DZ60.dealData`:
+ * ```
+ *   byte 0 : group id
+ *   byte 1 : sub id
+ *   byte 2+: payload, meaning depends on group/sub
+ * ```
+ * Panel keys are group [GROUP_PANEL_KEY] / sub [SUB_KEY_DOWN] with the code in byte 2. The group/sub
+ * table describes the *multimedia* channel only; the sibling channels in the same firmware reuse the
+ * two-byte header with unrelated meanings (the Bluetooth one puts ASCII device names behind `02 03`),
+ * which is why [ACTION] is the single action worth registering for and every other channel is left
+ * alone.
+ *
+ * Only three codes are confirmed — they are the three the stock player implements and the two that
+ * were captured live. The rest become learnable virtual key codes rather than guesses; see
+ * [toKeyCode].
+ *
+ * Pure and unit-tested; the registration and the send live in
+ * [com.andrerinas.openheadunit.connection.carkey.byd.CarBydReceiver].
+ */
+object BydPanelKey {
+
+    /** The multimedia service's broadcast. Unprotected, and a custom implicit action, so a receiver
+     * for it has to be registered dynamically — a manifest one is not delivered on Android 8+. */
+    const val ACTION = "APP_REV_DATA"
+
+    /** The `byte[]` extra every channel in this firmware family carries its frame in. */
+    const val EXTRA_FRAME = "list"
+
+    const val GROUP_PANEL_KEY = 4
+    const val SUB_KEY_DOWN = 1
+
+    /** Not a panel key frame. */
+    const val NO_KEY = -1
+
+    // ── Panel key codes ──────────────────────────────────────────────────────────────────────────
+    // Confirmed: implemented in the stock player's `onPanelKeyDown`, and NEXT/PREV were also
+    // captured live on a real unit.
+    const val CODE_PLAY_PAUSE = 0x02
+    const val CODE_NEXT = 0x03
+    const val CODE_PREV = 0x04
+    const val CODE_PHONE = 0x5E
+    const val CODE_MENU = 0x5F
+
+    /**
+     * Base for the virtual key codes given to panel keys with no confirmed meaning, so a user can
+     * learn them in the keymap. Follows the convention the other proprietary receivers already use
+     * (NWD `1000+`, Eryanet `2001+`, BZ `3001+`) and stays clear of all of them; `CommManager`
+     * drops anything at or above 1000 that the user has not mapped, which is exactly the wanted
+     * behaviour for a button whose function nobody knows yet.
+     */
+    const val VIRTUAL_BASE = 4000
+
+    /** One virtual code per possible payload byte. */
+    val VIRTUAL_RANGE = VIRTUAL_BASE until (VIRTUAL_BASE + 256)
+
+    /**
+     * The panel key code carried by [frame], or [NO_KEY] when this frame is not a key press.
+     *
+     * The channel is busy with source changes, ACC state, launcher metadata and the service's own
+     * echo of what other apps send it, so the group/sub check is what keeps all of that out. It also
+     * means a stray broadcast of this very generic action name cannot inject an arbitrary key.
+     */
+    fun panelKeyCode(frame: ByteArray?): Int {
+        if (frame == null || frame.size < 3) return NO_KEY
+        if (u(frame[0]) != GROUP_PANEL_KEY || u(frame[1]) != SUB_KEY_DOWN) return NO_KEY
+        return u(frame[2])
+    }
+
+    /**
+     * The key code to hand to `CarKeyReceiver.handleClick` for a panel key code.
+     *
+     * The three confirmed codes become the real Android media key codes, so play/pause, next and
+     * previous work on a BYD unit with nothing configured. Everything else becomes a virtual code:
+     * sending a guess would be worse than sending nothing, because a wrong guess is a button that
+     * does the wrong thing every time and reads as a bug, whereas a virtual code shows up in the
+     * keymap screen ready to be assigned to whichever Android Auto action the user finds it should
+     * do.
+     */
+    fun toKeyCode(panelCode: Int): Int = when (panelCode) {
+        CODE_PLAY_PAUSE -> KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE
+        CODE_NEXT -> KeyEvent.KEYCODE_MEDIA_NEXT
+        CODE_PREV -> KeyEvent.KEYCODE_MEDIA_PREVIOUS
+        else -> VIRTUAL_BASE + panelCode
+    }
+    /** The panel key code behind a virtual key code, or null when [keyCode] is not one of ours. */
+    fun panelCodeOf(keyCode: Int): Int? =
+        if (keyCode in VIRTUAL_RANGE) keyCode - VIRTUAL_BASE else null
+
+    /**
+     * A name for one of our virtual key codes, for the keymap screen — `KeyEvent.keyCodeToString`
+     * renders these as a bare number, which tells a user nothing about which button they just
+     * pressed. Null for any key code that is not ours.
+     *
+     * Deliberately not translated, like the `keyCodeToString` names it appears alongside: this
+     * names a piece of hardware, and the hex is what a user quotes in a bug report. The question
+     * mark on the phone button is not decoration — that reading is an inference from correlated
+     * Bluetooth traffic, never confirmed at the unit.
+     */
+    fun label(keyCode: Int): String? {
+        val panelCode = panelCodeOf(keyCode) ?: return null
+        val name = when (panelCode) {
+            CODE_PHONE -> "PHONE"
+            CODE_MENU -> "MENU"
+            else -> "KEY"
+        }
+        return String.format(Locale.US, "BYD %s (0x%02X)", name, panelCode)
+    }
+
+    /** Hex rendering of a frame, so an unrecognised one stays recoverable from a user's log. */
+    fun hex(frame: ByteArray): String =
+        frame.joinToString(" ") { String.format(Locale.US, "%02X", it.toInt() and 0xFF) }
+
+    private fun u(b: Byte): Int = b.toInt() and 0xFF
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/main/KeymapFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/KeymapFragment.kt
@@ -18,6 +18,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.andrerinas.openheadunit.R
 import com.andrerinas.openheadunit.contract.KeyIntent
+import com.andrerinas.openheadunit.input.BydPanelKey
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.IntentFilters
 import com.andrerinas.openheadunit.utils.Settings
@@ -206,7 +207,7 @@ class KeymapFragment : Fragment(), MainActivity.KeyListener {
         // Only ignore BACK if we are NOT in assignment mode
         if (keyCode == KeyEvent.KEYCODE_BACK && assignTargetCode == KeyEvent.KEYCODE_UNKNOWN) return false
 
-        val keyName = try { KeyEvent.keyCodeToString(keyCode).replace("KEYCODE_", "") } catch (e: Exception) { "UNKNOWN" }
+        val keyName = physicalKeyName(keyCode)
         val actionName = if (event.action == KeyEvent.ACTION_DOWN) "DOWN" else "UP"
         
         AppLog.i("KeymapFragment: Captured $keyName ($keyCode) $actionName")
@@ -236,6 +237,20 @@ class KeymapFragment : Fragment(), MainActivity.KeyListener {
         return false
     }
 
+    /**
+     * What to call a physical button in this screen. Proprietary buttons are carried as virtual key
+     * codes that `KeyEvent.keyCodeToString` renders as a bare number, which tells a user nothing
+     * about the button they just pressed, so the ones we can name get named.
+     */
+    private fun physicalKeyName(keyCode: Int): String {
+        BydPanelKey.label(keyCode)?.let { return it }
+        return try {
+            KeyEvent.keyCodeToString(keyCode).replace("KEYCODE_", "")
+        } catch (e: Exception) {
+            "UNKNOWN"
+        }
+    }
+
     inner class KeymapAdapter(
         private val items: List<KeymapItem>,
         private var codesMap: Map<Int, Int>,
@@ -260,7 +275,7 @@ class KeymapFragment : Fragment(), MainActivity.KeyListener {
             val physicalKey = codesMap[item.keyCode]
             
             if (physicalKey != null) {
-                holder.valueText.text = KeyEvent.keyCodeToString(physicalKey).replace("KEYCODE_", "")
+                holder.valueText.text = physicalKeyName(physicalKey)
             } else {
                 holder.valueText.text = getString(R.string.not_set)
             }


### PR DESCRIPTION
This functionality was built by reverse engineering the BYD System apps, in particular the Music app and an internal test app (mtest)
Also a sniffer app was created to read information boradcasted by the system

On this BYD head unit, the buttons are **not unhandled `KeyEvent`s — they are not `KeyEvent`s at all.**

The button reaches the MCU, the MCU talks to `com.byd.multimediaservice` over a serial link, and that userspace service re-emits the press as a **broadcast carrying a raw byte frame**. Nothing ever writes to `/dev/input/event*`, so `InputReader` never runs and the framework never synthesises a key event. There is nothing for `dispatchKeyEvent` to see and nothing for a `MEDIA_BUTTON` receiver to pick up.

### The protocol

Broadcast action `APP_REV_DATA`, with the frame in a `byte[]` extra named `list`. The action is unprotected and implicitly addressed.

Frame layout, taken from the stock player's `DZ60.dealData`:

```
byte 0 : group id
byte 1 : sub id
byte 2+: payload, meaning depends on group/sub
```

A panel key is **group `4`, sub `1`**, with the key code in byte 2. One frame per press, with **no matching release**.

```
04 01 03   ->  steering wheel: Next
04 01 5E   ->  panel: Connect
```

The channel is busy with unrelated traffic that shares the same action — source changes, ACC state, camera control, launcher metadata, and the service's echo of what other apps send it — so the group/sub check is what keeps all of that out. Sibling channels in the same firmware reuse the two-byte header with entirely different meanings (the Bluetooth one puts ASCII device names behind `02 03`), which is why `APP_REV_DATA` is the only action registered for and every other channel is left alone.

### Every key is virtual — no defaults

**No panel code is mapped to an Android key code**, not even the three the stock player implements. Each becomes a virtual code at `4000 + panelCode`, and nothing reaches Android Auto until the user binds it in the keymap screen.

### Changes

**`input/BydPanelKey.kt`** (new) — the decoder. Pure functions, no Android dependencies: `panelKeyCode()` validates the header and extracts the code, `toKeyCode()` maps it into the virtual range, `nameOf()`/`label()` supply the catalogue name, `hex()` renders a frame for logs.

**`connection/carkey/byd/CarBydReceiver.kt`** (new) — a `CarKeyReceiver` that registers for `APP_REV_DATA`, decodes each frame, logs it, feeds the keymap screen's debugger, and synthesises a DOWN + UP click (the frame carries no release).

It reads the payload once via `intent.extras?.get()` and type-checks it, rather than calling a typed getter that might not match: `getIntArrayExtra` on a `byte[]`.

`isSupported` is unconditionally `true`. There's no reliable BYD marker to probe: these units are a Freescale board on Android 4.4 with no vendor property naming the manufacturer, and probing for `com.byd.multimediaservice` would silently disable the feature on any firmware variant that renamed it. A false negative here is a head unit whose media buttons do nothing.. 

**`connection/carkey/CarKeyReceiver.kt`** — registers `CarBydReceiver` in `newDefaultReceivers()`.

**`main/KeymapFragment.kt`** — new `physicalKeyName()`, used both for the live key readout and for the bound-key column. `KeyEvent.keyCodeToString` renders a virtual code as a bare number, which tells the user nothing about the button they just pressed; the ones we can name now show as e.g. `BYD Connect (0x5E)`. Names are deliberately untranslated, like the `keyCodeToString` names they sit alongside — this names a piece of hardware, and the hex is what a user quotes in a bug report.

### Car-key receivers now live for the service's lifetime

CarKeyRecevers now live during the whole application lifetime. This is needed because virtual keys needs to be read on the KeymapFragment so they can be asigned to actions.

`CarKeysManager.registerReceivers()` was called from `AapService.onConnected()` and unregistered in `onDisconnected()` — so the receivers existed **only while a projection session was running**. Every other head unit's buttons arrive as real `KeyEvent`s and reach the keymap screen through `dispatchKeyEvent` without any receiver, so this gap was invisible. BYD keys depend entirely on the receiver, so pressing one on the keymap screen while disconnected did nothing at all.

Registration moved to `onCreate()`; teardown stays in `onDestroy()`, where it already was. Nothing leaks to the phone while disconnected — `CommManager.sendKey` returns immediately unless the transport is started. This mirrors what the `MediaSession` in the same file already does, and for the reason its own comment gives: releasing it early means "the keymap stops working until the next connection."

`CarKeysManager` also moved out of `AppComponent` into a `private val` on `AapService`, now that the service owns its full lifetime. At app scope, the `if (registered.isNotEmpty()) return` guard outlives the service instance that set it: a service that died without completing `onDestroy` would leave the manager believing it was still registered, and every later instance's registration would silently no-op with no log line. Service scope makes that desync structurally impossible, and stops the receivers' retained service `Context` from outliving the service.

### Side effects and limitations

- **FYT units:** the lifetime change applies to all three receivers, and `CarFYTReceiver.register()` does more than add a filter — it binds the FYT IPC service, requests root, and sets `sys.carlink.type=2` to take steering-wheel key focus from the unit's own apps. On FYT hardware that now happens at service start rather than at connect. Gated on `ro.fyt.platform` / `syu.fyt.platform`, so no other unit is affected. Worth a second opinion from anyone with FYT hardware; happy to add a `needsSession` flag to keep FYT session-scoped if preferred.