### PR TITLE
Native AA: say so when a unit will not host a WiFi Direct group

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiDirectManager.kt
@@ -34,6 +34,8 @@ import com.andrerinas.openheadunit.connection.wifi.modes.nativeaa.SoftApBssidPol
 import com.andrerinas.openheadunit.main.MainActivity
 import com.andrerinas.openheadunit.utils.ToastUtils
 import com.andrerinas.openheadunit.utils.AppLog
+import com.andrerinas.openheadunit.utils.ConnectionIssue
+import com.andrerinas.openheadunit.utils.ConnectionIssues
 import java.io.File
 import java.net.Inet4Address
 import java.net.InetSocketAddress
@@ -48,6 +50,15 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         private const val MAX_NATIVE_5GHZ_CREATE_RETRIES = 4
         private const val MAX_NATIVE_5GHZ_BAND_MISMATCH_RETRIES = 2
         private const val MAX_NATIVE_STANDARD_CREATE_RETRIES = 3
+
+        /**
+         * How often to repeat that this unit will not create a group.
+         *
+         * The same interval, and for the same reason, as `SoftApCredentialsProvider`'s no-access-point
+         * report: often enough that any window of a busy unit's log carries it, rare enough that a
+         * user can dismiss the banner it raises.
+         */
+        private const val GROUP_REFUSAL_REPORT_INTERVAL_MS = 60_000L
         private const val NATIVE_GROUP_MODE_UNKNOWN = "unknown"
         private const val NATIVE_GROUP_MODE_5GHZ_REQUESTED = "5GHz requested"
         private const val NATIVE_GROUP_MODE_24GHZ_REQUESTED = "2.4GHz requested"
@@ -134,6 +145,28 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
      * are spent.
      */
     private var legacyChannelAttempt = 0
+
+    /**
+     * True once this unit has let a `setWifiP2pChannels` request go unanswered.
+     *
+     * The request is the only pre-Q band lever, and on a driver that reloads the P2P interface to
+     * apply it the pending listener is dropped, so [WifiP2pChannelCompat] has to time out instead.
+     * Asking again costs that timeout on every bring-up and cannot produce a different answer, so
+     * the rest of the session goes straight to creating the group on the driver's own channel.
+     * Cleared by [stop] with the ladder, so a mode change asks once more.
+     */
+    private var legacyChannelRequestUnanswered = false
+
+    /**
+     * When the group refusal was last reported, so a unit refusing every attempt says so at a
+     * readable rate rather than on each one.
+     *
+     * The retry ladder gives up several times a minute while the phone keeps re-dialling, and each
+     * report both writes an ERROR line and re-stamps the standing record. Re-stamping is what brings
+     * the main-screen banner back after a dismissal, so at that rate the user could not dismiss it
+     * at all. Reset by [stop] rather than by a bring-up, so one refusal is reported per mode.
+     */
+    private var lastGroupRefusalReportAtMs = 0L
 
     /**
      * Bumped by [stop]. Every P2P callback that continues into another framework call captures this
@@ -809,6 +842,51 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         }
     }
 
+    /**
+     * Say that this unit will not create a group, at most once per [GROUP_REFUSAL_REPORT_INTERVAL_MS].
+     *
+     * The station state goes on the line because it is the one fact that makes the refusal readable,
+     * and the nearest other mention of it in a reporter's log is a minute earlier in a different
+     * component's output.
+     */
+    private fun reportGroupRefusal(reasonStr: String) {
+        val now = SystemClock.elapsedRealtime()
+        if (lastGroupRefusalReportAtMs != 0L &&
+            now - lastGroupRefusalReportAtMs < GROUP_REFUSAL_REPORT_INTERVAL_MS
+        ) return
+        lastGroupRefusalReportAtMs = now
+        AppLog.e(
+            "WifiDirectManager: createQuietGroup failed completely! Reason: $reasonStr. " +
+                describeStationForRefusal()
+        )
+        ConnectionIssues.raise(context, ConnectionIssue.WIFI_DIRECT_GROUP_REFUSED)
+    }
+
+    /**
+     * What this unit's own WiFi was doing when the platform refused to create a group.
+     *
+     * Descriptive, like [StationCoexistencePolicy], and for the same reason: a radio already serving
+     * a station link is the commonest shape of this refusal but has never been measured as its
+     * cause, so this states what was true and leaves the conclusion to whoever reads the log.
+     * [SupplicantState] rather than the SSID because the SSID is redacted without the location gate,
+     * which a head unit routinely cannot satisfy.
+     */
+    private fun describeStationForRefusal(): String = try {
+        val wifiManager = context.applicationContext
+            .getSystemService(Context.WIFI_SERVICE) as WifiManager
+        val info = wifiManager.connectionInfo
+        when {
+            info == null -> "This unit's own WiFi state could not be read."
+            info.supplicantState != SupplicantState.COMPLETED ->
+                "This unit's WiFi is not joined to any network."
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && info.frequency > 0 ->
+                "This unit's WiFi is joined to another network on ${info.frequency} MHz."
+            else -> "This unit's WiFi is joined to another network."
+        }
+    } catch (e: Exception) {
+        "This unit's own WiFi state could not be read (${e.message})."
+    }
+
     private fun getInterfaceByIp(targetIp: String): String? {
         try {
             val interfaces = NetworkInterface.getNetworkInterfaces()
@@ -1294,6 +1372,15 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         }
 
         val frequency = WifiP2pOperatingChannelPolicy.frequencyMhzFor(operatingChannel)
+        if (legacyChannelRequestUnanswered) {
+            AppLog.i(
+                "WifiDirectManager: not asking for operating channel $operatingChannel " +
+                    "($frequency MHz) again - this unit left the last request unanswered, so the " +
+                    "band stays the driver's choice."
+            )
+            standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_LEGACY)
+            return
+        }
         AppLog.i(
             "WifiDirectManager: no band request below Android 10, so asking for operating channel " +
                 "$operatingChannel ($frequency MHz) instead - rung ${legacyChannelAttempt + 1} of " +
@@ -1301,14 +1388,21 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 "this restricts which frequencies it may pick."
         )
         markP2pRequest()
