### PR TITLE
Android USB Handler exposure and Black list improvement 

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/App.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/App.kt
@@ -4,7 +4,10 @@ import androidx.appcompat.app.AppCompatDelegate
 import android.app.Application
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.os.UserManager
 import android.os.Build
 import androidx.core.content.ContextCompat
@@ -42,31 +45,18 @@ class App : Application() {
             ConscryptInitializer.initialize()
         }
 
-        // Root support
-        component.suExecutor.register()
-
         if (isUserUnlocked()) {
-            val settings = Settings(this) // Create a Settings instance
-            AppLog.init(settings, this) // Initialize AppLog with settings for conditional logging
-
-            // Sync auto-start settings to device-protected storage so that
-            // BootCompleteReceiver, UsbAttachedActivity, and AutoStartReceiver
-            // can read them during locked boot (before user unlock)
-            Settings.syncAutoStartOnBootToDeviceStorage(this, settings.autoStartOnBoot)
-            Settings.syncAutoStartOnUsbToDeviceStorage(this, settings.autoStartOnUsb)
-            Settings.syncAutoStartOnWifiToDeviceStorage(this, settings.autoStartOnWifi)
-            Settings.syncAutoStartWifiSsidToDeviceStorage(this, settings.autoStartWifiSsid)
-            Settings.syncAutoStartBtMacsToDeviceStorage(this, settings.autoStartBluetoothDeviceMacs)
-            // The blacklist joins them: an install that predates the mirror has its list only in
-            // credential storage, so without this it is invisible until the user edits it.
-            Settings.syncUsbBlacklistToDeviceStorage(this, settings.usbBlacklist)
-
-            // Apply app theme (runs the live manager when dynamic, or when a saved place
-            // can force the app theme even over a static base).
-            AppThemeManager.reapply(this, settings)
+            initUnlockedOnce()
         } else {
             AppLog.init(null, this) // Initialize with default logging if locked
             AppLog.w("App started in Direct Boot mode (locked). Settings access deferred.")
+            // The process outlives the lock screen, so without this it would spend the rest of
+            // its life on defaults: the user's log level, their theme and the auto-start mirrors
+            // would all stay unread until the process happened to die.
+            ContextCompat.registerReceiver(
+                this, userUnlockedReceiver, IntentFilter(Intent.ACTION_USER_UNLOCKED),
+                ContextCompat.RECEIVER_NOT_EXPORTED
+            )
         }
 
         if (ConscryptInitializer.isAvailable()) {
@@ -82,26 +72,72 @@ class App : Application() {
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             val serviceChannel = NotificationChannel(defaultChannel, "Headunit Service", NotificationManager.IMPORTANCE_LOW)
             serviceChannel.description = "Persistent service notification"
             serviceChannel.setShowBadge(false)
-            component.notificationManager.createNotificationChannel(serviceChannel)
+            notificationManager.createNotificationChannel(serviceChannel)
 
             val mediaChannel = NotificationChannel(BackgroundNotification.mediaChannel, "Media Playback", NotificationManager.IMPORTANCE_LOW)
             mediaChannel.setSound(null, null)
             mediaChannel.setShowBadge(false)
-            component.notificationManager.createNotificationChannel(mediaChannel)
+            notificationManager.createNotificationChannel(mediaChannel)
 
             AapNavigation.createNotificationChannel(this)
 
             val bootChannel = NotificationChannel(bootStartChannel, "Boot Auto-Start", NotificationManager.IMPORTANCE_HIGH)
             bootChannel.description = "Shown once after boot to open the app"
             bootChannel.setShowBadge(false)
-            component.notificationManager.createNotificationChannel(bootChannel)
+            notificationManager.createNotificationChannel(bootChannel)
         }
 
         // Register the main broadcast receiver safely for Android 14+ using ContextCompat
         ContextCompat.registerReceiver(this, AapBroadcastReceiver(), AapBroadcastReceiver.filter, ContextCompat.RECEIVER_NOT_EXPORTED)
+    }
+
+    /**
+     * Everything that needs credential-encrypted storage, including the object graph itself:
+     * AppComponent builds a VideoDecoder whose fields read Settings, so touching it before the
+     * first unlock throws and takes the whole process down. Runs once, at start or at unlock.
+     */
+    private fun initUnlockedOnce() {
+        if (unlockedInitDone) return
+        unlockedInitDone = true
+
+        // Root support
+        component.suExecutor.register()
+
+        val settings = Settings(this) // Create a Settings instance
+        AppLog.init(settings, this) // Initialize AppLog with settings for conditional logging
+
+        // Sync auto-start settings to device-protected storage so that
+        // BootCompleteReceiver, UsbAttachedActivity, and AutoStartReceiver
+        // can read them during locked boot (before user unlock)
+        Settings.syncAutoStartOnBootToDeviceStorage(this, settings.autoStartOnBoot)
+        Settings.syncAutoStartOnUsbToDeviceStorage(this, settings.autoStartOnUsb)
+        Settings.syncAutoStartOnWifiToDeviceStorage(this, settings.autoStartOnWifi)
+        Settings.syncAutoStartWifiSsidToDeviceStorage(this, settings.autoStartWifiSsid)
+        Settings.syncAutoStartBtMacsToDeviceStorage(this, settings.autoStartBluetoothDeviceMacs)
+        // The blacklist joins them: an install that predates the mirror has its list only in
+        // credential storage, so without this it is invisible until the user edits it.
+        Settings.syncUsbBlacklistToDeviceStorage(this, settings.usbBlacklist)
+
+        // Apply app theme (runs the live manager when dynamic, or when a saved place
+        // can force the app theme even over a static base).
+        AppThemeManager.reapply(this, settings)
+    }
+
+    private var unlockedInitDone = false
+
+    private val userUnlockedReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            AppLog.i("App: user unlocked, credential storage is available, applying settings")
+            initUnlockedOnce()
+            try {
+                unregisterReceiver(this)
+            } catch (_: IllegalArgumentException) {
+            }
+        }
     }
 
     private fun isUserUnlocked(): Boolean {

--- a/app/src/main/java/com/andrerinas/openheadunit/App.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/App.kt
@@ -57,6 +57,9 @@ class App : Application() {
             Settings.syncAutoStartOnWifiToDeviceStorage(this, settings.autoStartOnWifi)
             Settings.syncAutoStartWifiSsidToDeviceStorage(this, settings.autoStartWifiSsid)
             Settings.syncAutoStartBtMacsToDeviceStorage(this, settings.autoStartBluetoothDeviceMacs)
+            // The blacklist joins them: an install that predates the mirror has its list only in
+            // credential storage, so without this it is invisible until the user edits it.
+            Settings.syncUsbBlacklistToDeviceStorage(this, settings.usbBlacklist)
 
             // Apply app theme (runs the live manager when dynamic, or when a saved place
             // can force the app theme even over a static base).

--- a/app/src/main/java/com/andrerinas/openheadunit/app/AutoStartReceiver.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/app/AutoStartReceiver.kt
@@ -23,9 +23,17 @@ class AutoStartReceiver : BroadcastReceiver() {
         val isLocked = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && 
                       !(context.getSystemService(Context.USER_SERVICE) as UserManager).isUserUnlocked
         
+        // Before the first unlock there is no credential storage, which both the session and the
+        // object graph read, so there is nothing to start yet. Nothing replays this event either,
+        // so a phone that connected at the lock screen has to reconnect once the user is in.
+        if (isLocked) {
+            AppLog.w("AutoStartReceiver: device is locked, ignoring the Bluetooth event until the user unlocks.")
+            return
+        }
+
         // [FIX] Don't trigger auto-start if we are already connected!
         // This prevents activity restarts if BT reconnects during a session.
-        if (!isLocked && com.andrerinas.openheadunit.App.provide(context).commManager.isConnected) {
+        if (com.andrerinas.openheadunit.App.provide(context).commManager.isConnected) {
             AppLog.d("AutoStartReceiver: Already connected to Android Auto. Ignoring BT event.")
             return
         }

--- a/app/src/main/java/com/andrerinas/openheadunit/app/UsbAttachedActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/app/UsbAttachedActivity.kt
@@ -113,6 +113,11 @@ class UsbAttachedActivity : Activity() {
                 finish()
                 return
             }
+            if (isLocked) {
+                AppLog.w("Usb in accessory mode, but the user has not unlocked yet and a session needs credential storage. Waiting for unlock.")
+                finish()
+                return
+            }
             AppLog.i("Usb in accessory mode and has permission. Starting AapService.")
             ContextCompat.startForegroundService(this, Intent(this, AapService::class.java).apply {
                 action = AapService.ACTION_CHECK_USB
@@ -128,7 +133,7 @@ class UsbAttachedActivity : Activity() {
         // Use device-protected storage for the auto-start check so it works
         // during locked boot (before credential storage is available)
         val autoStartOnUsb = Settings.isAutoStartOnUsbEnabled(this)
-        if (autoStartOnUsb && !App.provide(this).commManager.isConnected) {
+        if (autoStartOnUsb && (isLocked || !App.provide(this).commManager.isConnected)) {
             AppLog.i("USB auto-start: launching app for ${deviceCompat.uniqueName}")
             try {
                 startActivity(Intent(this, MainActivity::class.java).apply {

--- a/app/src/main/java/com/andrerinas/openheadunit/app/UsbAttachedActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/app/UsbAttachedActivity.kt
@@ -16,6 +16,7 @@ import com.andrerinas.openheadunit.aap.AapService
 import com.andrerinas.openheadunit.connection.CommManager
 import com.andrerinas.openheadunit.connection.usb.UsbAccessoryMode
 import com.andrerinas.openheadunit.connection.usb.UsbDeviceCompat
+import com.andrerinas.openheadunit.connection.usb.UsbDeviceDiagnostics
 import com.andrerinas.openheadunit.connection.usb.UsbReceiver
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.DeviceIntent
@@ -34,6 +35,7 @@ class UsbAttachedActivity : Activity() {
 
     private fun resolveUsbDevice(intent: Intent?): UsbDevice? {
         val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
+        UsbDeviceDiagnostics.logDeviceList(this, usbManager, "USB attach")
         val androidDevices = usbManager.deviceList.values.filter { UsbDeviceCompat.isAndroidDevice(it) }
         return resolveDevice(intent, androidDevices)
     }
@@ -88,8 +90,8 @@ class UsbAttachedActivity : Activity() {
 
         val settings = if (!isLocked) Settings(this) else null
 
-        if (settings != null && settings.isUsbDeviceBlacklisted(device.vendorId, device.productId)) {
-            AppLog.i("UsbAttachedActivity: Ignored blacklisted USB device (${settings.formatUsbVidPidDisplay(device.vendorId, device.productId)})")
+        if (Settings.isUsbDeviceBlacklisted(this, device)) {
+            AppLog.i("UsbAttachedActivity: Ignored blacklisted USB device (${Settings.formatUsbVidPidDisplay(device.vendorId, device.productId)})")
             finish()
             return
         }
@@ -189,9 +191,8 @@ class UsbAttachedActivity : Activity() {
         val isLocked = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
                       !(getSystemService(Context.USER_SERVICE) as UserManager).isUserUnlocked
 
-        val settings = if (!isLocked) Settings(this) else null
-        if (settings != null && settings.isUsbDeviceBlacklisted(device.vendorId, device.productId)) {
-            AppLog.i("UsbAttachedActivity: Ignored blacklisted USB device in onNewIntent (${settings.formatUsbVidPidDisplay(device.vendorId, device.productId)})")
+        if (Settings.isUsbDeviceBlacklisted(this, device)) {
+            AppLog.i("UsbAttachedActivity: Ignored blacklisted USB device in onNewIntent (${Settings.formatUsbVidPidDisplay(device.vendorId, device.productId)})")
             finish()
             return
         }

--- a/app/src/main/java/com/andrerinas/openheadunit/app/WifiAutoStartReceiver.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/app/WifiAutoStartReceiver.kt
@@ -18,6 +18,7 @@ import com.andrerinas.openheadunit.main.MainActivity
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.Settings
 import android.os.Build
+import android.os.UserManager
 
 class WifiAutoStartReceiver : BroadcastReceiver() {
 
@@ -42,6 +43,16 @@ class WifiAutoStartReceiver : BroadcastReceiver() {
             if (!Settings.isAutoStartOnWifiEnabled(context)) return
             val targetSsid = Settings.getAutoStartWifiSsid(context).removeSurrounding("\"")
             if (targetSsid.isEmpty()) return
+
+            // Before the first unlock there is no credential storage, which both the session and
+            // the object graph read, so there is nothing to start yet. BootCompleteReceiver runs
+            // this decision again on ACTION_USER_UNLOCKED. Asked after the settings above so a
+            // user who never enabled this does not get the line on every locked boot.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
+                !(context.getSystemService(Context.USER_SERVICE) as UserManager).isUserUnlocked) {
+                AppLog.w("WifiAutoStartReceiver: device is locked, deferring WiFi auto-start until unlock.")
+                return
+            }
 
             val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
             val wifiInfo: WifiInfo? = wifiManager.connectionInfo

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbBlacklistPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbBlacklistPolicy.kt
@@ -1,0 +1,62 @@
+package com.andrerinas.openheadunit.connection.usb
+
+import java.util.Locale
+
+/**
+ * The user's "never touch this device" list: how a device is named in it, and the membership test.
+ *
+ * The key is the manufacturer and product strings rather than VID:PID, because a phone's VID:PID
+ * changes with its USB mode while its strings do not. Keyed on the numbers, a blacklisted phone
+ * walks straight back in on the next mode, and one that arrives already in accessory mode is never
+ * matched at all. A device with no string descriptors falls back to VID:PID, which is all it had.
+ *
+ * The format is pinned because three places have to agree on it: the list UI writes it, the
+ * device-protected mirror copies it, and a settings export hands it to the user as an editable file.
+ */
+object UsbBlacklistPolicy {
+
+    private const val NAME_PREFIX = "name:"
+    private const val VID_PID_PREFIX = "vidpid:"
+
+    /**
+     * The name the device is stored under. Pass null strings when they are unreadable, which is
+     * every device below API 21 and any device that ships no string descriptors.
+     */
+    fun key(manufacturer: String?, product: String?, vendorId: Int, productId: Int): String {
+        val name = listOfNotNull(manufacturer, product)
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .joinToString(" ")
+        return if (name.isNotEmpty()) NAME_PREFIX + name.lowercase(Locale.US)
+        else vidPidKey(vendorId, productId)
+    }
+
+    fun vidPidKey(vendorId: Int, productId: Int): String =
+        String.format(Locale.US, "%s%04x:%04x", VID_PID_PREFIX, vendorId, productId)
+
+    /**
+     * Matches on the device's own key, and also on its bare VID:PID. The second is for entries
+     * written before the key carried a prefix, so an old list keeps working until the user redoes
+     * it rather than failing silently.
+     */
+    fun isBlacklisted(blacklist: Set<String>, key: String, vendorId: Int, productId: Int): Boolean {
+        if (blacklist.isEmpty()) return false
+        val legacy = String.format(Locale.US, "%04x:%04x", vendorId, productId)
+        val wanted = setOf(key, vidPidKey(vendorId, productId), legacy)
+        return normalise(blacklist).any { it in wanted }
+    }
+
+    fun add(blacklist: Set<String>, key: String): Set<String> = normalise(blacklist) + key
+
+    fun remove(blacklist: Set<String>, key: String, vendorId: Int, productId: Int): Set<String> {
+        val legacy = String.format(Locale.US, "%04x:%04x", vendorId, productId)
+        val gone = setOf(key, vidPidKey(vendorId, productId), legacy)
+        return normalise(blacklist).filterTo(LinkedHashSet()) { it !in gone }
+    }
+
+    /** Writes the stored set back in the canonical form, so a rewrite fixes what a read tolerates. */
+    fun normalise(blacklist: Set<String>): Set<String> =
+        blacklist.mapNotNullTo(LinkedHashSet()) {
+            it.trim().lowercase(Locale.US).takeIf(String::isNotEmpty)
+        }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbDeviceCompat.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbDeviceCompat.kt
@@ -1,9 +1,11 @@
 package com.andrerinas.openheadunit.connection.usb
 
+import android.content.Context
 import android.hardware.usb.UsbConstants
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbInterface
 import android.os.Build
+import com.andrerinas.openheadunit.utils.Settings
 import com.andrerinas.openheadunit.utils.Utils
 import java.util.Locale
 
@@ -29,11 +31,6 @@ class UsbDeviceCompat(val wrappedDevice: UsbDevice) {
         get() = isInAccessoryMode(wrappedDevice)
 
     companion object {
-        private const val USB_VID_GOO = 0x18D1   // 6353   Nexus or ACC mode, see PID to distinguish
-        private const val USB_PID_ACC = 0x2D00      // Accessory                  100
-        private const val USB_PID_ACC_ADB = 0x2D01      // Accessory + ADB            110
-        private const val APPLE_VID = 0x05AC
-
         fun getUniqueName(device: UsbDevice): String {
             val vendorId = device.vendorId
             val productId = device.productId
@@ -55,79 +52,96 @@ class UsbDeviceCompat(val wrappedDevice: UsbDevice) {
             return vidPid
         }
 
-        fun isInAccessoryMode(device: UsbDevice): Boolean {
-            val dev_vend_id = device.vendorId
-            val dev_prod_id = device.productId
-            return dev_vend_id == USB_VID_GOO &&
-                (dev_prod_id == USB_PID_ACC || dev_prod_id == USB_PID_ACC_ADB)
-        }
+        fun isInAccessoryMode(device: UsbDevice): Boolean =
+            UsbDeviceIdentityPolicy.isInAccessoryMode(device.vendorId, device.productId)
 
-        fun isAndroidDevice(device: UsbDevice): Boolean {
-            // Apple does not support Android Auto
-            if (device.vendorId == APPLE_VID) return false
+        fun isAndroidDevice(device: UsbDevice): Boolean = evaluate(device).accepted
 
-            if (isInAccessoryMode(device)) return true
+        /**
+         * [isAndroidDevice] plus the user's blacklist. Every path that acts on a device asks this
+         * one; [isAndroidDevice] alone is for the list UI and the diagnostic dump, where a
+         * blacklisted device still has to appear so it can be taken off the list.
+         *
+         * The blacklist is read from device-protected storage, so it applies during a locked boot
+         * as well. It used to be consulted in one of seven paths, and skipped entirely when the
+         * user had not unlocked.
+         */
+        fun isConnectable(context: Context, device: UsbDevice): Boolean =
+            isAndroidDevice(device) && !Settings.isUsbDeviceBlacklisted(context, device)
 
-            return hasAndroidInterface(device)
+        /**
+         * How the device is named in the user's blacklist. Manufacturer and product rather than
+         * VID:PID, because those survive a USB mode change and the numbers do not; see
+         * [UsbBlacklistPolicy].
+         */
+        fun blacklistKey(device: UsbDevice): String {
+            val readable = Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+            return UsbBlacklistPolicy.key(
+                manufacturer = if (readable) device.manufacturerName else null,
+                product = if (readable) device.productName else null,
+                vendorId = device.vendorId,
+                productId = device.productId,
+            )
         }
 
         /**
-         * Identifies an Android device by USB class/subclass
-         * More reliable than a VID list
+         * The same decision as [isAndroidDevice], but it says which rule fired. A user reporting
+         * "no USB device found" cannot otherwise be told apart from a device we rejected, so this
+         * feeds the diagnostic dump rather than any connection logic.
          */
-        private fun hasAndroidInterface(device: UsbDevice): Boolean {
+        fun matchReason(device: UsbDevice): String = evaluate(device).toString()
+
+        /**
+         * [matchReason] plus the blacklist, for the paths that refuse on [isConnectable]. The
+         * descriptor verdict on its own says "accepted" for a device the user has vetoed, which
+         * is the opposite of what someone reading the log to find out why their phone will not
+         * connect is looking for.
+         */
+        fun connectableReason(context: Context, device: UsbDevice): String =
+            if (Settings.isUsbDeviceBlacklisted(context, device)) BLACKLISTED_REASON
+            else matchReason(device)
+
+        /**
+         * The blacklist is the one reason a device the descriptors accept still will not connect,
+         * and a user who set it months ago will not mention it in a bug report.
+         */
+        const val BLACKLISTED_REASON = "rejected: blacklisted by the user"
+
+        private fun evaluate(device: UsbDevice): UsbDeviceIdentityPolicy.Verdict =
+            UsbDeviceIdentityPolicy.evaluate(describe(device))
+
+        /** Maps the Android object onto the plain descriptors the policy decides on. */
+        private fun describe(device: UsbDevice): UsbDeviceIdentityPolicy.Device {
+            val interfaces = ArrayList<UsbDeviceIdentityPolicy.Interface>(device.interfaceCount)
             for (i in 0 until device.interfaceCount) {
-                val usbInterface = device.getInterface(i)
-                val ifaceClass = usbInterface.interfaceClass
-                val ifaceSubclass = usbInterface.interfaceSubclass
-                val ifaceProtocol = usbInterface.interfaceProtocol
-
-                // AOAP (Android Open Accessory Protocol)
-                if (ifaceClass == 0xFF && ifaceSubclass == 0xFF && ifaceProtocol == 0x00) {
-                    if (hasBulkEndpoint(usbInterface)) return true
-                }
-
-                // MTP (Media Transfer Protocol)
-                if (ifaceClass == UsbConstants.USB_CLASS_MASS_STORAGE &&
-                    ifaceSubclass == 0x06 && ifaceProtocol == 0x01) {
-                    return true
-                }
-
-                // ADB (Android Debug Bridge)
-                if (ifaceClass == 0xFF && ifaceSubclass == 0x42 && ifaceProtocol == 0x01) {
-                    return true
-                }
-
-                // RNDIS (USB tethering)
-                if (ifaceClass == 0xE0 && ifaceSubclass == 0x01 && ifaceProtocol == 0x03) {
-                    return true
-                }
-
-                // IAD (Interface Association Descriptor) - современные Android
-                if (ifaceClass == 0xEF && ifaceSubclass == 0x04 && ifaceProtocol == 0x01) {
-                    return true
-                }
-
-                // PTP (Picture Transfer Protocol) - старые Android
-                if (ifaceClass == 0x06 && ifaceSubclass == 0x01 && ifaceProtocol == 0x01) {
-                    return true
-                }
+                interfaces.add(describe(device.getInterface(i)))
             }
-
-            return false
+            return UsbDeviceIdentityPolicy.Device(
+                vendorId = device.vendorId,
+                productId = device.productId,
+                deviceClass = device.deviceClass,
+                interfaces = interfaces,
+            )
         }
 
-        /**
-         * Checks for the presence of a bulk endpoint (needed for data transfer)
-         */
-        private fun hasBulkEndpoint(usbInterface: UsbInterface): Boolean {
+        private fun describe(usbInterface: UsbInterface): UsbDeviceIdentityPolicy.Interface {
+            var hasBulkIn = false
+            var hasBulkOut = false
             for (j in 0 until usbInterface.endpointCount) {
                 val endpoint = usbInterface.getEndpoint(j)
-                if (endpoint.type == UsbConstants.USB_ENDPOINT_XFER_BULK) {
-                    return true
-                }
+                if (endpoint.type != UsbConstants.USB_ENDPOINT_XFER_BULK) continue
+                if (endpoint.direction == UsbConstants.USB_DIR_IN) hasBulkIn = true else hasBulkOut = true
             }
-            return false
+            return UsbDeviceIdentityPolicy.Interface(
+                ifaceClass = usbInterface.interfaceClass,
+                subclass = usbInterface.interfaceSubclass,
+                protocol = usbInterface.interfaceProtocol,
+                // getName() is API 21; below that the descriptor rules run without it, which
+                // only costs the accessory case its tie-breaker.
+                name = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) usbInterface.name else null,
+                hasBulkIn = hasBulkIn,
+                hasBulkOut = hasBulkOut,
+            )
         }
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbDeviceDiagnostics.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbDeviceDiagnostics.kt
@@ -1,0 +1,104 @@
+package com.andrerinas.openheadunit.connection.usb
+
+import android.content.Context
+import android.hardware.usb.UsbConstants
+import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbInterface
+import android.hardware.usb.UsbManager
+import com.andrerinas.openheadunit.utils.AppLog
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Dumps the raw USB bus alongside our own verdict on each device. Every enumeration site filters
+ * with [UsbDeviceCompat.isAndroidDevice], so a user reporting "no USB device found" could mean
+ * nothing was on the bus or that we rejected what was there, and the logs could not tell them
+ * apart. An empty result is the case worth reporting, so it prints at INFO; otherwise Verbose.
+ */
+object UsbDeviceDiagnostics {
+
+    /** Last dump per caller, so a repeated scan of an unchanged bus does not repeat itself. */
+    private val lastSignatures = ConcurrentHashMap<String, String>()
+
+    fun logDeviceList(context: Context, usbManager: UsbManager, caller: String) {
+        val devices = try {
+            usbManager.deviceList.values.toList()
+        } catch (e: Throwable) {
+            // Some head unit ROMs throw out of getDeviceList() rather than returning empty.
+            AppLog.e("UsbDiagnostics: $caller could not read the USB device list: ${e.message}")
+            return
+        }
+
+        val accepted = devices.count { UsbDeviceCompat.isConnectable(context, it) }
+        val reportAtInfo = accepted == 0
+        val lines = devices.map { "UsbDiagnostics:   ${describe(context, it, usbManager)}" }
+
+        // The service scan runs on every attach, detach and permission result, so repeating an
+        // unchanged bus would bury the change that matters in a log the user has to read. Keyed by
+        // caller as well, so pressing the USB button always says what it saw.
+        val signature = "$accepted/${devices.size}|" + lines.joinToString("|")
+        if (lastSignatures.put(caller, signature) == signature) return
+
+        val header = "UsbDiagnostics: $caller sees ${devices.size} USB device(s), " +
+            "$accepted usable for Android Auto"
+        if (reportAtInfo) AppLog.i(header) else AppLog.v(header)
+
+        for (line in lines) {
+            if (reportAtInfo) AppLog.i(line) else AppLog.v(line)
+        }
+
+        if (devices.isEmpty()) {
+            // The common causes, in the order they are worth checking, so the log answers the
+            // question without a round trip to the reporter.
+            AppLog.i(
+                "UsbDiagnostics: nothing is on the bus. Either the port carries no data, the unit " +
+                    "is not in USB host mode, or a wireless adapter is waiting for its phone " +
+                    "before it presents itself."
+            )
+        }
+    }
+
+    /** One line per device: identity, our verdict, and every interface descriptor behind it. */
+    fun describe(context: Context, device: UsbDevice, usbManager: UsbManager): String {
+        val sb = StringBuilder()
+        sb.append(UsbDeviceCompat.getUniqueName(device))
+        sb.append(" [")
+        sb.append(String.format(Locale.US, "class %02X/%02X/%02X",
+            device.deviceClass, device.deviceSubclass, device.deviceProtocol))
+        sb.append(if (usbManager.hasPermission(device)) ", permission" else ", no permission")
+        sb.append("] ")
+        sb.append(UsbDeviceCompat.connectableReason(context, device))
+
+        for (i in 0 until device.interfaceCount) {
+            val iface = device.getInterface(i)
+            sb.append(String.format(Locale.US, " | if%d %02X/%02X/%02X",
+                i, iface.interfaceClass, iface.interfaceSubclass, iface.interfaceProtocol))
+            sb.append(" ").append(endpointSummary(iface))
+        }
+        return sb.toString()
+    }
+
+    /**
+     * Endpoint shape matters because an accessory interface needs a bulk IN and a bulk OUT. Counts
+     * rather than flags: a phone in file transfer and a vendor ethernet controller both come out as
+     * "bulkIn+bulkOut", and the second bulk OUT is the only thing in the shape that differs.
+     */
+    private fun endpointSummary(iface: UsbInterface): String {
+        var bulkIn = 0
+        var bulkOut = 0
+        var others = 0
+        for (j in 0 until iface.endpointCount) {
+            val ep = iface.getEndpoint(j)
+            if (ep.type == UsbConstants.USB_ENDPOINT_XFER_BULK) {
+                if (ep.direction == UsbConstants.USB_DIR_IN) bulkIn++ else bulkOut++
+            } else {
+                others++
+            }
+        }
+        val parts = mutableListOf<String>()
+        if (bulkIn > 0) parts.add("${bulkIn}xbulkIn")
+        if (bulkOut > 0) parts.add("${bulkOut}xbulkOut")
+        if (others > 0) parts.add("$others other")
+        return if (parts.isEmpty()) "(no endpoints)" else "(${parts.joinToString("+")})"
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbDeviceIdentityPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbDeviceIdentityPolicy.kt
@@ -1,0 +1,158 @@
+package com.andrerinas.openheadunit.connection.usb
+
+/**
+ * Decides whether a USB device is something we can project Android Auto to, and says why.
+ *
+ * The rules used to live inside [UsbDeviceCompat] against a live `UsbDevice`, so nothing could be
+ * tested and a wrong verdict was only ever visible on hardware. This takes plain descriptors
+ * instead, so a device that misbehaves in the field can be reproduced from its logged line.
+ */
+object UsbDeviceIdentityPolicy {
+
+    /** One interface descriptor, plus the endpoint shape the accessory rule needs. */
+    data class Interface(
+        val ifaceClass: Int,
+        val subclass: Int,
+        val protocol: Int,
+        val name: String? = null,
+        val hasBulkIn: Boolean = false,
+        val hasBulkOut: Boolean = false,
+    )
+
+    /**
+     * A whole device. [interfaces] is every interface across every configuration, which is what
+     * `UsbDevice.getInterfaceCount()` returns and is what makes the CDC-sibling rule below work.
+     *
+     * It is not enough on its own. The same ethernet adapter also enumerates as a single vendor
+     * configuration with no CDC interface anywhere in the descriptor, and then only [deviceClass]
+     * separates it from a phone.
+     */
+    data class Device(
+        val vendorId: Int,
+        val productId: Int,
+        val deviceClass: Int,
+        val interfaces: List<Interface>,
+    )
+
+    data class Verdict(val accepted: Boolean, val reason: String) {
+        /** The form the diagnostic dump prints, e.g. "accepted: ADB". */
+        override fun toString(): String = (if (accepted) "accepted: " else "rejected: ") + reason
+    }
+
+    private const val APPLE_VID = 0x05AC
+    private const val GOOGLE_VID = 0x18D1
+    private const val PID_ACCESSORY = 0x2D00
+    private const val PID_ACCESSORY_ADB = 0x2D01
+
+    /**
+     * `iInterface` on the vendor-class interface. Three different products present the identical
+     * FF/FF/00 triple, and only this string tells them apart: the accessory gadget names itself,
+     * Android's MTP function names itself, and a network adapter names its own thing.
+     */
+    private const val NAME_ACCESSORY = "Android Accessory Interface"
+    private const val NAME_MTP = "MTP"
+
+    /**
+     * CDC control subclasses that mean "this device carries a network". Keyed on these rather than
+     * on the CDC classes themselves because a phone in file transfer can ship a CDC ACM pair whose
+     * data interface is byte-identical to an ethernet adapter's, and only the control subclass
+     * tells a serial port from a NIC.
+     */
+    private val CDC_NETWORK_SUBCLASSES = setOf(
+        0x06, // ECM
+        0x0C, // EEM
+        0x0D, // NCM
+        0x0E, // MBIM
+    )
+
+    /** Device classes that describe the whole device and can never be a phone. */
+    private val EXCLUDED_DEVICE_CLASSES = setOf(
+        0x01, // audio
+        0x07, // printer
+        0x08, // mass storage
+        0x09, // hub
+        0x0E, // video
+        0x11, // billboard, the alt-mode announcer inside every USB-C dock
+    )
+
+    fun evaluate(device: Device): Verdict {
+        // Apple does not support Android Auto.
+        if (device.vendorId == APPLE_VID) return Verdict(false, "Apple VID")
+
+        if (isInAccessoryMode(device.vendorId, device.productId)) {
+            return Verdict(true, "already in accessory mode")
+        }
+
+        // Rarely fires, because a composite device reports class 0 and defers to its interfaces.
+        // It is still the cheapest way to drop a device that has declared what it is.
+        if (device.deviceClass in EXCLUDED_DEVICE_CLASSES) {
+            return Verdict(false, "device class ${hex(device.deviceClass)} is not a phone")
+        }
+
+        // The unambiguous triples first, so a tethering or debugging phone is decided before the
+        // vendor-class rule below ever has to guess.
+        for (iface in device.interfaces) {
+            unambiguousMatch(iface)?.let { return Verdict(true, it) }
+        }
+
+        for (iface in device.interfaces) {
+            if (isVendorClass(iface) && iface.hasBulkIn && iface.hasBulkOut) {
+                return accessoryVerdict(device, iface)
+            }
+        }
+
+        return Verdict(false, "no Android interface")
+    }
+
+    /**
+     * The post-switch identity. Kept here rather than in the caller so the accepted PID set has one
+     * definition, because widening it is a known pending change.
+     */
+    fun isInAccessoryMode(vendorId: Int, productId: Int): Boolean =
+        vendorId == GOOGLE_VID && (productId == PID_ACCESSORY || productId == PID_ACCESSORY_ADB)
+
+    private fun unambiguousMatch(iface: Interface): String? = when {
+        // ADB.
+        iface.ifaceClass == 0xFF && iface.subclass == 0x42 && iface.protocol == 0x01 -> "ADB"
+        // RNDIS tethering. Checked before the vendor-class rule because a tethering phone also
+        // carries the CDC-data interface that rule treats as a network adapter.
+        iface.ifaceClass == 0xE0 && iface.subclass == 0x01 && iface.protocol == 0x03 -> "RNDIS"
+        // PTP, the still-image class.
+        iface.ifaceClass == 0x06 && iface.subclass == 0x01 && iface.protocol == 0x01 -> "PTP"
+        // Interface Association Descriptor.
+        iface.ifaceClass == 0xEF && iface.subclass == 0x04 && iface.protocol == 0x01 -> "IAD"
+        // Mass storage carrying MTP over CBI. Modern phones do not use this; kept because older
+        // ones did. The name is what the rule has always claimed, so it stays.
+        iface.ifaceClass == 0x08 && iface.subclass == 0x06 && iface.protocol == 0x01 -> "MTP"
+        else -> null
+    }
+
+    /**
+     * FF/FF/00 with a bulk pair is the real accessory triple, so it cannot simply be tightened.
+     * A USB ethernet controller presents exactly that on its vendor control interface, and OHU
+     * used to accept and auto-connect to one. The name settles it when there is one; failing that,
+     * a vendor-class device descriptor or a CDC sibling means a peripheral rather than a phone.
+     */
+    private fun accessoryVerdict(device: Device, iface: Interface): Verdict = when {
+        iface.name == NAME_ACCESSORY -> Verdict(true, "AOAP")
+        iface.name == NAME_MTP -> Verdict(true, "MTP")
+        // An Android gadget always defers to its interfaces and reports device class 0. A vendor
+        // class on the device descriptor is the adapter saying the whole device is proprietary,
+        // and it is the only thing separating one from a phone in file transfer, whose interface
+        // carries the same triple and the same endpoints.
+        device.deviceClass == 0xFF -> Verdict(false, "vendor-class device, not a phone")
+        device.interfaces.any { it.ifaceClass == 0x02 && it.subclass in CDC_NETWORK_SUBCLASSES } ->
+            Verdict(false, "CDC network adapter")
+        // Nothing named it and nothing vetoed it, so probe rather than guess. The name is printed
+        // because a wrong verdict here is only ever diagnosed from a reporter's log line.
+        else -> Verdict(true, "AOAP (vendor interface named ${describeName(iface.name)})")
+    }
+
+    private fun describeName(name: String?): String =
+        if (name.isNullOrBlank()) "nothing" else "'" + name + "'"
+
+    private fun isVendorClass(iface: Interface): Boolean =
+        iface.ifaceClass == 0xFF && iface.subclass == 0xFF && iface.protocol == 0x00
+
+    private fun hex(value: Int): String = "0x%02X".format(value)
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbLauncherListener.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbLauncherListener.kt
@@ -8,6 +8,7 @@ import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.R
 import com.andrerinas.openheadunit.connection.usb.UsbLauncherManager.Companion.ATTACH_FALLBACK_DELAY_MS
 import com.andrerinas.openheadunit.utils.AppLog
+import com.andrerinas.openheadunit.utils.Settings
 import com.andrerinas.openheadunit.utils.ToastUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -21,8 +22,8 @@ class UsbLauncherListener(private val manager: UsbLauncherManager) : UsbReceiver
     private val service = manager.service
 
     override fun onUsbAttach(device: UsbDevice) {
-        if (!UsbDeviceCompat.isAndroidDevice(device)) {
-            AppLog.i("Ignoring non-Android USB device attached in service (VID: ${device.vendorId}): ${device.deviceName}")
+        if (!UsbDeviceCompat.isConnectable(service, device)) {
+            AppLog.i("Ignoring USB device attached in service (${Settings.formatUsbVidPidDisplay(device.vendorId, device.productId)}): ${UsbDeviceCompat.connectableReason(service, device)}")
             return
         }
 
@@ -86,8 +87,8 @@ class UsbLauncherListener(private val manager: UsbLauncherManager) : UsbReceiver
     }
 
     override fun onUsbPermission(granted: Boolean, connect: Boolean, device: UsbDevice) {
-        if (!UsbDeviceCompat.isAndroidDevice(device)) {
-            AppLog.i("Ignoring USB permission callback for non-Android device (VID: ${device.vendorId}): ${device.deviceName}")
+        if (!UsbDeviceCompat.isConnectable(service, device)) {
+            AppLog.i("Ignoring USB permission callback (VID: ${device.vendorId}): ${UsbDeviceCompat.matchReason(device)}")
             return
         }
         val deviceName = UsbDeviceCompat(device).uniqueName

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbLauncherManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbLauncherManager.kt
@@ -138,7 +138,8 @@ class UsbLauncherManager(val service: AapService) {
             isSwitchingToProjection.get()) return
 
         val usbManager = service.getSystemService(Context.USB_SERVICE) as UsbManager
-        val deviceList = usbManager.deviceList.values.filter { UsbDeviceCompat.isAndroidDevice(it) }
+        UsbDeviceDiagnostics.logDeviceList(service, usbManager, "service scan (force=$force)")
+        val deviceList = usbManager.deviceList.values.filter { UsbDeviceCompat.isConnectable(service, it) }
 
         // Check for devices already in accessory mode first.
         // After AOA switch the device re-enumerates and appears as a new USB device — we must

--- a/app/src/main/java/com/andrerinas/openheadunit/main/HomeFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/HomeFragment.kt
@@ -28,6 +28,7 @@ import com.andrerinas.openheadunit.aap.AapProjectionActivity
 import com.andrerinas.openheadunit.aap.AapService
 import com.andrerinas.openheadunit.connection.wifi.modes.helper.NearbyManager
 import com.andrerinas.openheadunit.connection.usb.UsbDeviceCompat
+import com.andrerinas.openheadunit.connection.usb.UsbDeviceDiagnostics
 import android.content.res.Configuration
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.AppPermissions
@@ -396,8 +397,9 @@ class HomeFragment : Fragment() {
 
             // Get list of Android USB devices
             val usbManager = requireContext().getSystemService(Context.USB_SERVICE) as UsbManager
+            UsbDeviceDiagnostics.logDeviceList(requireContext(), usbManager, "USB button")
             val androidDevices = usbManager.deviceList.values
-                .filter { UsbDeviceCompat.isAndroidDevice(it) }
+                .filter { UsbDeviceCompat.isConnectable(requireContext(), it) }
 
             // If exactly one device found - auto-connect
             if (androidDevices.size == 1) {

--- a/app/src/main/java/com/andrerinas/openheadunit/main/MainViewModel.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/MainViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
 import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.connection.usb.UsbDeviceCompat
+import com.andrerinas.openheadunit.connection.usb.UsbDeviceDiagnostics
 import com.andrerinas.openheadunit.connection.usb.UsbReceiver
 import com.andrerinas.openheadunit.utils.Settings
 
@@ -48,6 +49,7 @@ class MainViewModel(application: Application): AndroidViewModel(application), Us
 
     private fun createDeviceList(allowDevices: Set<String>): List<UsbDeviceCompat> {
         val manager = app.getSystemService(android.content.Context.USB_SERVICE) as UsbManager
+        UsbDeviceDiagnostics.logDeviceList(app, manager, "USB list")
         val devices = manager.deviceList.values.map { UsbDeviceCompat(it) }
         return filterAndSort(devices, allowDevices)
     }

--- a/app/src/main/java/com/andrerinas/openheadunit/main/UsbListFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/UsbListFragment.kt
@@ -126,7 +126,7 @@ class UsbListFragment : Fragment() {
             holder.startButton.tag = position
             holder.startButton.setOnClickListener(this)
 
-            val isBlacklisted = mSettings.isUsbDeviceBlacklisted(device.vendorId, device.productId)
+            val isBlacklisted = mSettings.isUsbDeviceBlacklisted(device.wrappedDevice)
 
             if (device.isInAccessoryMode) {
                 holder.allowButton.setText(R.string.allowed)
@@ -169,19 +169,19 @@ class UsbListFragment : Fragment() {
             }
             val device = deviceList[position]
             if (v.id == android.R.id.button1) {
-                val isBlacklisted = mSettings.isUsbDeviceBlacklisted(device.vendorId, device.productId)
+                val isBlacklisted = mSettings.isUsbDeviceBlacklisted(device.wrappedDevice)
                 val isAllowed = allowedDevices.contains(device.uniqueName)
 
                 when {
                     isBlacklisted -> {
                         // Blacklisted -> Ignored
-                        mSettings.removeUsbDeviceFromBlacklist(device.vendorId, device.productId)
+                        mSettings.removeUsbDeviceFromBlacklist(device.wrappedDevice)
                     }
                     isAllowed -> {
                         // Allowed -> Blacklisted
                         allowedDevices.remove(device.uniqueName)
                         mSettings.allowedDevices = allowedDevices
-                        mSettings.addUsbDeviceToBlacklist(device.vendorId, device.productId)
+                        mSettings.addUsbDeviceToBlacklist(device.wrappedDevice)
                     }
                     else -> {
                         // Ignored -> Allowed
@@ -191,6 +191,11 @@ class UsbListFragment : Fragment() {
                 }
                 notifyDataSetChanged()
             } else {
+                if (mSettings.isUsbDeviceBlacklisted(device.wrappedDevice)) {
+                    // The row already says "Blacklisted" and the button used to connect anyway.
+                    Toast.makeText(mContext, R.string.blacklisted, Toast.LENGTH_SHORT).show()
+                    return
+                }
                 if (App.provide(mContext).commManager.isConnected) {
 
                     // Already connected -> bring existing projection to front

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -5,6 +5,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
+import android.hardware.usb.UsbDevice
 import android.location.Location
 import android.media.AudioManager
 import android.os.Build
@@ -15,6 +16,7 @@ import com.andrerinas.openheadunit.decoder.audio.PlaybackFocusPolicy
 import com.andrerinas.openheadunit.aap.VehicleTypePolicy
 import com.andrerinas.openheadunit.aap.protocol.proto.Control
 import com.andrerinas.openheadunit.app.UsbAttachedActivity
+import com.andrerinas.openheadunit.connection.usb.UsbBlacklistPolicy
 import com.andrerinas.openheadunit.connection.usb.UsbDeviceCompat
 import com.andrerinas.openheadunit.connection.wifi.modes.helper.HelperStrategy
 import com.andrerinas.openheadunit.connection.wifi.modes.nativeaa.NativeStrategy
@@ -875,37 +877,36 @@ class Settings(private val context: Context) {
         set(value) { prefs.edit().putBoolean("listen-for-usb-devices", value).apply() }
 
     var usbBlacklist: Set<String>
-        @Synchronized get() = prefs.getStringSet("usb-blacklist", null)?.toSet() ?: emptySet()
-        @Synchronized set(value) { prefs.edit().putStringSet("usb-blacklist", value).apply() }
+        @Synchronized get() = prefs.getStringSet(KEY_USB_BLACKLIST, null)?.toSet() ?: emptySet()
+        @Synchronized set(value) { storeUsbBlacklist(UsbBlacklistPolicy.normalise(value)) }
 
-    fun formatUsbVidPidKey(vid: Int, pid: Int): String {
-        return String.format(java.util.Locale.US, "%04x:%04x", vid, pid).lowercase()
-    }
+    fun formatUsbVidPidDisplay(vid: Int, pid: Int): String = Companion.formatUsbVidPidDisplay(vid, pid)
 
-    fun formatUsbVidPidDisplay(vid: Int, pid: Int): String {
-        return String.format(java.util.Locale.US, "VID: 0x%04X, PID: 0x%04X", vid, pid)
+    @Synchronized
+    fun isUsbDeviceBlacklisted(device: UsbDevice): Boolean = UsbBlacklistPolicy.isBlacklisted(
+        usbBlacklist, UsbDeviceCompat.blacklistKey(device), device.vendorId, device.productId
+    )
+
+    @Synchronized
+    fun addUsbDeviceToBlacklist(device: UsbDevice) {
+        storeUsbBlacklist(UsbBlacklistPolicy.add(usbBlacklist, UsbDeviceCompat.blacklistKey(device)))
     }
 
     @Synchronized
-    fun isUsbDeviceBlacklisted(vid: Int, pid: Int): Boolean {
-        val key = formatUsbVidPidKey(vid, pid)
-        return usbBlacklist.contains(key)
+    fun removeUsbDeviceFromBlacklist(device: UsbDevice) {
+        storeUsbBlacklist(UsbBlacklistPolicy.remove(
+            usbBlacklist, UsbDeviceCompat.blacklistKey(device), device.vendorId, device.productId
+        ))
     }
 
-    @Synchronized
-    fun addUsbDeviceToBlacklist(vid: Int, pid: Int) {
-        val key = formatUsbVidPidKey(vid, pid)
-        val set = (prefs.getStringSet("usb-blacklist", null)?.toSet() ?: emptySet()).toMutableSet()
-        set.add(key)
-        prefs.edit().putStringSet("usb-blacklist", set).apply()
-    }
-
-    @Synchronized
-    fun removeUsbDeviceFromBlacklist(vid: Int, pid: Int) {
-        val key = formatUsbVidPidKey(vid, pid)
-        val set = (prefs.getStringSet("usb-blacklist", null)?.toSet() ?: emptySet()).toMutableSet()
-        set.remove(key)
-        prefs.edit().putStringSet("usb-blacklist", set).apply()
+    /**
+     * Every write goes through here so the device-protected mirror can never fall behind. The
+     * mirror is what [isUsbDeviceBlacklisted] reads on a locked boot, where credential storage
+     * is unavailable and the check used to be skipped entirely.
+     */
+    private fun storeUsbBlacklist(value: Set<String>) {
+        prefs.edit().putStringSet(KEY_USB_BLACKLIST, value).apply()
+        syncUsbBlacklistToDeviceStorage(context, value)
     }
 
     var showToastMessages: Boolean
@@ -1063,6 +1064,7 @@ class Settings(private val context: Context) {
             syncAutoStartOnWifiToDeviceStorage(context, false)
             syncListenForUsbDevicesToDeviceStorage(context, true)
             syncAutoStartBtMacToDeviceStorage(context, "")
+            syncUsbBlacklistToDeviceStorage(context, emptySet())
         }
     }
 
@@ -1256,6 +1258,38 @@ class Settings(private val context: Context) {
         )
 
         private const val DEVICE_PREFS_NAME = "settings_device_protected"
+        const val KEY_USB_BLACKLIST = "usb-blacklist"
+
+        fun formatUsbVidPidDisplay(vid: Int, pid: Int): String =
+            String.format(java.util.Locale.US, "VID: 0x%04X, PID: 0x%04X", vid, pid)
+
+        /**
+         * Reads the USB blacklist from device-protected storage, so a blacklisted device is
+         * refused during a locked boot too. Falls back to regular prefs below API 24.
+         */
+        fun isUsbDeviceBlacklisted(context: Context, device: UsbDevice): Boolean {
+            val prefs = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                context.createDeviceProtectedStorageContext()
+                    .getSharedPreferences(DEVICE_PREFS_NAME, Context.MODE_PRIVATE)
+            } else {
+                context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            }
+            val blacklist = prefs.getStringSet(KEY_USB_BLACKLIST, null) ?: return false
+            return UsbBlacklistPolicy.isBlacklisted(
+                blacklist, UsbDeviceCompat.blacklistKey(device), device.vendorId, device.productId
+            )
+        }
+
+        fun syncUsbBlacklistToDeviceStorage(context: Context, blacklist: Set<String>) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                context.createDeviceProtectedStorageContext()
+                    .getSharedPreferences(DEVICE_PREFS_NAME, Context.MODE_PRIVATE)
+                    .edit()
+                    .putStringSet(KEY_USB_BLACKLIST, blacklist)
+                    .apply()
+            }
+        }
+
         private const val KEY_AUTO_START_ON_BOOT = "auto-start-on-boot"
 
         /**

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
@@ -483,6 +483,7 @@ object SettingsBackupManager {
         Settings.syncAutoStartWifiSsidToDeviceStorage(context, settings.autoStartWifiSsid)
         Settings.syncListenForUsbDevicesToDeviceStorage(context, settings.listenForUsbDevices)
         Settings.syncAutoStartBtMacsToDeviceStorage(context, settings.autoStartBluetoothDeviceMacs)
+        Settings.syncUsbBlacklistToDeviceStorage(context, settings.usbBlacklist)
         Settings.setUsbAttachedActivityEnabled(context, settings.listenForUsbDevices)
         AppThemeManager.reapply(context, settings)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,7 +181,7 @@
     <string name="ignored">Ignored</string>
     <string name="blacklisted">Blacklisted</string>
     <string name="usb_blacklist_title">USB Device Blacklist</string>
-    <string name="usb_blacklist_description">Devices in the blacklist will be completely ignored on connection (no auto-start, no prompts).</string>
+    <string name="usb_blacklist_description">Devices in the blacklist are ignored on connection: no auto-start, no prompts. A device is matched by its name, so a blacklisted phone stays blacklisted in every USB mode. Some makers give every model the same name, and those cannot be told apart.</string>
     <string name="add_to_blacklist">Add to Blacklist</string>
     <string name="remove_from_blacklist">Remove from Blacklist</string>
     <string name="usb_device_action_title">USB Device Action</string>

--- a/app/src/main/res/xml/usb_device_filter.xml
+++ b/app/src/main/res/xml/usb_device_filter.xml
@@ -1,12 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!--
+    Which devices Android offers us as a handler for, and the only filter that runs before the
+    system dialog appears. This used to be <usb-device />, so the OS proposed Open Headunit for
+    every attached device: a flash drive and a Bluetooth audio dongle both raised the prompt on
+    hardware. The blacklist cannot help there, because it runs inside the app after the prompt.
+
+    These entries are the descriptor triples UsbDeviceIdentityPolicy accepts, and the two must stay
+    in step. Broader here means the OS launches us for a device we then reject; narrower means a
+    device we would accept never auto-starts. A device that matches nothing is still reachable
+    through the USB button, which enumerates the bus itself.
+
+    Android's DeviceFilter checks the device descriptor and then every interface descriptor, so an
+    entry with no vendor-id is a descriptor test rather than a vendor allowlist. An unlisted phone
+    does not need an app update to work.
+-->
 <resources>
 
-    <!-- Match all devices -->
-    <usb-device />
+    <!-- Already in accessory mode. Widening this set means widening the policy with it. -->
+    <usb-device vendor-id="6353" product-id="11520" />  <!-- 0x18D1:0x2D00 accessory -->
+    <usb-device vendor-id="6353" product-id="11521" />  <!-- 0x18D1:0x2D01 accessory + ADB -->
 
-    <usb-device vendor-id="6353" product-id="11520" />
-    <usb-device vendor-id="6353" product-id="11521" />
+    <!--
+        Vendor class. This is the accessory interface, and also how modern Android presents MTP,
+        so it is what catches a phone in charging-only or file-transfer mode. It is the loosest
+        entry here: a USB ethernet controller carries the same triple on its control interface and
+        will still raise the dialog. The policy rejects it in the app, which the manifest cannot do
+        because it can express neither the interface name nor the CDC siblings.
+    -->
+    <usb-device class="255" subclass="255" protocol="0" />
 
+    <usb-device class="255" subclass="66" protocol="1" />   <!-- ADB -->
+    <usb-device class="6" subclass="1" protocol="1" />      <!-- PTP -->
+    <usb-device class="224" subclass="1" protocol="3" />    <!-- RNDIS tethering -->
+    <usb-device class="239" subclass="4" protocol="1" />    <!-- IAD -->
+    <usb-device class="8" subclass="6" protocol="1" />      <!-- MTP over mass storage -->
 
 </resources>

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/usb/UsbBlacklistPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/usb/UsbBlacklistPolicyTest.kt
@@ -1,0 +1,111 @@
+package com.andrerinas.openheadunit.connection.usb
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The identities are from the round 1 and round 3 `UsbHostManager` captures on the transfer branch.
+ * The point of the phone cases is that one handset appears under three VID:PIDs and one pair of
+ * strings, so a numeric key cannot hold it and a string key can.
+ */
+class UsbBlacklistPolicyTest {
+
+    private fun poco(vendorId: Int, productId: Int) =
+        UsbBlacklistPolicy.key("Xiaomi", "POCO X3 NFC", vendorId, productId)
+
+    @Test
+    fun `the same phone keys the same in every USB mode it was captured in`() {
+        val fileTransfer = poco(0x18D1, 0x4EE1)
+        val debugging = poco(0x05C6, 0x90DB)
+        val accessory = poco(0x18D1, 0x2D01)
+        assertEquals("name:xiaomi poco x3 nfc", fileTransfer)
+        assertEquals(fileTransfer, debugging)
+        assertEquals(fileTransfer, accessory)
+    }
+
+    @Test
+    fun `blacklisting a phone in one mode blocks it in the others, including accessory mode`() {
+        // A device that arrives already switched is checked first by the service scan, so a key
+        // that misses 18D1:2D01 lets a blacklisted phone connect anyway.
+        val list = UsbBlacklistPolicy.add(emptySet(), poco(0x18D1, 0x4EE1))
+        assertTrue(UsbBlacklistPolicy.isBlacklisted(list, poco(0x05C6, 0x90DB), 0x05C6, 0x90DB))
+        assertTrue(UsbBlacklistPolicy.isBlacklisted(list, poco(0x18D1, 0x2D01), 0x18D1, 0x2D01))
+    }
+
+    @Test
+    fun `two phones from different makers no longer share a namespace`() {
+        val list = UsbBlacklistPolicy.add(emptySet(), poco(0x18D1, 0x4EE1))
+        val moto = UsbBlacklistPolicy.key("motorola", "motorola edge 30 neo", 0x18D1, 0x4EE1)
+        assertFalse(UsbBlacklistPolicy.isBlacklisted(list, moto, 0x18D1, 0x4EE1))
+    }
+
+    @Test
+    fun `a device with no readable strings falls back to its VID and PID`() {
+        // Below API 21, and on peripherals that ship no string descriptors. They have one stable
+        // id and no modes, so the numbers are the right key for them.
+        assertEquals("vidpid:090c:1000", UsbBlacklistPolicy.key(null, null, 0x090C, 0x1000))
+        assertEquals("vidpid:090c:1000", UsbBlacklistPolicy.key("", "   ", 0x090C, 0x1000))
+    }
+
+    @Test
+    fun `a manufacturer with no product name still keys on the name`() {
+        assertEquals("vidpid:0b95:1790", UsbBlacklistPolicy.key(null, null, 0x0B95, 0x1790))
+        assertEquals("name:asix", UsbBlacklistPolicy.key("ASIX", null, 0x0B95, 0x1790))
+    }
+
+    @Test
+    fun `an entry written before the key had a prefix still matches`() {
+        val old = setOf("0b95:1790")
+        val key = UsbBlacklistPolicy.key("ASIX", "AX88179B", 0x0B95, 0x1790)
+        assertTrue(UsbBlacklistPolicy.isBlacklisted(old, key, 0x0B95, 0x1790))
+        assertEquals(emptySet<String>(), UsbBlacklistPolicy.remove(old, key, 0x0B95, 0x1790))
+    }
+
+    @Test
+    fun `a stored entry in the wrong case or with stray spacing still matches`() {
+        // The set survives a settings export, a hand edit and an import, so what comes back is
+        // not necessarily what the UI wrote.
+        val stored = setOf("Name:Xiaomi POCO X3 NFC", "  vidpid:090C:1000  ")
+        assertTrue(UsbBlacklistPolicy.isBlacklisted(stored, poco(0x18D1, 0x4EE1), 0x18D1, 0x4EE1))
+        assertTrue(
+            UsbBlacklistPolicy.isBlacklisted(
+                stored, UsbBlacklistPolicy.key(null, null, 0x090C, 0x1000), 0x090C, 0x1000
+            )
+        )
+    }
+
+    @Test
+    fun `a device that is not listed is not blacklisted`() {
+        assertFalse(UsbBlacklistPolicy.isBlacklisted(emptySet(), poco(0x18D1, 0x4EE1), 0x18D1, 0x4EE1))
+        val list = UsbBlacklistPolicy.add(emptySet(), poco(0x18D1, 0x4EE1))
+        val flashDisk = UsbBlacklistPolicy.key(null, null, 0x090C, 0x1000)
+        assertFalse(UsbBlacklistPolicy.isBlacklisted(list, flashDisk, 0x090C, 0x1000))
+    }
+
+    @Test
+    fun `adding rewrites the whole set in canonical form and does not duplicate`() {
+        val once = UsbBlacklistPolicy.add(setOf("VIDPID:0B95:1790"), poco(0x18D1, 0x4EE1))
+        assertEquals(setOf("vidpid:0b95:1790", "name:xiaomi poco x3 nfc"), once)
+        assertEquals(once, UsbBlacklistPolicy.add(once, poco(0x05C6, 0x90DB)))
+    }
+
+    @Test
+    fun `removing takes out only the device asked for`() {
+        val list = UsbBlacklistPolicy.add(
+            UsbBlacklistPolicy.add(emptySet(), poco(0x18D1, 0x4EE1)),
+            UsbBlacklistPolicy.key(null, null, 0x090C, 0x1000),
+        )
+        val left = UsbBlacklistPolicy.remove(list, poco(0x18D1, 0x2D01), 0x18D1, 0x2D01)
+        assertEquals(setOf("vidpid:090c:1000"), left)
+    }
+
+    @Test
+    fun `normalising drops blank entries a hand-edited backup can leave behind`() {
+        assertEquals(
+            setOf("vidpid:0b95:1790"),
+            UsbBlacklistPolicy.normalise(setOf("VIDPID:0B95:1790", "", "   ")),
+        )
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/usb/UsbDeviceIdentityPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/usb/UsbDeviceIdentityPolicyTest.kt
@@ -1,0 +1,270 @@
+package com.andrerinas.openheadunit.connection.usb
+
+import com.andrerinas.openheadunit.connection.usb.UsbDeviceIdentityPolicy.Device
+import com.andrerinas.openheadunit.connection.usb.UsbDeviceIdentityPolicy.Interface
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The descriptors are transcribed from `UsbHostManager` dumps taken on hardware, in
+ * `evidence/usb-device-diagnostics-round1/` on the transfer branch. The ASIX and the phone in MTP
+ * mode present the same FF/FF/00 triple with the same endpoint shape, so any rule that separates
+ * them by the triple or by endpoint count alone will pass one of these tests and fail the other.
+ *
+ * The adapter has two enumerations and both are fixtures here, because covering only the composite
+ * one shipped a fix that did nothing on hardware: it alternates between them plug to plug, and its
+ * vendor-only form carries no CDC interface for the sibling rule to find.
+ */
+class UsbDeviceIdentityPolicyTest {
+
+    private fun evaluate(device: Device) = UsbDeviceIdentityPolicy.evaluate(device)
+
+    // A vendor-class interface with the accessory endpoint shape: bulk in, bulk out, one interrupt.
+    private fun vendorClass(name: String?) =
+        Interface(0xFF, 0xFF, 0x00, name = name, hasBulkIn = true, hasBulkOut = true)
+
+    /**
+     * ASIX AX88179A/B, 0B95:1790, the gigabit-ethernet controller inside a common USB-C dock, in
+     * its composite form: device class 0, all three configurations flattened into one list.
+     */
+    private val asixComposite = Device(
+        vendorId = 0x0B95, productId = 0x1790, deviceClass = 0x00,
+        interfaces = listOf(
+            vendorClass("Network_Interface"),
+            Interface(0x02, 0x0D, 0x00),                                  // CDC NCM control
+            Interface(0x0A, 0x00, 0x01),
+            Interface(0x0A, 0x00, 0x01, hasBulkIn = true, hasBulkOut = true),
+            Interface(0x02, 0x06, 0x00),                                  // CDC ECM control
+            Interface(0x0A, 0x00, 0x00),
+            Interface(0x0A, 0x00, 0x00, hasBulkIn = true, hasBulkOut = true),
+        ),
+    )
+
+    /**
+     * The same adapter's other form, seconds apart in the same capture: one vendor configuration,
+     * one unnamed interface, no CDC anywhere. Only the device class is left to judge it on.
+     */
+    private val asixVendorOnly = Device(
+        vendorId = 0x0B95, productId = 0x1790, deviceClass = 0xFF,
+        interfaces = listOf(vendorClass(null)),
+    )
+
+    /**
+     * A Samsung in file transfer, USB debugging off, round 3's `04E8:6860` capture. It ships a CDC
+     * ACM pair alongside MTP, and its data interface is byte-identical to the ethernet adapter's,
+     * so the network veto has to key on the control subclass or this phone is rejected.
+     */
+    private val samsungFileTransfer = Device(
+        vendorId = 0x04E8, productId = 0x6860, deviceClass = 0x00,
+        interfaces = listOf(
+            Interface(0x06, 0x01, 0x01, "MTP", hasBulkIn = true, hasBulkOut = true),
+            Interface(0x02, 0x02, 0x01, "CDC Abstract Control Model (ACM)"),
+            Interface(0x0A, 0x00, 0x00, "CDC ACM Data", hasBulkIn = true, hasBulkOut = true),
+        ),
+    )
+
+    /** motorola edge 30 neo in file-transfer mode. Charging only presents this same descriptor. */
+    private val phoneMtp = Device(
+        vendorId = 0x22B8, productId = 0x2E82, deviceClass = 0x00,
+        interfaces = listOf(vendorClass("MTP")),
+    )
+
+    @Test
+    fun `a USB ethernet adapter is not a phone, however much its control interface looks like one`() {
+        val verdict = evaluate(asixComposite)
+        assertFalse(verdict.accepted)
+        assertEquals("rejected: CDC network adapter", verdict.toString())
+    }
+
+    @Test
+    fun `a phone in file transfer mode is accepted on the same triple that rejects the adapter`() {
+        val verdict = evaluate(phoneMtp)
+        assertTrue(verdict.accepted)
+        assertEquals("accepted: MTP", verdict.toString())
+    }
+
+    @Test
+    fun `the endpoint shape does not separate them, so it cannot be the discriminator`() {
+        val adapterInterface = asixComposite.interfaces.first()
+        val phoneInterface = phoneMtp.interfaces.first()
+        assertEquals(adapterInterface.hasBulkIn, phoneInterface.hasBulkIn)
+        assertEquals(adapterInterface.hasBulkOut, phoneInterface.hasBulkOut)
+        assertEquals(adapterInterface.ifaceClass, phoneInterface.ifaceClass)
+        assertEquals(adapterInterface.subclass, phoneInterface.subclass)
+        assertEquals(adapterInterface.protocol, phoneInterface.protocol)
+    }
+
+    @Test
+    fun `a real accessory names its own interface and is accepted whatever else is on the device`() {
+        val accessory = Device(
+            vendorId = 0x1234, productId = 0x5678, deviceClass = 0x00,
+            interfaces = listOf(vendorClass("Android Accessory Interface"), Interface(0x0A, 0x00, 0x00)),
+        )
+        assertEquals("accepted: AOAP", evaluate(accessory).toString())
+    }
+
+    @Test
+    fun `the adapter's other form is rejected on its device class, having nothing else to go on`() {
+        val verdict = evaluate(asixVendorOnly)
+        assertFalse(verdict.accepted)
+        assertEquals("rejected: vendor-class device, not a phone", verdict.toString())
+    }
+
+    @Test
+    fun `that form and a phone in file transfer differ only in the device class byte`() {
+        assertEquals(asixVendorOnly.interfaces.size, phoneMtp.interfaces.size)
+        val adapter = asixVendorOnly.interfaces.first()
+        val phone = phoneMtp.interfaces.first()
+        assertEquals(adapter.ifaceClass, phone.ifaceClass)
+        assertEquals(adapter.subclass, phone.subclass)
+        assertEquals(adapter.protocol, phone.protocol)
+        assertEquals(adapter.hasBulkIn, phone.hasBulkIn)
+        assertEquals(adapter.hasBulkOut, phone.hasBulkOut)
+        assertEquals(0xFF, asixVendorOnly.deviceClass)
+        assertEquals(0x00, phoneMtp.deviceClass)
+    }
+
+    @Test
+    fun `an unnamed vendor interface with no CDC siblings is still accepted`() {
+        // Pre-API-21 reads no interface name, and an open firmware dongle may not set one. Nothing
+        // says this is a phone, but nothing says it is not, and the probe is the real test.
+        val device = Device(0x18D1, 0x4EE1, 0x00, listOf(vendorClass(null)))
+        assertEquals("accepted: AOAP (vendor interface named nothing)", evaluate(device).toString())
+    }
+
+    @Test
+    fun `the verdict carries the interface name, because that is what a wrong one is read from`() {
+        val device = Device(0x2717, 0xFF40, 0x00, listOf(vendorClass("Some_Vendor_Thing")))
+        assertEquals(
+            "accepted: AOAP (vendor interface named 'Some_Vendor_Thing')",
+            evaluate(device).toString(),
+        )
+    }
+
+    @Test
+    fun `a billboard device names its class rather than falling through`() {
+        val billboard = Device(0x1D5C, 0x7102, 0x11, listOf(Interface(0x11, 0x00, 0x00)))
+        assertEquals("rejected: device class 0x11 is not a phone", evaluate(billboard).toString())
+    }
+
+    @Test
+    fun `a vendor-class device is still accepted when it declares an unambiguous interface`() {
+        // The veto sits in the accessory branch, so a device that says ADB or PTP outright never
+        // reaches it. Nothing captured looks like this; the ordering is what the test pins.
+        val device = Device(
+            0x1234, 0x5678, 0xFF,
+            listOf(Interface(0xFF, 0x42, 0x01, "ADB Interface", hasBulkIn = true, hasBulkOut = true)),
+        )
+        assertEquals("accepted: ADB", evaluate(device).toString())
+    }
+
+    @Test
+    fun `a vendor interface with no bulk pair is not an accessory interface`() {
+        val device = Device(
+            0x1234, 0x5678, 0x00,
+            listOf(Interface(0xFF, 0xFF, 0x00, hasBulkIn = true, hasBulkOut = false)),
+        )
+        assertEquals("rejected: no Android interface", evaluate(device).toString())
+    }
+
+    @Test
+    fun `a Samsung in file transfer is accepted, CDC serial interfaces and all`() {
+        assertEquals("accepted: PTP", evaluate(samsungFileTransfer).toString())
+    }
+
+    @Test
+    fun `a CDC serial pair is not a network, even on an otherwise ambiguous device`() {
+        // The same phone with a vendor MTP interface instead of a PTP one, and no interface name to
+        // settle it. Only the ACM control subclass keeps this apart from the ethernet adapter.
+        val device = Device(
+            0x04E8, 0x6860, 0x00,
+            listOf(
+                vendorClass(null),
+                Interface(0x02, 0x02, 0x01),
+                Interface(0x0A, 0x00, 0x00, hasBulkIn = true, hasBulkOut = true),
+            ),
+        )
+        assertTrue(evaluate(device).accepted)
+    }
+
+    @Test
+    fun `a tethering phone survives the network adapter rule because RNDIS is decided first`() {
+        // It carries the CDC data interface the rule keys on, so order is the only thing saving it.
+        val tethering = Device(
+            vendorId = 0x22B8, productId = 0x2E24, deviceClass = 0x00,
+            interfaces = listOf(
+                Interface(0xE0, 0x01, 0x03),
+                Interface(0x0A, 0x00, 0x00, hasBulkIn = true, hasBulkOut = true),
+            ),
+        )
+        assertEquals("accepted: RNDIS", evaluate(tethering).toString())
+    }
+
+    @Test
+    fun `every USB mode of the phone that was swept on hardware is still accepted`() {
+        val adb = Interface(0xFF, 0x42, 0x01, "ADB Interface", hasBulkIn = true, hasBulkOut = true)
+        val ptp = Interface(0x06, 0x01, 0x01, null, hasBulkIn = true, hasBulkOut = true)
+        val modes = mapOf(
+            "adb" to Device(0x22B8, 0x2E81, 0x00, listOf(adb)),
+            "mtp" to phoneMtp,
+            "ptp" to Device(0x22B8, 0x2E83, 0x00, listOf(ptp)),
+            "ptp_adb" to Device(0x22B8, 0x2E84, 0x00, listOf(ptp, adb)),
+            "midi_adb" to Device(
+                0x18D1, 0x4EE9, 0x00,
+                listOf(
+                    Interface(0x01, 0x01, 0x00, "MIDI function"),
+                    Interface(0x01, 0x03, 0x00, null, hasBulkIn = true, hasBulkOut = true),
+                    adb,
+                ),
+            ),
+        )
+        for ((mode, device) in modes) {
+            assertTrue("$mode should be accepted", evaluate(device).accepted)
+        }
+    }
+
+    @Test
+    fun `the two devices round 1 rejected are still rejected, for the same stated reason`() {
+        val flashDisk = Device(
+            0x090C, 0x1000, 0x00,
+            listOf(Interface(0x08, 0x06, 0x50, null, hasBulkIn = true, hasBulkOut = true)),
+        )
+        val bluetoothAudioDongle = Device(
+            0x0A12, 0x4007, 0x00,
+            listOf(
+                Interface(0x03, 0x00, 0x00), Interface(0x03, 0x00, 0x00),
+                Interface(0x01, 0x01, 0x00), Interface(0x01, 0x02, 0x00),
+                Interface(0x01, 0x02, 0x00), Interface(0x01, 0x02, 0x00),
+            ),
+        )
+        assertEquals("rejected: no Android interface", evaluate(flashDisk).toString())
+        assertEquals("rejected: no Android interface", evaluate(bluetoothAudioDongle).toString())
+    }
+
+    @Test
+    fun `a device already in accessory mode is accepted before any interface is read`() {
+        val accessory = Device(0x18D1, 0x2D00, 0x00, emptyList())
+        val accessoryAdb = Device(0x18D1, 0x2D01, 0x00, emptyList())
+        assertEquals("accepted: already in accessory mode", evaluate(accessory).toString())
+        assertTrue(evaluate(accessoryAdb).accepted)
+    }
+
+    @Test
+    fun `Apple is refused even when it presents a matching interface`() {
+        val device = Device(0x05AC, 0x12A8, 0x00, listOf(vendorClass("Android Accessory Interface")))
+        assertEquals("rejected: Apple VID", evaluate(device).toString())
+    }
+
+    @Test
+    fun `a device that has declared itself a hub or a printer is dropped on its device class`() {
+        assertEquals("rejected: device class 0x09 is not a phone", evaluate(Device(0x1234, 0x1, 0x09, emptyList())).toString())
+        assertEquals("rejected: device class 0x07 is not a phone", evaluate(Device(0x1234, 0x1, 0x07, emptyList())).toString())
+    }
+
+    @Test
+    fun `an empty bus entry is rejected rather than throwing`() {
+        assertFalse(evaluate(Device(0x1234, 0x5678, 0x00, emptyList())).accepted)
+    }
+}


### PR DESCRIPTION
- Three commits. The first is the USB work, the second is a Direct Boot crash that work uncovered, and the third narrows the manifest filter and is deliberately last and self-contained, so it can be dropped with a single `git reset --hard HEAD~1` if you would rather keep the match-all.

- **The diagnostic.** Every trigger now logs the raw USB device list with each device's descriptors, endpoints and our verdict, so a report of "it sees nothing" can be told apart from "it sees the device and refuses it". An empty bus says so in the user's own terms instead of printing nothing at all.

- **Device identification.** `UsbDeviceIdentityPolicy` replaces an inline check that accepted any vendor-class interface, which is also what a USB ethernet controller presents: a dock NIC was logged `accepted: AOAP` and auto-connected to. It is now rejected on the CDC siblings in its composite enumeration and on the device class in its vendor-only one, and it alternates between the two within a single replug. The network veto keys on the CDC control subclass, ECM/EEM/NCM/MBIM, rather than on the CDC classes themselves, because a phone in file transfer can ship a CDC ACM pair whose data interface is byte-identical to an adapter's and only the control subclass separates a serial port from a NIC. The policy is pure and unit tested, with both descriptor forms of the adapter and every USB mode of two handsets as fixtures.

- **The blacklist.** The user's "never touch this device" list was consulted in one of seven paths that act on a device, and skipped entirely when the user had not unlocked, so a blacklisted device was still connected to, and the device list rendered a row "Blacklisted" in red and started it anyway. There is one gate now, `UsbDeviceCompat.isConnectable`, used by every path that acts, with the list mirrored to device-protected storage the way the auto-start settings already are. The key is manufacturer plus product rather than VID:PID, because a phone's numbers change with its USB mode and its strings do not; a device with no string descriptors falls back to the numbers, which is all it ever had.

- **Direct Boot.** Found while testing the blacklist's locked-boot claim, and present on `main` rather than introduced here: the app crashed before the user's first unlock, so every locked-boot entry point was dead code that had never once been reached. `App.onCreate` touched the object graph twice above its own `isUserUnlocked()` guard, and the graph is not buildable there, because `AppComponent` builds a `VideoDecoder` whose field initialisers read credential-encrypted preferences. Nothing in `onCreate` touches the graph now, the notification channels take their manager from the system service, and everything needing credential storage moved into `initUnlockedOnce()`, which an `ACTION_USER_UNLOCKED` receiver also runs so that a process which started locked does not spend the rest of its life on default settings. `UsbAttachedActivity`, `WifiAutoStartReceiver` and `AutoStartReceiver` each defer, and the activity still refuses a blacklisted device and still performs the accessory-mode switch while locked, which is the whole reason it is `directBootAware`.

- **The manifest filter.** `usb_device_filter.xml` was `<usb-device />`, so Android offered the app as a handler for every device on the bus, and a flash drive and a Bluetooth audio dongle both raised the system prompt on real hardware. It now lists the descriptor triples the policy accepts. Android's `DeviceFilter` checks the device descriptor and then every interface descriptor, so an entry without a vendor id is a descriptor test rather than a vendor allowlist, and an unlisted phone does not need an app update to work. A device that matches nothing is still reachable through the app's own USB button, which enumerates the bus itself.

- **Hardware validation, three rounds on a phone acting as USB host** with a second phone, a USB-C dock, a flash disk and a Bluetooth dongle. The ethernet adapter is rejected in both of its enumerations with no auto-connect, the billboard device is rejected on its class, and the Bluetooth dongle raises no system dialog. One blacklist entry keyed on the name covers six distinct VID:PIDs the same handset presents across its USB modes, the accessory-mode one included, which the old numeric key missed outright; a list written by an older build still matches on the numbers; and taking a device back off the list returns it to a full projection session.

- **The locked-boot arms specifically.** The previous build crashed three times in one boot on that host; the fixed build survives, the blacklist applies at the lock screen, the accessory-mode switch still runs to completion while locked with the session correctly held until unlock, and the unlock handover fires in the same process id and writes the device-protected mirror. An ordinary unlocked start was re-checked end to end, including a projection session at 47 to 52 fps with zero dropped frames and its foreground notification present.

- 984 unit tests, 0 failures. `UsbDeviceIdentityPolicyTest` and `UsbBlacklistPolicyTest` carry the new logic; the Android lifecycle parts are covered by the hardware rounds rather than by tests, since this project does not use Robolectric.
