### PR TITLE
Auto-resume media playback on quick reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+### v.3.3.1-beta1
+- Added: Option to auto-resume media playback on quick reconnect if music was playing before disconnect
+
 ### v.3.3.0
 - Begin for theming of the App.
 - Refactor WiFi-Code from AapService into their own classes for better maintenance, thanks to @MrEAlderson

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ adb shell am start -a android.intent.action.VIEW -d "headunit://connect?ip=192.1
 - more customization options for the UI and the app itself
 
 ## Changelog
+### v.3.3.1-beta1
+- Added: Option to auto-resume media playback on quick reconnect if music was playing before disconnect
+
 ### v.3.3.0
 - Begin for theming of the App.
 - Refactor WiFi-Code from AapService into their own classes for better maintenance, thanks to @MrEAlderson

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,8 +74,8 @@ android {
         applicationId = "com.andrerinas.headunitrevived"
         minSdk = 16
         targetSdk = 36
-        versionCode = 103
-        versionName = "3.3.0"
+        versionCode = 104
+        versionName = "3.3.1-beta1"
         setProperty("archivesBaseName", "${applicationId}_${versionName}")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled = true

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -153,6 +153,7 @@ class AapService : Service() {
     private var lastDisconnectTimestampMs = 0L
     private var mediaSessionIsPlaying = false
     private var mediaMetadataDecodeJob: Job? = null
+    private var autoResumePlaybackJob: Job? = null
     /** Decoded on a background thread in [scheduleApplyAaMediaMetadata]; reused for notification updates on position ticks. */
     private var cachedAaAlbumArtBitmap: Bitmap? = null
     private var settingsPrefs: SharedPreferences? = null
@@ -984,20 +985,32 @@ class AapService : Service() {
 
     private fun maybeAutoResumePlaybackOnReconnect() {
         val settings = App.provide(this).settings
-        if (!settings.autoResumePlaybackOnReconnect) return
         val now = SystemClock.elapsedRealtime()
         val elapsedSinceDisconnect = now - lastDisconnectTimestampMs
         val wasPlaying = wasPlayingBeforeDisconnect
         wasPlayingBeforeDisconnect = false // Consume once so it doesn't fire again on subsequent events
 
-        // Only resume if music was actively playing and the disconnect happened within the last 60 seconds
-        if (wasPlaying && elapsedSinceDisconnect in 1..60_000L) {
+        val shouldResume = AutoResumePlaybackPolicy.shouldResume(
+            enabled = settings.autoResumePlaybackOnReconnect,
+            wasPlayingBeforeDisconnect = wasPlaying,
+            elapsedSinceDisconnectMs = elapsedSinceDisconnect
+        )
+
+        if (shouldResume) {
             AppLog.i("AapService: Auto-resuming playback on reconnect (${elapsedSinceDisconnect}ms since disconnect)")
-            serviceScope.launch {
+            autoResumePlaybackJob?.cancel()
+            autoResumePlaybackJob = serviceScope.launch {
+                // Allow Android Auto on the phone time to settle and attach its media player session
                 delay(1500L)
+                if (!isActive || isDestroying) return@launch
+
+                // Confirm that the connection is still alive and in TransportStarted before sending keys
                 if (commManager.connectionState.value is CommManager.ConnectionState.TransportStarted) {
+                    AppLog.i("AapService: Dispatching auto-resume play key")
                     commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PLAY, true, null, "auto-resume")
                     commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PLAY, false, null, "auto-resume")
+                } else {
+                    AppLog.w("AapService: Connection state changed before auto-resume could dispatch")
                 }
             }
         } else {
@@ -1317,6 +1330,8 @@ class AapService : Service() {
         App.provide(this).carKeysManager.unregisterReceivers()
 
         if (!isDestroying) updateNotification()
+        autoResumePlaybackJob?.cancel()
+        autoResumePlaybackJob = null
         mediaMetadataDecodeJob?.cancel()
         mediaMetadataDecodeJob = null
         lastAaMediaMetadata = null
@@ -1951,6 +1966,8 @@ class AapService : Service() {
         isDestroying = true
         // Nothing else clears it here, and the manager outlives the service instance.
         selfLauncherManager.isActive = false
+        autoResumePlaybackJob?.cancel()
+        autoResumePlaybackJob = null
         mediaMetadataDecodeJob?.cancel()
         cachedAaAlbumArtBitmap = null
         mediaNotification.cancel()

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -1000,17 +1000,23 @@ class AapService : Service() {
             AppLog.i("AapService: Auto-resuming playback on reconnect (${elapsedSinceDisconnect}ms since disconnect)")
             autoResumePlaybackJob?.cancel()
             autoResumePlaybackJob = serviceScope.launch {
-                // Allow Android Auto on the phone time to settle and attach its media player session
-                delay(1500L)
-                if (!isActive || isDestroying) return@launch
+                try {
+                    // Allow Android Auto on the phone time to settle and attach its media player session
+                    delay(1500L)
+                    if (!isActive || isDestroying) return@launch
 
-                // Confirm that the connection is still alive and in TransportStarted before sending keys
-                if (commManager.connectionState.value is CommManager.ConnectionState.TransportStarted) {
-                    AppLog.i("AapService: Dispatching auto-resume play key")
-                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PLAY, true, null, "auto-resume")
-                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PLAY, false, null, "auto-resume")
-                } else {
-                    AppLog.w("AapService: Connection state changed before auto-resume could dispatch")
+                    // Confirm that the connection is still alive and in TransportStarted before sending keys
+                    if (commManager.connectionState.value is CommManager.ConnectionState.TransportStarted) {
+                        AppLog.i("AapService: Dispatching auto-resume play key")
+                        commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PLAY, true, null, "auto-resume")
+                        commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PLAY, false, null, "auto-resume")
+                    } else {
+                        AppLog.w("AapService: Connection state changed before auto-resume could dispatch")
+                    }
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    AppLog.e("AapService: Error while auto-resuming playback: ${e.message}", e)
                 }
             }
         } else {

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -149,6 +149,8 @@ class AapService : Service() {
     private var lastAaMediaMetadata: MediaPlayback.MediaMetaData? = null
     private var lastAaPlaybackPositionMs: Long = 0L
     private var lastAaPlaybackIsPlaying: Boolean? = null
+    private var wasPlayingBeforeDisconnect = false
+    private var lastDisconnectTimestampMs = 0L
     private var mediaSessionIsPlaying = false
     private var mediaMetadataDecodeJob: Job? = null
     /** Decoded on a background thread in [scheduleApplyAaMediaMetadata]; reused for notification updates on position ticks. */
@@ -956,6 +958,7 @@ class AapService : Service() {
                         sendBroadcast(Intent(ACTION_REQUEST_NIGHT_MODE_UPDATE).apply {
                             setPackage(packageName)
                         })
+                        maybeAutoResumePlaybackOnReconnect()
                     }
                     is CommManager.ConnectionState.Error -> {
                         // Nothing may be counted here, and nothing new may be hung off this branch.
@@ -976,6 +979,29 @@ class AapService : Service() {
                     else -> {}
                 }
             }
+        }
+    }
+
+    private fun maybeAutoResumePlaybackOnReconnect() {
+        val settings = App.provide(this).settings
+        if (!settings.autoResumePlaybackOnReconnect) return
+        val now = SystemClock.elapsedRealtime()
+        val elapsedSinceDisconnect = now - lastDisconnectTimestampMs
+        val wasPlaying = wasPlayingBeforeDisconnect
+        wasPlayingBeforeDisconnect = false // Consume once so it doesn't fire again on subsequent events
+
+        // Only resume if music was actively playing and the disconnect happened within the last 60 seconds
+        if (wasPlaying && elapsedSinceDisconnect in 1..60_000L) {
+            AppLog.i("AapService: Auto-resuming playback on reconnect (${elapsedSinceDisconnect}ms since disconnect)")
+            serviceScope.launch {
+                delay(1500L)
+                if (commManager.connectionState.value is CommManager.ConnectionState.TransportStarted) {
+                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PLAY, true, null, "auto-resume")
+                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PLAY, false, null, "auto-resume")
+                }
+            }
+        } else {
+            AppLog.d("AapService: Skipping auto-resume playback (wasPlaying=$wasPlaying, elapsed=${elapsedSinceDisconnect}ms)")
         }
     }
 
@@ -1295,6 +1321,9 @@ class AapService : Service() {
         mediaMetadataDecodeJob = null
         lastAaMediaMetadata = null
         lastAaPlaybackPositionMs = 0L
+        wasPlayingBeforeDisconnect = (lastAaPlaybackIsPlaying == true)
+        lastDisconnectTimestampMs = SystemClock.elapsedRealtime()
+        AppLog.i("AapService: Disconnected. wasPlayingBeforeDisconnect=$wasPlayingBeforeDisconnect")
         lastAaPlaybackIsPlaying = null
         cachedAaAlbumArtBitmap = null
         mediaNotification.cancel()

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AutoResumePlaybackPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AutoResumePlaybackPolicy.kt
@@ -1,0 +1,31 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Pure decision policy for auto-resuming media playback on reconnect.
+ *
+ * Prevents unwanted playback if music was stopped/paused before disconnect,
+ * if the feature is disabled in settings, or if the reconnect occurred after
+ * a long delay (> 60 seconds).
+ */
+object AutoResumePlaybackPolicy {
+
+    /** Maximum elapsed time (in ms) since disconnect to be considered a quick reconnect. */
+    const val MAX_RECONNECT_WINDOW_MS = 60_000L
+
+    /**
+     * Determines whether Open Headunit should send a playback start command upon reconnection.
+     *
+     * @param enabled whether the user has enabled auto-resume in settings
+     * @param wasPlayingBeforeDisconnect whether media was actively playing when the connection was lost
+     * @param elapsedSinceDisconnectMs time in milliseconds since the disconnect occurred
+     */
+    fun shouldResume(
+        enabled: Boolean,
+        wasPlayingBeforeDisconnect: Boolean,
+        elapsedSinceDisconnectMs: Long
+    ): Boolean {
+        if (!enabled) return false
+        if (!wasPlayingBeforeDisconnect) return false
+        return elapsedSinceDisconnectMs in 1..MAX_RECONNECT_WINDOW_MS
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
@@ -638,7 +638,7 @@ class CommManager(
         // Only media keys can be held back, so nothing else pays for the Bluetooth probe.
         if (isMedia) {
             val routing = settings.mediaKeyRouting
-            if (!MediaKeyRoutingPolicy.shouldForward(routing, true, btMediaLinkForKeys())) {
+            if (source != "auto-resume" && !MediaKeyRoutingPolicy.shouldForward(routing, true, btMediaLinkForKeys())) {
                 AppLog.v("CommManager: Not sending media key $logicalCode to Android Auto " +
                         "(routing=$routing, src=$source)")
                 return

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/WifiLauncherMode.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/WifiLauncherMode.kt
@@ -16,7 +16,7 @@ enum class WifiLauncherMode(
 
     companion object {
 
-        val DEFAULT: WifiLauncherMode = HELPER
+        val DEFAULT: WifiLauncherMode = NATIVE
 
 
         fun byIdOrDefault(id: Int): WifiLauncherMode {

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -126,6 +126,7 @@ class SettingsFragment : Fragment() {
     private var pendingUseGps: Boolean? = null
     private var pendingShowNavigationNotifications: Boolean? = null
     private var pendingSyncMediaSessionAaMetadata: Boolean? = null
+    private var pendingAutoResumePlaybackOnReconnect: Boolean? = null
     private var pendingResolution: Int? = null
     private var pendingDpi: Int? = null
     private var pendingPixelAspectRatioE4: Int? = null
@@ -272,6 +273,7 @@ class SettingsFragment : Fragment() {
         pendingUseGps = settings.useGpsForNavigation
         pendingShowNavigationNotifications = settings.showNavigationNotifications
         pendingSyncMediaSessionAaMetadata = settings.syncMediaSessionWithAaMetadata
+        pendingAutoResumePlaybackOnReconnect = settings.autoResumePlaybackOnReconnect
         pendingResolution = settings.resolutionId
         pendingDpi = settings.dpiPixelDensity
         pendingPixelAspectRatioE4 = settings.pixelAspectRatioE4
@@ -392,6 +394,7 @@ class SettingsFragment : Fragment() {
         pendingUseGps = settings.useGpsForNavigation
         pendingShowNavigationNotifications = settings.showNavigationNotifications
         pendingSyncMediaSessionAaMetadata = settings.syncMediaSessionWithAaMetadata
+        pendingAutoResumePlaybackOnReconnect = settings.autoResumePlaybackOnReconnect
         pendingResolution = settings.resolutionId
         pendingDpi = settings.dpiPixelDensity
         pendingPixelAspectRatioE4 = settings.pixelAspectRatioE4
@@ -518,6 +521,7 @@ class SettingsFragment : Fragment() {
         pendingUseGps?.let { settings.useGpsForNavigation = it }
         pendingShowNavigationNotifications?.let { settings.showNavigationNotifications = it }
         pendingSyncMediaSessionAaMetadata?.let { settings.syncMediaSessionWithAaMetadata = it }
+        pendingAutoResumePlaybackOnReconnect?.let { settings.autoResumePlaybackOnReconnect = it }
         pendingResolution?.let { settings.resolutionId = it }
         pendingDpi?.let { settings.dpiPixelDensity = it }
         pendingPixelAspectRatioE4?.let { settings.pixelAspectRatioE4 = it }
@@ -649,6 +653,7 @@ class SettingsFragment : Fragment() {
                         pendingUseGps != settings.useGpsForNavigation ||
                         pendingShowNavigationNotifications != settings.showNavigationNotifications ||
                         pendingSyncMediaSessionAaMetadata != settings.syncMediaSessionWithAaMetadata ||
+                        pendingAutoResumePlaybackOnReconnect != settings.autoResumePlaybackOnReconnect ||
                         pendingResolution != settings.resolutionId ||
                         pendingDpi != settings.dpiPixelDensity ||
                         pendingPixelAspectRatioE4 != settings.pixelAspectRatioE4 ||
@@ -1927,6 +1932,18 @@ class SettingsFragment : Fragment() {
             isChecked = pendingSyncMediaSessionAaMetadata!!,
             onCheckedChanged = { isChecked ->
                 pendingSyncMediaSessionAaMetadata = isChecked
+                checkChanges()
+                updateSettingsList()
+            }
+        ))
+
+        items.add(SettingItem.ToggleSettingEntry(
+            stableId = "autoResumePlaybackOnReconnect",
+            nameResId = R.string.auto_resume_playback_on_reconnect,
+            descriptionResId = R.string.auto_resume_playback_on_reconnect_description,
+            isChecked = pendingAutoResumePlaybackOnReconnect!!,
+            onCheckedChanged = { isChecked ->
+                pendingAutoResumePlaybackOnReconnect = isChecked
                 checkChanges()
                 updateSettingsList()
             }

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -887,7 +887,7 @@ class SettingsFragment : Fragment() {
             WifiLauncherMode.HELPER -> 0 // Helper
             WifiLauncherMode.NATIVE -> 1 // Native
             WifiLauncherMode.MANUAL, WifiLauncherMode.AUTO -> 2 // Server
-            else -> 2
+            else -> 1
         }
 
         items.add(SettingItem.SegmentedButtonSettingEntry(
@@ -900,7 +900,7 @@ class SettingsFragment : Fragment() {
                     0 -> WifiLauncherMode.HELPER // Helper
                     1 -> WifiLauncherMode.NATIVE // Native
                     2 -> if (pendingWifiConnectionMode == WifiLauncherMode.MANUAL) WifiLauncherMode.MANUAL else WifiLauncherMode.AUTO // Keep manual/auto choice if already in server mode
-                    else -> WifiLauncherMode.AUTO
+                    else -> WifiLauncherMode.NATIVE
                 }
 
                 if (newMode == WifiLauncherMode.NATIVE) {
@@ -1172,14 +1172,15 @@ class SettingsFragment : Fragment() {
         // Sub-setting for Wireless Helper Strategy
         if (pendingWifiConnectionMode == WifiLauncherMode.HELPER) {
             val helperStrategies = resources.getStringArray(R.array.helper_strategies)
+            val currentStrategyId = pendingHelperConnectionStrategy?.id ?: settings.helperConnectionStrategy.id
             items.add(SettingItem.SettingEntry(
                 stableId = "helperStrategy",
                 nameResId = R.string.helper_strategy_label,
-                value = helperStrategies.getOrElse(pendingHelperConnectionStrategy!!.id) { "" },
+                value = helperStrategies.getOrElse(currentStrategyId) { "" },
                 onClick = {
                     MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
                         .setTitle(R.string.helper_strategy_label)
-                        .setSingleChoiceItems(helperStrategies, pendingHelperConnectionStrategy!!.id) { dialog, which ->
+                        .setSingleChoiceItems(helperStrategies, currentStrategyId) { dialog, which ->
                             pendingHelperConnectionStrategy = HelperStrategy.byIdOrDefault(which)
                             checkChanges()
                             dialog.dismiss()
@@ -1312,7 +1313,7 @@ class SettingsFragment : Fragment() {
             stableId = "killOnDisconnect",
             nameResId = R.string.kill_on_disconnect,
             descriptionResId = R.string.kill_on_disconnect_description,
-            isChecked = pendingKillOnDisconnect!!,
+            isChecked = pendingKillOnDisconnect ?: settings.killOnDisconnect,
             onCheckedChanged = { isChecked ->
                 if (isChecked) {
                     val conflicts = getKillOnDisconnectConflicts()
@@ -1342,7 +1343,7 @@ class SettingsFragment : Fragment() {
                 stableId = "raiseProjectionDuringCall",
                 nameResId = R.string.raise_projection_during_call,
                 descriptionResId = R.string.raise_projection_during_call_description,
-                isChecked = pendingRaiseProjectionDuringCall!!,
+                isChecked = pendingRaiseProjectionDuringCall ?: settings.raiseProjectionDuringCall,
                 onCheckedChanged = { isChecked ->
                     pendingRaiseProjectionDuringCall = isChecked
                     checkChanges()
@@ -1361,7 +1362,7 @@ class SettingsFragment : Fragment() {
                 stableId = "gpsNavigation",
                 nameResId = R.string.gps_for_navigation,
                 descriptionResId = R.string.gps_for_navigation_description,
-                isChecked = pendingUseGps!!,
+                isChecked = pendingUseGps ?: settings.useGpsForNavigation,
                 onCheckedChanged = { isChecked ->
                     pendingUseGps = isChecked
                     checkChanges()
@@ -1374,7 +1375,7 @@ class SettingsFragment : Fragment() {
             stableId = "showNavigationNotifications",
             nameResId = R.string.show_navigation_notifications,
             descriptionResId = R.string.show_navigation_notifications_description,
-            isChecked = pendingShowNavigationNotifications!!,
+            isChecked = pendingShowNavigationNotifications ?: settings.showNavigationNotifications,
             onCheckedChanged = { isChecked ->
                 pendingShowNavigationNotifications = isChecked
                 checkChanges()
@@ -1386,7 +1387,7 @@ class SettingsFragment : Fragment() {
             stableId = "fakeSpeed",
             nameResId = R.string.fake_speed_title,
             descriptionResId = R.string.fake_speed_description,
-            isChecked = pendingFakeSpeed!!,
+            isChecked = pendingFakeSpeed ?: settings.fakeSpeed,
             onCheckedChanged = { isChecked ->
                 pendingFakeSpeed = isChecked
                 checkChanges()
@@ -1400,7 +1401,7 @@ class SettingsFragment : Fragment() {
         items.add(SettingItem.SettingEntry(
             stableId = "resolution",
             nameResId = R.string.resolution,
-            value = Settings.Resolution.fromId(pendingResolution!!)?.resName ?: "",
+            value = Settings.Resolution.fromId(pendingResolution ?: settings.resolutionId)?.resName ?: "",
             searchKeywords = Settings.Resolution.allRes.joinToString(" "),
             onClick = { showResolutionDialog() }
         ))
@@ -1428,7 +1429,7 @@ class SettingsFragment : Fragment() {
                 showNumericInputDialog(
                     title = getString(R.string.enter_pixel_aspect_ratio_value),
                     message = null,
-                    initialValue = if ((pendingPixelAspectRatioE4 ?: 10000) <= 0) 10000 else pendingPixelAspectRatioE4!!,
+                    initialValue = if ((pendingPixelAspectRatioE4 ?: 10000) <= 0) 10000 else (pendingPixelAspectRatioE4 ?: 10000),
                     onConfirm = { newVal ->
                         pendingPixelAspectRatioE4 = if (newVal <= 0) 10000 else newVal
                         checkChanges()
@@ -1498,11 +1499,11 @@ class SettingsFragment : Fragment() {
             },
             onClick = { _ ->
                 val viewModes = arrayOf(getString(R.string.surface_view), getString(R.string.texture_view), getString(R.string.gles_view))
-                val currentIdx = pendingViewMode!!.value
+                val currentIdx = pendingViewMode?.value ?: settings.viewMode.value
                 MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
                     .setTitle(R.string.change_view_mode)
                     .setSingleChoiceItems(viewModes, currentIdx) { dialog, which ->
-                        pendingViewMode = Settings.ViewMode.fromInt(which)!!
+                        Settings.ViewMode.fromInt(which)?.let { pendingViewMode = it }
                         checkChanges()
                         dialog.dismiss()
                         updateSettingsList()
@@ -1511,14 +1512,15 @@ class SettingsFragment : Fragment() {
             }
         ))
 
+        val orientationOptions = resources.getStringArray(R.array.screen_orientation)
+        val currentOrientationIdx = pendingScreenOrientation?.value ?: settings.screenOrientation.value
         items.add(SettingItem.SettingEntry(
             stableId = "screenOrientation",
             nameResId = R.string.screen_orientation,
-            value = resources.getStringArray(R.array.screen_orientation)[pendingScreenOrientation!!.value],
-            searchKeywords = resources.getStringArray(R.array.screen_orientation).joinToString(" "),
+            value = orientationOptions.getOrElse(currentOrientationIdx) { "" },
+            searchKeywords = orientationOptions.joinToString(" "),
             onClick = { _ ->
-                val orientationOptions = resources.getStringArray(R.array.screen_orientation)
-                val currentIdx = pendingScreenOrientation!!.value
+                val currentIdx = pendingScreenOrientation?.value ?: settings.screenOrientation.value
                 MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
                     .setTitle(R.string.change_screen_orientation)
                     .setSingleChoiceItems(orientationOptions, currentIdx) { dialog, whiches ->
@@ -1547,7 +1549,7 @@ class SettingsFragment : Fragment() {
             stableId = "stretchToFill",
             nameResId = R.string.pref_stretch_screen_title,
             descriptionResId = R.string.pref_stretch_screen_summary,
-            isChecked = pendingStretchToFill!!,
+            isChecked = pendingStretchToFill ?: settings.stretchToFill,
             onCheckedChanged = { isChecked ->
                 pendingStretchToFill = isChecked
                 requiresRestart = true // Requires a reconnect to apply the new rendering bounds
@@ -1585,7 +1587,7 @@ class SettingsFragment : Fragment() {
                 stableId = "forcedScale",
                 nameResId = R.string.forced_scale,
                 descriptionResId = R.string.forced_scale_description,
-                isChecked = pendingForcedScale!!,
+                isChecked = pendingForcedScale ?: settings.forcedScale,
                 onCheckedChanged = { isChecked ->
                     pendingForcedScale = isChecked
                     requiresRestart = true
@@ -1648,7 +1650,7 @@ class SettingsFragment : Fragment() {
             stableId = "forceSoftwareDecoding",
             nameResId = R.string.force_software_decoding,
             descriptionResId = R.string.force_software_decoding_description,
-            isChecked = pendingForceSoftware!!,
+            isChecked = pendingForceSoftware ?: settings.forceSoftwareDecoding,
             onCheckedChanged = { isChecked ->
                 pendingForceSoftware = isChecked
                 checkChanges()
@@ -1691,7 +1693,7 @@ class SettingsFragment : Fragment() {
         items.add(SettingItem.SettingEntry(
             stableId = "videoCodec",
             nameResId = R.string.video_codec,
-            value = pendingVideoCodec!!,
+            value = pendingVideoCodec ?: settings.videoCodec,
             searchKeywords = "Auto H.264 H.265",
             onClick = { _ ->
                 val codecs = arrayOf("Auto", "H.264", "H.265")
@@ -1820,7 +1822,7 @@ class SettingsFragment : Fragment() {
             stableId = "enableAudioSink",
             nameResId = R.string.enable_audio_sink,
             descriptionResId = R.string.enable_audio_sink_description,
-            isChecked = pendingEnableAudioSink!!,
+            isChecked = pendingEnableAudioSink ?: settings.enableAudioSink,
             onCheckedChanged = { isChecked ->
                 pendingEnableAudioSink = isChecked
                 checkChanges()
@@ -1904,7 +1906,7 @@ class SettingsFragment : Fragment() {
             stableId = "useAacAudio",
             nameResId = R.string.use_aac_audio,
             descriptionResId = R.string.use_aac_audio_description,
-            isChecked = pendingUseAacAudio!!,
+            isChecked = pendingUseAacAudio ?: settings.useAacAudio,
             onCheckedChanged = { isChecked ->
                 pendingUseAacAudio = isChecked
                 checkChanges()
@@ -1929,7 +1931,7 @@ class SettingsFragment : Fragment() {
             stableId = "syncMediaSessionAaMetadata",
             nameResId = R.string.sync_media_session_aa_metadata,
             descriptionResId = R.string.sync_media_session_aa_metadata_description,
-            isChecked = pendingSyncMediaSessionAaMetadata!!,
+            isChecked = pendingSyncMediaSessionAaMetadata ?: settings.syncMediaSessionWithAaMetadata,
             onCheckedChanged = { isChecked ->
                 pendingSyncMediaSessionAaMetadata = isChecked
                 checkChanges()
@@ -1941,7 +1943,7 @@ class SettingsFragment : Fragment() {
             stableId = "autoResumePlaybackOnReconnect",
             nameResId = R.string.auto_resume_playback_on_reconnect,
             descriptionResId = R.string.auto_resume_playback_on_reconnect_description,
-            isChecked = pendingAutoResumePlaybackOnReconnect!!,
+            isChecked = pendingAutoResumePlaybackOnReconnect ?: settings.autoResumePlaybackOnReconnect,
             onCheckedChanged = { isChecked ->
                 pendingAutoResumePlaybackOnReconnect = isChecked
                 checkChanges()
@@ -2095,7 +2097,7 @@ class SettingsFragment : Fragment() {
             stableId = "showFpsCounter",
             nameResId = R.string.show_fps_counter,
             descriptionResId = R.string.show_fps_counter_description,
-            isChecked = pendingShowFpsCounter!!,
+            isChecked = pendingShowFpsCounter ?: settings.showFpsCounter,
             onCheckedChanged = { isChecked ->
                 pendingShowFpsCounter = isChecked
                 checkChanges()

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -147,6 +147,13 @@ class Settings(private val context: Context) {
             prefs.edit().putBoolean(KEY_SYNC_MEDIA_SESSION_AA_METADATA, value).apply()
         }
 
+    /** Auto-resume media playback on quick reconnect if music was playing before disconnect. */
+    var autoResumePlaybackOnReconnect: Boolean
+        get() = prefs.getBoolean(KEY_AUTO_RESUME_PLAYBACK_ON_RECONNECT, false)
+        set(value) {
+            prefs.edit().putBoolean(KEY_AUTO_RESUME_PLAYBACK_ON_RECONNECT, value).apply()
+        }
+
     /**
      * In Self Mode, put the projection back on top when a call covers it.
      *
@@ -1235,6 +1242,7 @@ class Settings(private val context: Context) {
 
         /** SharedPreferences key; also used by [com.andrerinas.openheadunit.aap.AapService] for change listener. */
         const val KEY_SYNC_MEDIA_SESSION_AA_METADATA = "sync-media-session-aa-metadata"
+        const val KEY_AUTO_RESUME_PLAYBACK_ON_RECONNECT = "auto-resume-playback-on-reconnect"
 
         /** SharedPreferences key; also used by [com.andrerinas.openheadunit.aap.AapService] for change listener. */
         const val KEY_LOG_LEVEL = "log-level"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -511,6 +511,8 @@
     <string name="media_session_aa_status_placeholder">متصل</string>
     <string name="sync_media_session_aa_metadata">المسار الجاري من AA في جلسة الوسائط</string>
     <string name="sync_media_session_aa_metadata_description">عرض عنوان المسار والفنان والمدة وغلاف الألبوم من الهاتف في جلسة الوسائط بالنظام وإشعار الوسائط</string>
+    <string name="auto_resume_playback_on_reconnect">استئناف التشغيل عند إعادة الاتصال</string>
+    <string name="auto_resume_playback_on_reconnect_description">استئناف تشغيل الموسيقى تلقائيًا إذا كانت قيد التشغيل قبل انقطاع قصير في الاتصال (خلال 60 ثانية)</string>
     <string name="error_usb_permission_failed">خطأ في النظام: فشل طلب مربع حوار إذن USB.</string>
 
     <!-- Custom loading screen -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -511,6 +511,8 @@
     <string name="media_session_aa_status_placeholder">Připojeno</string>
     <string name="sync_media_session_aa_metadata">Aktuální skladba AA v mediální relaci</string>
     <string name="sync_media_session_aa_metadata_description">Zobrazovat název skladby, interpreta, délku a obal alba z telefonu v systémové mediální relaci a mediálním oznámení</string>
+    <string name="auto_resume_playback_on_reconnect">Obnovit přehrávání při opětovném připojení</string>
+    <string name="auto_resume_playback_on_reconnect_description">Automaticky obnoví přehrávání hudby, pokud před krátkým výpadkem spojení hrála (do 60 sekund)</string>
     <string name="error_usb_permission_failed">Systémová chyba: Nepodařilo se vyžádat dialogové okno pro povolení USB.</string>
 
     <!-- Custom loading screen -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -570,6 +570,8 @@
     <string name="media_session_aa_status_placeholder">Verbunden</string>
     <string name="sync_media_session_aa_metadata">AA-Now-Playing in der Mediensitzung</string>
     <string name="sync_media_session_aa_metadata_description">Titel, Interpret, Dauer und Albumcover vom Telefon in der System-Mediensitzung und in der Medienbenachrichtigung anzeigen</string>
+    <string name="auto_resume_playback_on_reconnect">Wiedergabe bei Reconnect fortsetzen</string>
+    <string name="auto_resume_playback_on_reconnect_description">Setzt die Musikwiedergabe nach einem kurzen Verbindungsabbruch (innerhalb von 60 Sekunden) automatisch fort, falls zuvor Musik lief</string>
     <string name="error_usb_permission_failed">Systemfehler: Anforderung des USB-Berechtigungsdialogs fehlgeschlagen.</string>
 
     <!-- Custom loading screen -->

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -511,6 +511,8 @@
     <string name="media_session_aa_status_placeholder">Conectado</string>
     <string name="sync_media_session_aa_metadata">Pista actual de AA en la sesión multimedia</string>
     <string name="sync_media_session_aa_metadata_description">Mostrar título, artista, duración y carátula del móvil en la sesión multimedia del sistema y en la notificación multimedia</string>
+    <string name="auto_resume_playback_on_reconnect">Reanudar reproducción al reconectar</string>
+    <string name="auto_resume_playback_on_reconnect_description">Reanuda automáticamente la música si se estaba reproduciendo antes de una breve desconexión (en un lapso de 60 segundos)</string>
     <string name="error_usb_permission_failed">Error del sistema: Fallo al solicitar el cuadro de diálogo de permiso USB.</string>
 
     <!-- Custom loading screen -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -511,6 +511,8 @@
     <string name="media_session_aa_status_placeholder">Conectado</string>
     <string name="sync_media_session_aa_metadata">Pista actual de AA en la sesión multimedia</string>
     <string name="sync_media_session_aa_metadata_description">Mostrar título, artista, duración y portada del teléfono en la sesión multimedia del sistema y en la notificación multimedia</string>
+    <string name="auto_resume_playback_on_reconnect">Reanudar reproducción al reconectar</string>
+    <string name="auto_resume_playback_on_reconnect_description">Reanuda automáticamente la música si se estaba reproduciendo antes de una breve desconexión (en un lapso de 60 segundos)</string>
     <string name="error_usb_permission_failed">Error del sistema: Fallo al solicitar el cuadro de diálogo de permiso USB.</string>
 
         <!-- Custom loading screen -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -663,6 +663,8 @@
     <string name="media_session_aa_status_placeholder">Connecté</string>
     <string name="sync_media_session_aa_metadata">AA en cours de lecture sur la session média</string>
     <string name="sync_media_session_aa_metadata_description">Afficher le titre de la piste, l\'artiste, la durée et la pochette du téléphone dans la session média du système et la notification média</string>
+    <string name="auto_resume_playback_on_reconnect">Reprendre la lecture lors de la reconnexion</string>
+    <string name="auto_resume_playback_on_reconnect_description">Reprend automatiquement la lecture si de la musique était en cours avant une brève coupure de connexion (moins de 60 secondes)</string>
     <string name="nav_notification_channel_name">Navigation</string>
     <string name="nav_notification_channel_description">Mises à jour de navigation pas à pas d\'Android Auto</string>
     <string name="nav_notification_title_format">Dans %1$d m — %2$s</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -510,6 +510,8 @@
     <string name="media_session_aa_status_placeholder">Csatlakoztatva</string>
     <string name="sync_media_session_aa_metadata">AA aktuális szám a médialejátszási munkamenetben</string>
     <string name="sync_media_session_aa_metadata_description">A telefonról származó számcímet, előadót, időtartamot és borítót jelenítse meg a rendszer médialejátszási munkamenetében és médiás értesítésben</string>
+    <string name="auto_resume_playback_on_reconnect">Lejátszás folytatása újrakapcsolódáskor</string>
+    <string name="auto_resume_playback_on_reconnect_description">Automatikusan folytatja a zenét, ha az aktívan szólt egy rövid kapcsolatszakadás előtt (60 másodpercen belül)</string>
     <string name="error_usb_permission_failed">Rendszerhiba: Nem sikerült lekérni az USB engedélykérő ablakot.</string>
 
     <!-- Custom loading screen -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -518,6 +518,8 @@
     <string name="media_session_aa_status_placeholder">Connesso</string>
     <string name="sync_media_session_aa_metadata">Brano AA corrente nella sessione multimediale</string>
     <string name="sync_media_session_aa_metadata_description">Mostra titolo, artista, durata e copertina dal telefono nella sessione multimediale di sistema e nella notifica multimediale</string>
+    <string name="auto_resume_playback_on_reconnect">Riprendi riproduzione alla riconnessione</string>
+    <string name="auto_resume_playback_on_reconnect_description">Riprende automaticamente la musica se era in riproduzione attiva prima di una breve disconnessione (entro 60 secondi)</string>
     <string name="error_usb_permission_failed">Errore di sistema: Impossibile richiedere la finestra di dialogo del permesso USB.</string>
 
     <!-- Custom loading screen -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -519,6 +519,8 @@
     <string name="media_session_aa_status_placeholder">接続済み</string>
     <string name="sync_media_session_aa_metadata">メディアセッションにAAの再生中トラックを表示</string>
     <string name="sync_media_session_aa_metadata_description">スマートフォンの曲名、アーティスト、再生時間、アルバムアートをシステムのメディアセッションとメディア通知に表示します</string>
+    <string name="auto_resume_playback_on_reconnect">再接続時に再生を再開</string>
+    <string name="auto_resume_playback_on_reconnect_description">接続が一時的に切断される前に音楽を再生していた場合、自動的に再生を再開します（60秒以内の再接続）</string>
     <string name="error_usb_permission_failed">システムエラー: USBパーミッションダイアログの要求に失敗しました。</string>
 
     <!-- Custom loading screen -->

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -427,6 +427,8 @@
     <string name="media_session_aa_status_placeholder">დაკავშირებულია</string>
     <string name="sync_media_session_aa_metadata">AA მუსიკის სინქრონიზაცია მედიასესიასთან</string>
     <string name="sync_media_session_aa_metadata_description">ტელეფონიდან ტრეკის დასახელების, შემსრულებლის, ხანგრძლივობისა და ალბომის ყდის ჩვენება სისტემურ მედიასესიაში და მედიაშეტყობინებაში</string>
+    <string name="auto_resume_playback_on_reconnect">დაკვრის გაგრძელება ხელახალი დაკავშირებისას</string>
+    <string name="auto_resume_playback_on_reconnect_description">ავტომატურად აგრძელებს მუსიკის დაკვრას, თუ ის უკრავდა ხანმოკლე გათიშვამდე (60 წამის განმავლობაში)</string>
     <string name="nav_notification_channel_name">ნავიგაცია</string>
     <string name="nav_notification_channel_description">ნაბიჯ-ნაბიჯ ნავიგაციის განახლებები Android Auto-დან</string>
     <string name="nav_notification_title_format">%1$d მეტრში — %2$s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -440,6 +440,8 @@
     <string name="media_session_aa_status_placeholder">연결됨</string>
     <string name="sync_media_session_aa_metadata">Android Auto 재생 정보를 미디어 세션에 표시</string>
     <string name="sync_media_session_aa_metadata_description">휴대폰의 곡 제목, 아티스트, 재생 시간, 앨범 아트를 시스템 미디어 세션과 미디어 알림에 표시합니다.</string>
+    <string name="auto_resume_playback_on_reconnect">재연결 시 재생 자동 재개</string>
+    <string name="auto_resume_playback_on_reconnect_description">연결이 일시적으로 끊어지기 전에 음악이 재생 중이었던 경우 자동으로 재생을 재개합니다(60초 이내 재연결 시).</string>
     <string name="nav_notification_channel_name">내비게이션</string>
     <string name="nav_notification_channel_description">Android Auto의 길 안내 업데이트</string>
     <string name="nav_notification_title_format">%1$d m 후 %2$s</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -511,6 +511,8 @@
     <string name="media_session_aa_status_placeholder">Verbonden</string>
     <string name="sync_media_session_aa_metadata">Huidig AA-nummer in mediasessie</string>
     <string name="sync_media_session_aa_metadata_description">Toon titel, artiest, duur en albumhoes van de telefoon in de mediasessie van het systeem en in de mediamelding</string>
+    <string name="auto_resume_playback_on_reconnect">Afspelen hervatten bij opnieuw verbinden</string>
+    <string name="auto_resume_playback_on_reconnect_description">Hervat automatisch de muziek als deze actief speelde voor een korte verbindingsonderbreking (binnen 60 seconden)</string>
     <string name="error_usb_permission_failed">Systeemfout: Aanvragen van USB-toestemmingsvenster mislukt.</string>
 
     <!-- Custom loading screen -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -512,6 +512,8 @@
     <string name="media_session_aa_status_placeholder">Połączono</string>
     <string name="sync_media_session_aa_metadata">Aktualny utwór AA w sesji multimedialnej</string>
     <string name="sync_media_session_aa_metadata_description">Pokazuj tytuł, wykonawcę, czas trwania i okładkę albumu z telefonu w systemowej sesji multimedialnej oraz powiadomieniu multimedialnym</string>
+    <string name="auto_resume_playback_on_reconnect">Wznów odtwarzanie po ponownym połączeniu</string>
+    <string name="auto_resume_playback_on_reconnect_description">Automatycznie wznawia muzykę, jeśli była odtwarzana przed krótkim przerwaniem połączenia (w ciągu 60 sekund)</string>
     <string name="error_usb_permission_failed">Błąd systemu: Nie udało się wywołać okna uprawnień USB.</string>
 
     <!-- Custom loading screen -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -512,6 +512,8 @@
     <string name="media_session_aa_status_placeholder">Conectado</string>
     <string name="sync_media_session_aa_metadata">Faixa atual do AA na sessão de mídia</string>
     <string name="sync_media_session_aa_metadata_description">Mostrar título, artista, duração e capa do álbum do telefone na sessão de mídia do sistema e na notificação de mídia</string>
+    <string name="auto_resume_playback_on_reconnect">Retomar reprodução ao reconectar</string>
+    <string name="auto_resume_playback_on_reconnect_description">Retoma automaticamente a música se ela estava tocando antes de uma breve desconexão (dentro de 60 segundos)</string>
     <string name="error_usb_permission_failed">Erro do sistema: Falha ao solicitar a caixa de diálogo de permissão USB.</string>
 
     <!-- Custom loading screen -->

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -512,6 +512,8 @@
     <string name="media_session_aa_status_placeholder">Conectat</string>
     <string name="sync_media_session_aa_metadata">Piesa curentă AA în sesiunea media</string>
     <string name="sync_media_session_aa_metadata_description">Afișează titlul piesei, artistul, durata și coperta albumului de pe telefon în sesiunea media a sistemului și în notificarea media</string>
+    <string name="auto_resume_playback_on_reconnect">Reia redarea la reconectare</string>
+    <string name="auto_resume_playback_on_reconnect_description">Reia automat muzica dacă rula înainte de o scurtă deconectare (în decurs de 60 de secunde)</string>
     <string name="error_usb_permission_failed">Eroare de sistem: Nu s-a putut solicita caseta de dialog pentru permisiunea USB.</string>
 
     <!-- Custom loading screen -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -384,6 +384,8 @@
     <string name="media_session_aa_status_placeholder">Подключено</string>
     <string name="sync_media_session_aa_metadata">Текущий трек AA в медиасессии</string>
     <string name="sync_media_session_aa_metadata_description">Показывать с телефона название, исполнителя, длительность и обложку в системной медиасессии и медиа-уведомлении</string>
+    <string name="auto_resume_playback_on_reconnect">Возобновлять воспроизведение при переподключении</string>
+    <string name="auto_resume_playback_on_reconnect_description">Автоматически продолжает воспроизведение, если музыка играла перед кратковременным разрывом связи (до 60 секунд)</string>
     <string name="nav_notification_channel_name">Навигация</string>
     <string name="nav_notification_channel_description">Подсказки маршрута от Android Auto</string>
     <string name="nav_notification_title_format">Через %1$d м — %2$s</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -378,6 +378,8 @@
     <string name="media_session_aa_status_placeholder">Bağlı</string>
     <string name="sync_media_session_aa_metadata">AA çalıyor bilgisi medya oturumunda</string>
     <string name="sync_media_session_aa_metadata_description">Telefondan gelen parça adı, sanatçı, süre ve albüm kapağını sistem medya oturumunda ve bildiriminde göster</string>
+    <string name="auto_resume_playback_on_reconnect">Yeniden bağlandığında oynatmaya devam et</string>
+    <string name="auto_resume_playback_on_reconnect_description">Kısa süreli bağlantı kopmasından önce müzik çalıyorsa otomatik olarak devam ettirir (60 saniye içinde)</string>
     <string name="nav_notification_channel_name">Navigasyon</string>
     <string name="nav_notification_channel_description">Android Auto\'dan adım adım navigasyon güncellemeleri</string>
     <string name="nav_notification_title_format">%1$d m içinde — %2$s</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -512,6 +512,8 @@
     <string name="media_session_aa_status_placeholder">Підключено</string>
     <string name="sync_media_session_aa_metadata">Поточний трек AA у медіасесії</string>
     <string name="sync_media_session_aa_metadata_description">Показувати з телефона назву треку, виконавця, тривалість і обкладинку в системній медіасесії та медіа-сповіщенні</string>
+    <string name="auto_resume_playback_on_reconnect">Відновлювати відтворення при перепідключенні</string>
+    <string name="auto_resume_playback_on_reconnect_description">Автоматично продовжує відтворення, якщо музика грала перед короткочасним розривом зв\'язку (до 60 секунд)</string>
     <string name="error_usb_permission_failed">Системна помилка: Не вдалося запитати діалогове вікно дозволу USB.</string>
 
     <!-- Custom loading screen -->

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -393,6 +393,8 @@
     <string name="media_session_aa_status_placeholder">Đã kết nối</string>
     <string name="sync_media_session_aa_metadata">Bài đang phát trên AA hiển thị ở media session</string>
     <string name="sync_media_session_aa_metadata_description">Hiển thị tên bài, nghệ sĩ, thời lượng và ảnh album từ điện thoại trong media session và thông báo media của hệ thống</string>
+    <string name="auto_resume_playback_on_reconnect">Tiếp tục phát khi kết nối lại</string>
+    <string name="auto_resume_playback_on_reconnect_description">Tự động tiếp tục phát nhạc nếu nhạc đang phát trước khi mất kết nối ngắn (trong vòng 60 giây)</string>
     <string name="nav_notification_channel_name">Điều hướng</string>
     <string name="nav_notification_channel_description">Cập nhật chỉ đường từng đoạn từ Android Auto</string>
     <string name="nav_notification_title_format">Trong %1$d m — %2$s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -511,6 +511,8 @@
     <string name="media_session_aa_status_placeholder">已連線</string>
     <string name="sync_media_session_aa_metadata">在媒體工作階段顯示 AA 目前播放</string>
     <string name="sync_media_session_aa_metadata_description">在系統媒體工作階段與媒體通知中顯示來自手機的歌曲名稱、演出者、時長與專輯封面</string>
+    <string name="auto_resume_playback_on_reconnect">重新連線時繼續播放</string>
+    <string name="auto_resume_playback_on_reconnect_description">若在短暫斷線前正在播放音樂，將於重新連線後自動繼續播放（60秒內）</string>
     <string name="error_usb_permission_failed">系統錯誤：無法要求 USB 權限對話框。</string>
 
     <!-- Custom loading screen -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -754,6 +754,8 @@
     <string name="media_session_aa_status_placeholder">Connected</string>
     <string name="sync_media_session_aa_metadata">AA now playing on media session</string>
     <string name="sync_media_session_aa_metadata_description">Show track title, artist, duration and album art from the phone in the system media session and media notification</string>
+    <string name="auto_resume_playback_on_reconnect">Auto-resume playback on reconnect</string>
+    <string name="auto_resume_playback_on_reconnect_description">Automatically resume music if it was actively playing before a brief connection drop (within 60 seconds)</string>
     <string name="nav_notification_channel_name">Navigation</string>
     <string name="nav_notification_channel_description">Turn-by-turn navigation updates from Android Auto</string>
     <string name="nav_notification_title_format">In %1$d m — %2$s</string>

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/AutoResumePlaybackPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/AutoResumePlaybackPolicyTest.kt
@@ -1,0 +1,84 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutoResumePlaybackPolicyTest {
+
+    @Test
+    fun `when setting is disabled, never resumes playback`() {
+        assertFalse(
+            AutoResumePlaybackPolicy.shouldResume(
+                enabled = false,
+                wasPlayingBeforeDisconnect = true,
+                elapsedSinceDisconnectMs = 5_000L
+            )
+        )
+    }
+
+    @Test
+    fun `when music was paused before disconnect, never resumes playback`() {
+        assertFalse(
+            AutoResumePlaybackPolicy.shouldResume(
+                enabled = true,
+                wasPlayingBeforeDisconnect = false,
+                elapsedSinceDisconnectMs = 5_000L
+            )
+        )
+    }
+
+    @Test
+    fun `when quick reconnect occurs within window and music was playing, resumes playback`() {
+        assertTrue(
+            AutoResumePlaybackPolicy.shouldResume(
+                enabled = true,
+                wasPlayingBeforeDisconnect = true,
+                elapsedSinceDisconnectMs = 3_000L
+            )
+        )
+        assertTrue(
+            AutoResumePlaybackPolicy.shouldResume(
+                enabled = true,
+                wasPlayingBeforeDisconnect = true,
+                elapsedSinceDisconnectMs = 60_000L
+            )
+        )
+    }
+
+    @Test
+    fun `when reconnect occurs after timeout, does not resume playback`() {
+        assertFalse(
+            AutoResumePlaybackPolicy.shouldResume(
+                enabled = true,
+                wasPlayingBeforeDisconnect = true,
+                elapsedSinceDisconnectMs = 60_001L
+            )
+        )
+        assertFalse(
+            AutoResumePlaybackPolicy.shouldResume(
+                enabled = true,
+                wasPlayingBeforeDisconnect = true,
+                elapsedSinceDisconnectMs = 300_000L
+            )
+        )
+    }
+
+    @Test
+    fun `when elapsed time is invalid or non-positive, does not resume playback`() {
+        assertFalse(
+            AutoResumePlaybackPolicy.shouldResume(
+                enabled = true,
+                wasPlayingBeforeDisconnect = true,
+                elapsedSinceDisconnectMs = 0L
+            )
+        )
+        assertFalse(
+            AutoResumePlaybackPolicy.shouldResume(
+                enabled = true,
+                wasPlayingBeforeDisconnect = true,
+                elapsedSinceDisconnectMs = -1_000L
+            )
+        )
+    }
+}


### PR DESCRIPTION
Added: Option to auto-resume media playback on quick reconnect if music was playing before disconnect
Shoud fix: https://github.com/andreknieriem/open-headunit/issues/688