-        WifiP2pChannelCompat.setOperatingChannel(mgr, ch, operatingChannel, handler) { applied, detail ->
+        WifiP2pChannelCompat.setOperatingChannel(mgr, ch, operatingChannel, handler) { applied, answered, detail ->
             legacyChannelRestrictionApplied = applied
             if (applied) {
                 AppLog.i("WifiDirectManager: operating channel $operatingChannel ($frequency MHz) $detail.")
-            } else {
+            } else if (answered) {
                 AppLog.w(
                     "WifiDirectManager: this unit would not take an operating channel ($detail), so " +
                         "the group's band stays the driver's choice, as it was before."
+                )
+            } else {
+                legacyChannelRequestUnanswered = true
+                AppLog.w(
+                    "WifiDirectManager: this unit never answered the operating channel request " +
+                        "($detail), so the group's band stays the driver's choice and the rest of " +
+                        "this session goes straight to creating the group."
                 )
             }
             standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_LEGACY)
@@ -1344,6 +1438,8 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         mgr.createGroup(ch, object : WifiP2pManager.ActionListener {
             override fun onSuccess() {
                 AppLog.i("WifiDirectManager: Standard createGroup SUCCESS!")
+                // The one thing that disproves the record: this unit just hosted a group.
+                ConnectionIssues.clear(context, ConnectionIssue.WIFI_DIRECT_GROUP_REFUSED)
                 nativeGroupCreationMode = groupMode
                 // The platform chose the band here, so there is no mismatch to correct.
                 nativeRequestedBand = NativeGroupBandPolicy.Band.UNSPECIFIED
@@ -1380,13 +1476,13 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                             "the next channel it was offered."
                     )
                     markP2pRequest()
-                    WifiP2pChannelCompat.clearOperatingChannel(mgr, ch, handler) { _, detail ->
+                    WifiP2pChannelCompat.clearOperatingChannel(mgr, ch, handler) { _, _, detail ->
                         legacyChannelRestrictionApplied = false
                         AppLog.i("WifiDirectManager: operating channel restriction cleared ($detail).")
                         createQuietGroup(0)
                     }
                 } else {
-                    AppLog.e("WifiDirectManager: createQuietGroup failed completely! Reason: $reasonStr")
+                    reportGroupRefusal(reasonStr)
                     isGroupCreatingOrCreated = false
                 }
             }
@@ -1403,7 +1499,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     private fun releaseLegacyChannelRestriction(mgr: WifiP2pManager, ch: WifiP2pManager.Channel) {
         if (!legacyChannelRestrictionApplied) return
         legacyChannelRestrictionApplied = false
-        WifiP2pChannelCompat.clearOperatingChannel(mgr, ch, handler) { applied, detail ->
+        WifiP2pChannelCompat.clearOperatingChannel(mgr, ch, handler) { applied, _, detail ->
             if (applied) {
                 AppLog.i("WifiDirectManager: operating channel restriction released; discovery can use the social channels again.")
             } else {
@@ -1662,6 +1758,11 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         nativeRecreateCount = 0
         lastNativeGroupStatusMessage = null
         legacyChannelAttempt = 0
+        legacyChannelRequestUnanswered = false
+        lastGroupRefusalReportAtMs = 0L
+        // Unconditional, and not gated on legacyChannelRestrictionApplied: a request that never
+        // answered may still have been applied, and the restriction is supplicant state that
+        // outlives this process.
         manager?.let { mgr -> channel?.let { ch -> releaseLegacyChannelRestriction(mgr, ch) } }
         AapService.scanningState.value = false
         try { context.unregisterReceiver(receiver) } catch (e: Exception) {}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiP2pChannelCompat.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiP2pChannelCompat.kt
@@ -39,17 +39,19 @@ object WifiP2pChannelCompat {
      * @param onResult invoked exactly once, with the platform's own verdict where there is one and
      *   with the reflection's where there is not. [onResult] is what continues group creation, so it
      *   must run on every path - including the one where the method does not exist, and the one
-     *   where the platform simply never calls back.
+     *   where the platform simply never calls back. `answered` separates the two kinds of no: a
+     *   refusal arrives immediately and asking again is free, while a platform that never calls back
+     *   costs [ANSWER_TIMEOUT_MS] every time and cannot give a different reply.
      */
     fun setOperatingChannel(
         manager: WifiP2pManager,
         channel: WifiP2pManager.Channel,
         operatingChannel: Int,
         handler: Handler,
-        onResult: (applied: Boolean, detail: String) -> Unit,
+        onResult: (applied: Boolean, answered: Boolean, detail: String) -> Unit,
     ) {
         if (!WifiP2pOperatingChannelPolicy.isRequestable(operatingChannel)) {
-            onResult(false, "channel $operatingChannel is outside what the platform accepts")
+            onResult(false, true, "channel $operatingChannel is outside what the platform accepts")
             return
         }
         // One latch shared by the listener, the timeout and the failure paths below, so whichever
@@ -58,10 +60,10 @@ object WifiP2pChannelCompat {
         // Held so answering early can cancel it; postDelayed's token overload is API 28 and this
         // path exists for the devices below that.
         var timeout: Runnable? = null
-        val answer = { applied: Boolean, detail: String ->
+        val answer = { applied: Boolean, byPlatform: Boolean, detail: String ->
             if (answered.compareAndSet(false, true)) {
                 timeout?.let { handler.removeCallbacks(it) }
-                onResult(applied, detail)
+                onResult(applied, byPlatform, detail)
             }
         }
         try {
@@ -73,10 +75,10 @@ object WifiP2pChannelCompat {
                 WifiP2pManager.ActionListener::class.java,
             )
             val listener = object : WifiP2pManager.ActionListener {
-                override fun onSuccess() = answer(true, "accepted")
-                override fun onFailure(reason: Int) = answer(false, "refused (reason=$reason)")
+                override fun onSuccess() = answer(true, true, "accepted")
+                override fun onFailure(reason: Int) = answer(false, true, "refused (reason=$reason)")
             }
-            val onTimeout = Runnable { answer(false, "no answer in ${ANSWER_TIMEOUT_MS}ms") }
+            val onTimeout = Runnable { answer(false, false, "no answer in ${ANSWER_TIMEOUT_MS}ms") }
             timeout = onTimeout
             handler.postDelayed(onTimeout, ANSWER_TIMEOUT_MS)
             method.invoke(
@@ -87,13 +89,15 @@ object WifiP2pChannelCompat {
                 listener,
             )
         } catch (e: NoSuchMethodException) {
-            answer(false, "this platform has no $METHOD")
+            // Not an answer: the method is absent on this platform and will stay absent, so the
+            // caller should stop asking rather than retry a lookup that cannot start succeeding.
+            answer(false, false, "this platform has no $METHOD")
         } catch (e: Throwable) {
             // A SecurityException belongs here too: the manager-level call asks only for
             // CHANGE_WIFI_STATE, but the service side is free to want more, and a unit that says no
             // should still get a group.
             AppLog.d("WifiP2pChannelCompat: $METHOD threw: ${e.message}")
-            answer(false, "${e.javaClass.simpleName}: ${e.message}")
+            answer(false, false, "${e.javaClass.simpleName}: ${e.message}")
         }
     }
 
@@ -108,7 +112,7 @@ object WifiP2pChannelCompat {
         manager: WifiP2pManager,
         channel: WifiP2pManager.Channel,
         handler: Handler,
-        onResult: (applied: Boolean, detail: String) -> Unit = { _, _ -> },
+        onResult: (applied: Boolean, answered: Boolean, detail: String) -> Unit = { _, _, _ -> },
     ) = setOperatingChannel(
         manager,
         channel,

--- a/app/src/main/java/com/andrerinas/openheadunit/main/ConnectionIssueBannerPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/ConnectionIssueBannerPolicy.kt
@@ -31,6 +31,10 @@ object ConnectionIssueBannerPolicy {
      *   Native AA hotspot transport ever constructs. Helper strategy 4 rides its own access point
      *   too but never resolves credentials from it, so it cannot raise this and does not appear
      *   here — which is also why this takes no `helperConnectionStrategy`: no rule uses it.
+     * - `WIFI_DIRECT_GROUP_REFUSED` is raised in `WifiDirectManager` on the branch that gives up on
+     *   group creation, which only the Native AA WiFi Direct transport reaches. The helper's own
+     *   WiFi Direct strategy shares that manager but hands the phone no credentials, so a refused
+     *   group there is not the reason a connection failed.
      *
      * A record is not deleted when it stops applying. It describes what the hardware did, and the
      * user may well be back on that route tomorrow; it is only hidden while it cannot be the
@@ -41,7 +45,8 @@ object ConnectionIssueBannerPolicy {
         return when (transport) {
             NativeTransport.WIFI_DIRECT -> setOf(
                 ConnectionIssue.BLUETOOTH_SENT_NO_DATA,
-                ConnectionIssue.BSSID_UNAVAILABLE
+                ConnectionIssue.BSSID_UNAVAILABLE,
+                ConnectionIssue.WIFI_DIRECT_GROUP_REFUSED
             )
             NativeTransport.HOTSPOT -> setOf(
                 ConnectionIssue.BLUETOOTH_SENT_NO_DATA,
@@ -68,8 +73,9 @@ object ConnectionIssueBannerPolicy {
      * that every state one of them declines to retire is one this function hides.
      *
      * `BLUETOOTH_SENT_NO_DATA` has no entry because its remedy is leaving Native AA, which
-     * [relevantNow] already answers. `HOTSPOT_NOT_RUNNING` has none either: no setting fixes it,
-     * and switching the access point on disproves it outright, so the record retires itself.
+     * [relevantNow] already answers. `HOTSPOT_NOT_RUNNING` and `WIFI_DIRECT_GROUP_REFUSED` have none
+     * either: no setting fixes them, and an access point coming up or a group forming disproves them
+     * outright, so those records retire themselves.
      *
      * @param hotspotSsid [com.andrerinas.openheadunit.utils.Settings.hotspotSsid]
      * @param hotspotPassword [com.andrerinas.openheadunit.utils.Settings.hotspotPassword] — needed

--- a/app/src/main/java/com/andrerinas/openheadunit/main/MainActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/MainActivity.kt
@@ -928,6 +928,8 @@ class MainActivity : BaseActivity() {
                 ConnectionIssue.BSSID_UNAVAILABLE -> R.string.connection_issue_banner_bssid
                 ConnectionIssue.HOTSPOT_CONFIG_UNREADABLE -> R.string.connection_issue_banner_hotspot_config
                 ConnectionIssue.HOTSPOT_NOT_RUNNING -> R.string.connection_issue_banner_hotspot_off
+                ConnectionIssue.WIFI_DIRECT_GROUP_REFUSED ->
+                    R.string.connection_issue_banner_wifi_direct_refused
             }
         )
         banner.setOnClickListener { openRemedyFor(issue) }
@@ -949,10 +951,10 @@ class MainActivity : BaseActivity() {
     /**
      * Open Settings on the row that fixes [issue].
      *
-     * Seeds the search box rather than using EXTRA_DESTINATION, which targets a whole screen: all
-     * three remedies are rows inside the settings list, and search is the only thing that reaches
-     * them regardless of the Basic/Advanced tier. Static BSSID is Advanced-only, so a Basic-mode
-     * user sent to Settings without this would not find the row the banner just named.
+     * Seeds the search box rather than using EXTRA_DESTINATION, which targets a whole screen: every
+     * remedy is a row inside the settings list, and search is the only thing that reaches them
+     * regardless of the Basic/Advanced tier. Static BSSID is Advanced-only, so a Basic-mode user
+     * sent to Settings without this would not find the row the banner just named.
      *
      * The hotspot query is a phrase carried in both override rows' search keywords rather than
      * either row's title, because that condition needs *both* of them: with a manual name set the
@@ -967,6 +969,7 @@ class MainActivity : BaseActivity() {
             ConnectionIssue.HOTSPOT_CONFIG_UNREADABLE ->
                 getString(R.string.connection_issue_remedy_hotspot_query)
             ConnectionIssue.HOTSPOT_NOT_RUNNING -> getString(R.string.auto_enable_hotspot)
+            ConnectionIssue.WIFI_DIRECT_GROUP_REFUSED -> getString(R.string.native_ap_transport)
         }
         startActivity(
             Intent(this, SettingsActivity::class.java)

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/ConnectionIssues.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/ConnectionIssues.kt
@@ -31,7 +31,17 @@ enum class ConnectionIssue {
      * The commonest way the hotspot route fails and, until now, the quietest: the resolve loop said
      * so once per run into a log that a busy unit drops, and nothing anywhere carried it afterwards.
      */
-    HOTSPOT_NOT_RUNNING
+    HOTSPOT_NOT_RUNNING,
+
+    /**
+     * The platform would not create a WiFi Direct group, so there was no network to hand the phone.
+     *
+     * Distinct from the two hotspot records in that no setting reaches it: the refusal is the unit's
+     * radio saying it cannot be a group owner right now, most often because it is already an
+     * associated station on some other network. The user's levers are leaving that network or
+     * switching the Native transport to the head unit's own access point.
+     */
+    WIFI_DIRECT_GROUP_REFUSED
 }
 
 /** An issue that is currently true, and when it was last raised. */
@@ -127,6 +137,7 @@ object ConnectionIssues {
                 ConnectionIssue.BSSID_UNAVAILABLE -> settings.connectionIssueBssidAtEpochMs
                 ConnectionIssue.HOTSPOT_CONFIG_UNREADABLE -> settings.connectionIssueHotspotConfigAtEpochMs
                 ConnectionIssue.HOTSPOT_NOT_RUNNING -> settings.connectionIssueHotspotOffAtEpochMs
+                ConnectionIssue.WIFI_DIRECT_GROUP_REFUSED -> settings.connectionIssueWifiDirectRefusedAtEpochMs
             }
         } catch (e: Exception) {
             0L
@@ -139,6 +150,7 @@ object ConnectionIssues {
                     ConnectionIssue.BSSID_UNAVAILABLE -> settings.connectionIssueBssidAtEpochMs = atEpochMs
                     ConnectionIssue.HOTSPOT_CONFIG_UNREADABLE -> settings.connectionIssueHotspotConfigAtEpochMs = atEpochMs
                     ConnectionIssue.HOTSPOT_NOT_RUNNING -> settings.connectionIssueHotspotOffAtEpochMs = atEpochMs
+                    ConnectionIssue.WIFI_DIRECT_GROUP_REFUSED -> settings.connectionIssueWifiDirectRefusedAtEpochMs = atEpochMs
                 }
             } catch (e: Exception) {
                 AppLog.d("ConnectionIssues: could not record $issue: ${e.message}")

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/HotspotManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/HotspotManager.kt
@@ -251,7 +251,8 @@ object HotspotManager {
             attempted = tryConnectivityManager(context, enabled) || attempted
             attempted = tryLegacyWifiManager(context, enabled) || attempted
         } else {
-            AppLog.w("HotspotManager: Cannot enable the hotspot without the \"Modify system settings\" permission (WRITE_SETTINGS). Grant it in the setup wizard or Settings > Permissions.")
+            val verb = if (enabled) "enable" else "turn off"
+            AppLog.w("HotspotManager: Cannot $verb the hotspot without the \"Modify system settings\" permission (WRITE_SETTINGS). Grant it in the setup wizard or Settings > Permissions.")
         }
 
         if (!enabled) return BandOutcome(attempted, up = false, configured = configured)

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/LogExporter.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/LogExporter.kt
@@ -6,6 +6,7 @@ import android.os.Build
 import android.util.Log
 import androidx.core.content.FileProvider
 import com.andrerinas.openheadunit.BuildConfig
+import com.andrerinas.openheadunit.connection.wifi.WifiLauncherMode
 import com.andrerinas.openheadunit.decoder.video.VideoFaultInjector
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -138,10 +139,25 @@ object LogExporter {
             "video=codec:${settings.videoCodec} fps:${settings.fpsLimit} resId:${settings.resolutionId} " +
             "view:${settings.viewMode.name} forceSw:${settings.forceSoftwareDecoding} " +
             "swDecoder:${settings.softwareVideoDecoder.name} | " +
-            "wifi=mode:${settings.wifiConnectionMode} strategy:${settings.helperConnectionStrategy} | " +
+            "wifi=mode:${settings.wifiConnectionMode} strategy:${wifiTransport(settings)} | " +
             "logLevel=${settings.exporterLogLevel.name} | " +
             "debug=${debugLevers(settings)}"
     }
+
+    /**
+     * The transport selector that the reported mode actually reads.
+     *
+     * Native AA has its own, `nativeApStrategy`, and reads `helperConnectionStrategy` nowhere. This
+     * line printed the helper's for every mode, so a Native capture opened with a value nothing in
+     * that mode consults - which meant a header could not tell a Native/WiFi-Direct failure from a
+     * Native/hotspot one, and reading it literally sent triage after a Nearby path that never ran.
+     */
+    private fun wifiTransport(settings: Settings): String =
+        if (settings.wifiConnectionMode == WifiLauncherMode.NATIVE) {
+            settings.nativeApStrategy.name
+        } else {
+            settings.helperConnectionStrategy.name
+        }
 
     /**
      * The settings that make the app behave unlike itself, in the one line every capture opens with.

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -1732,7 +1732,7 @@ class Settings(private val context: Context) {
     // reboot, which an elapsed-realtime stamp does not survive. Every other stamp on this route is
     // elapsed realtime, so the AtEpochMs suffix is the reminder that these are not.
     //
-    // 0 means "not standing" in all four.
+    // 0 means "not standing" in all five.
     // ---------------------------------------------------------------------------------------------
 
     /** The phone connected over Bluetooth, we wrote, and nothing ever came back. */
@@ -1754,6 +1754,11 @@ class Settings(private val context: Context) {
     var connectionIssueHotspotOffAtEpochMs: Long
         get() = prefs.getLong("connection-issue-hotspot-off", 0L)
         set(value) = prefs.edit().putLong("connection-issue-hotspot-off", value).apply()
+
+    /** The platform refused to create a WiFi Direct group, so there was no network to hand over. */
+    var connectionIssueWifiDirectRefusedAtEpochMs: Long
+        get() = prefs.getLong("connection-issue-p2p-refused", 0L)
+        set(value) = prefs.edit().putLong("connection-issue-p2p-refused", value).apply()
 
     /**
      * When the user last dismissed the failure banner.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -967,6 +967,7 @@
     <string name="connection_issue_banner_bssid">This unit could not read its own WiFi MAC address (BSSID), so your phone was never told which network to join. Tap to turn on Location, or to enter the address by hand.</string>
     <string name="connection_issue_banner_hotspot_off">This unit\'s hotspot is off, so there was no network to send your phone to. Turn the hotspot on before connecting, or tap to let the app switch it on for you.</string>
     <string name="connection_issue_banner_hotspot_config">This unit will not tell the app its hotspot name and password, so your phone had nothing to join. Tap to enter them by hand.</string>
+    <string name="connection_issue_banner_wifi_direct_refused">This unit\'s WiFi would not create the WiFi Direct network your phone was going to join, and the app cannot make it. If this unit is joined to another WiFi network, disconnecting it is worth trying. Tap to use this unit\'s own hotspot instead.</string>
     <string name="connection_issue_banner_dismiss">Dismiss</string>
     <!-- What the hotspot banner types into the settings search. Both override rows carry it
          as a search keyword, so this one string is what makes the tap reach the pair. -->

--- a/app/src/test/java/com/andrerinas/openheadunit/main/ConnectionIssueBannerPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/main/ConnectionIssueBannerPolicyTest.kt
@@ -183,6 +183,30 @@ class ConnectionIssueBannerPolicyTest {
     }
 
     @Test
+    fun `only the WiFi Direct route can be blocked by a refused group`() {
+        // The hotspot transport never asks for a group, so a refused one cannot be why it failed.
+        assertTrue(
+            ConnectionIssue.WIFI_DIRECT_GROUP_REFUSED in
+                ConnectionIssueBannerPolicy.relevantNow(3, NativeTransport.WIFI_DIRECT)
+        )
+        assertFalse(
+            ConnectionIssue.WIFI_DIRECT_GROUP_REFUSED in
+                ConnectionIssueBannerPolicy.relevantNow(3, NativeTransport.HOTSPOT)
+        )
+    }
+
+    @Test
+    fun `no setting is a remedy for a refused group`() {
+        // A group forming disproves it outright, so the record retires itself. Nothing the user can
+        // type reaches the radio's refusal, so hiding the banner on a typed value would hide a
+        // condition that is still exactly as true as it was.
+        assertFalse(
+            ConnectionIssue.WIFI_DIRECT_GROUP_REFUSED in
+                ConnectionIssueBannerPolicy.remedyApplied("OHU-TEST", "testtest1234", "AA:BB:CC:DD:EE:FF")
+        )
+    }
+
+    @Test
     fun `no setting is a remedy for there being no access point`() {
         // Switching the hotspot on disproves it outright, so the record retires itself and there is
         // nothing for remedyApplied to hide.


### PR DESCRIPTION
A head unit that refuses group creation outright had nothing anywhere to say so. The terminal branch logged one line and cleared a latch, the main screen stayed blank, and the phone sat on a loading screen while the head unit retried into a log nobody reads from the driver's seat.

Measured on the reporter's Qualcomm sm6150 unit on API 28 #907, comparing v3.3.0-beta2 with v3.3.0-beta3:

- The bring-up loop that beta3 fixed is gone: 4127 createGroup attempts in 92 s became 27 in 143 s. Because it is gone the platform finally answers, and beta3 is the first capture that contains any verdict at all. It is BUSY, on all 27 attempts, and createGroup never once succeeds.
- No group means no SSID, passphrase or address, so all ten handshakes read SSID=<null>, IP=<null> and not one byte of the wireless setup exchange is ever written. That is what the phone is waiting for.
- The unit's wlan0 is an associated station on another network for the whole capture. That is the commonest shape of this refusal and has never been measured as its cause, so the new line describes it and does not prescribe, as StationCoexistencePolicy already does for the coexistence case.

ConnectionIssue.WIFI_DIRECT_GROUP_REFUSED is raised where the ladder gives up and cleared where a group forms, which is the only thing that disproves it. No remedyApplied entry, for the same reason HOTSPOT_NOT_RUNNING has none: no setting reaches a radio's refusal, so hiding the banner on a typed value would hide a condition still exactly as true as it was. The report carries a 60 s cooldown because the ladder gives up several times a minute and each report re-stamps the record, which is what brings the banner back after a dismissal; without it the banner could not be dismissed at all.

setWifiP2pChannels now reports whether the platform answered at all, not just whether it applied. A refusal arrives immediately and asking again is free; a platform that never calls back costs the 2 s timeout on every bring-up and cannot give a different reply. On this unit that was 25 timeouts, roughly a third of the capture. The rest of the session now goes straight to creating the group on the driver's own channel. stop() still clears the restriction unconditionally: a request that never answered may still have been applied.

The session banner printed helperConnectionStrategy for every mode. Native AA reads nativeApStrategy and consults the helper's selector nowhere, so a Native capture opened with a value nothing in that mode uses, and a header could not tell a WiFi Direct failure from a hotspot one. It now prints the selector the reported mode actually reads. HotspotManager's missing-permission warning also said "cannot enable" on the disable path, which is where it fired here.