### PR TITLE
WiFi Direct: walk a pinned 5 GHz channel, and hold the bring-up for USB

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -1891,6 +1891,9 @@ class AapService : Service() {
     /** When the current USB deferral started, so the budget is measured across its retries. */
     private var usbDeferralStartedMs = 0L
     private var usbDeferralJob: Job? = null
+    // Whether a hold is actually running. The recheck coroutine has to null usbDeferralJob before it
+    // re-enters, or the re-entrant guard below would never let go, so the job cannot answer this.
+    private var usbDeferralHolding = false
 
     /**
      * Hold the wireless bring-up while a USB projection attempt is in flight, so a plugged-in
@@ -1918,9 +1921,16 @@ class AapService : Service() {
                 msSinceFirstDeferral = waitedMs,
             )
         ) {
-            if (waitedMs > 0 && usbDeferralJob != null) {
-                AppLog.i("AapService: USB handoff settled after ${waitedMs}ms — arming wireless now")
+            if (waitedMs > 0 && usbDeferralHolding) {
+                // The budget running out is not the USB attempt settling, and a hold that reached it
+                // used to be indistinguishable from one that did not.
+                if (waitedMs >= WirelessBringUpDeferralPolicy.DEFER_BUDGET_MS) {
+                    AppLog.i("AapService: the USB attempt did not settle within ${waitedMs}ms — arming wireless anyway")
+                } else {
+                    AppLog.i("AapService: USB handoff settled after ${waitedMs}ms — arming wireless now")
+                }
             }
+            usbDeferralHolding = false
             usbDeferralStartedMs = 0L
             usbDeferralJob?.cancel()
             usbDeferralJob = null
@@ -1931,6 +1941,7 @@ class AapService : Service() {
 
         AppLog.i("AapService: a USB projection attempt is in flight — holding the wireless bring-up " +
             "for up to ${WirelessBringUpDeferralPolicy.DEFER_BUDGET_MS}ms")
+        usbDeferralHolding = true
         usbDeferralJob = serviceScope.launch {
             delay(USB_DEFERRAL_RECHECK_MS)
             usbDeferralJob = null

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -36,6 +36,7 @@ import com.andrerinas.openheadunit.app.ForegroundServiceTypePolicy
 import com.andrerinas.openheadunit.app.WifiAutoStartReceiver
 import com.andrerinas.openheadunit.connection.wifi.HotspotExitAction
 import com.andrerinas.openheadunit.connection.wifi.UsbSessionQuiescePolicy
+import com.andrerinas.openheadunit.connection.wifi.WirelessBringUpDeferralPolicy
 import com.andrerinas.openheadunit.connection.wifi.UserExitHotspotPolicy
 import com.andrerinas.openheadunit.decoder.audio.PlaybackFocusPolicy
 import com.andrerinas.openheadunit.main.MainActivity
@@ -55,6 +56,7 @@ import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.PlaybackStateCompat
 import androidx.media.session.MediaButtonReceiver
+import com.andrerinas.openheadunit.connection.usb.UsbDeviceCompat
 import com.andrerinas.openheadunit.connection.usb.UsbReceiver
 import com.andrerinas.openheadunit.location.GpsLocationService
 import com.andrerinas.openheadunit.utils.LocaleHelper
@@ -64,6 +66,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.hardware.usb.UsbManager
 import android.os.SystemClock
 import android.app.NotificationManager
 import android.graphics.PixelFormat
@@ -943,13 +946,17 @@ class AapService : Service() {
 
         // Decided here as well as inside initWifiMode() so a paused start skips the wait-for-WiFi
         // machinery entirely rather than setting it up and being turned away at the end of it.
+        // Before wireless, not after. A device the USB rules accept starts a switch here, and
+        // initWifiModeWithOptionalWait() then stands back for it; one they reject stakes nothing
+        // and wireless arms as it always did.
+        usbLauncherManager.checkAlreadyConnected()
+
         if (applyBootLoopGuard()) {
             AppLog.w("AapService: Wireless bring-up paused by the boot-loop guard. USB and the rest of the app are unaffected.")
         } else {
             initWifiModeWithOptionalWait()
         }
         scheduleBootLoopStrikeClear()
-        usbLauncherManager.checkAlreadyConnected()
         registerNetworkMonitor()
     }
 
@@ -1881,6 +1888,58 @@ class AapService : Service() {
         }
     }
 
+    /** When the current USB deferral started, so the budget is measured across its retries. */
+    private var usbDeferralStartedMs = 0L
+    private var usbDeferralJob: Job? = null
+
+    /**
+     * Hold the wireless bring-up while a USB projection attempt is in flight, so a plugged-in
+     * dongle does not get a WiFi Direct group, a 5288 server and a Bluetooth poke raised around it
+     * and torn straight back down. Re-checks on a timer rather than refusing outright: nothing else
+     * would re-arm wireless if the USB attempt comes to nothing.
+     */
+    private fun deferWirelessForUsbHandoff(): Boolean {
+        if (isDestroying) return false
+
+        val accessoryOnBus = try {
+            val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
+            usbManager.deviceList.values.any { UsbDeviceCompat.isInAccessoryMode(it) }
+        } catch (e: Exception) {
+            AppLog.w("AapService: Could not read the USB bus before wireless bring-up: ${e.message}")
+            false
+        }
+
+        if (usbDeferralStartedMs == 0L) usbDeferralStartedMs = SystemClock.elapsedRealtime()
+        val waitedMs = SystemClock.elapsedRealtime() - usbDeferralStartedMs
+
+        if (!WirelessBringUpDeferralPolicy.shouldDefer(
+                accessoryDeviceOnBus = accessoryOnBus,
+                switchInFlight = usbLauncherManager.isSwitchingToProjection(),
+                msSinceFirstDeferral = waitedMs,
+            )
+        ) {
+            if (waitedMs > 0 && usbDeferralJob != null) {
+                AppLog.i("AapService: USB handoff settled after ${waitedMs}ms — arming wireless now")
+            }
+            usbDeferralStartedMs = 0L
+            usbDeferralJob?.cancel()
+            usbDeferralJob = null
+            return false
+        }
+
+        if (usbDeferralJob?.isActive == true) return true
+
+        AppLog.i("AapService: a USB projection attempt is in flight — holding the wireless bring-up " +
+            "for up to ${WirelessBringUpDeferralPolicy.DEFER_BUDGET_MS}ms")
+        usbDeferralJob = serviceScope.launch {
+            delay(USB_DEFERRAL_RECHECK_MS)
+            usbDeferralJob = null
+            if (commManager.isConnected) usbDeferralStartedMs = 0L
+            else initWifiModeWithOptionalWait()
+        }
+        return true
+    }
+
     /**
      * Decides whether to call [initWifiMode] immediately or wait for WiFi connectivity.
      *
@@ -1892,6 +1951,8 @@ class AapService : Service() {
      * When the setting is disabled, or the mode is not 2, [initWifiMode] runs immediately.
      */
     private fun initWifiModeWithOptionalWait() {
+        if (deferWirelessForUsbHandoff()) return
+
         val settings = App.provide(this).settings
 
         if (settings.wifiConnectionMode != WifiLauncherMode.HELPER || settings.helperConnectionStrategy != HelperStrategy.WIFI_DIRECT || !settings.waitForWifiBeforeWifiDirect) {
@@ -2826,6 +2887,9 @@ class AapService : Service() {
 
         /** Delay before retrying USB connection after an unexpected disconnect. */
         private const val USB_RECONNECT_DELAY_MS = 3000L
+
+        /** How often the USB deferral re-asks; well inside its own budget. */
+        private const val USB_DEFERRAL_RECHECK_MS = 1_000L
 
         /**
          * `NetworkCallback.onAvailable` fires per network and again on re-validation, so a

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/WirelessBringUpDeferralPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/WirelessBringUpDeferralPolicy.kt
@@ -1,0 +1,35 @@
+package com.andrerinas.openheadunit.connection.wifi
+
+/**
+ * Whether the wireless stack should stand back and let an in-flight USB session win the start.
+ *
+ * `onCreate` arms WiFi Direct, the 5288 server and, on Native mode, a Bluetooth HFP poke before it
+ * has looked at the USB bus, so a dongle already plugged in gets a whole wireless bring-up raised
+ * and torn down around it. [UsbSessionQuiescePolicy] fixes that at connect time, which is too late.
+ *
+ * The question is deliberately narrow. "Is a USB device attached" would be the obvious one and is
+ * wrong: `UsbDeviceIdentityPolicy` accepts an unnamed vendor-class interface rather than guessing,
+ * so a peripheral that is permanently plugged in - a dock, an audio or Bluetooth adapter - could
+ * hold wireless off on every start. An accessory-mode device or a live switch claim cannot be
+ * anything but a projection attempt.
+ */
+object WirelessBringUpDeferralPolicy {
+
+    /**
+     * How long wireless waits. The backstop is a dongle that reaches accessory mode and then never
+     * negotiates, which the rig saw when no phone was paired to it: without a bound, that unit
+     * would never get its wireless stack.
+     */
+    const val DEFER_BUDGET_MS = 8_000L
+
+    /**
+     * @param accessoryDeviceOnBus  something is enumerated as 0x18D1:0x2D00/0x2D01
+     * @param switchInFlight        an AOA switch is running, or an activity has claimed one
+     * @param msSinceFirstDeferral  0 on the first call for a given start
+     */
+    fun shouldDefer(
+        accessoryDeviceOnBus: Boolean,
+        switchInFlight: Boolean,
+        msSinceFirstDeferral: Long,
+    ): Boolean = (accessoryDeviceOnBus || switchInFlight) && msSinceFirstDeferral < DEFER_BUDGET_MS
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/StationStandDown.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/StationStandDown.kt
@@ -42,10 +42,11 @@ object StationStandDown {
         val settings = try {
             App.provide(context).settings
         } catch (e: Exception) {
-            AppLog.d("StationStandDown: settings unavailable, not standing down: ${e.message}")
+            // Without somewhere to record the network id there is no way back to it, and a
+            // stand-down we cannot undo is worse than one that never happened.
+            AppLog.d("StationStandDown: no store for the restore record, not standing down: ${e.message}")
             return false
         }
-        if (!settings.standDownStationForWifiDirect) return false
 
         try {
             val wm = context.applicationContext
@@ -59,7 +60,6 @@ object StationStandDown {
             val overlay = AppPermissions.isOverlayGranted(context)
 
             if (!StationStandDownPolicy.shouldStandDown(
-                    enabled = settings.standDownStationForWifiDirect,
                     sdkInt = Build.VERSION.SDK_INT,
                     canDrawOverlays = overlay,
                     associated = associated,
@@ -68,7 +68,7 @@ object StationStandDown {
             ) {
                 val why = StationStandDownPolicy.describeUnavailable(Build.VERSION.SDK_INT, overlay)
                 when {
-                    why != null -> AppLog.w("StationStandDown: $why")
+                    why != null -> AppLog.i("StationStandDown: $why")
                     !associated -> AppLog.i(
                         "StationStandDown: this unit is not joined to another WiFi network, so " +
                             "there is nothing to stand down before creating the group."

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/StationStandDownPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/StationStandDownPolicy.kt
@@ -8,11 +8,9 @@ package com.andrerinas.openheadunit.connection.wifi.direct
  * for, refuses to create one at all. That is the shape of a unit whose group never forms and of one
  * whose picture stutters on a busy home channel.
  *
- * Bounded to the bring-up and reversed afterwards, because the same association is measured to be
- * the *good* state once a session is running: on this hardware class an unjoined unit lost the
- * picture for seconds at a time where a joined one ran clean. [StationCoexistencePolicy] is why this
- * is a setting the user turns on rather than something the app decides, and it keeps describing
- * rather than prescribing regardless of what happens here.
+ * Unconditional on every Native AA WiFi Direct bring-up: the platform gate below and whether this
+ * unit is joined to anything are the only questions. Bounded to the bring-up and reversed on
+ * teardown. [StationCoexistencePolicy] keeps describing rather than prescribing regardless.
  *
  * Pure, so every combination is a unit test rather than a device.
  */
@@ -46,31 +44,29 @@ object StationStandDownPolicy {
      *   guessing one would disable a network the user never joined.
      */
     fun shouldStandDown(
-        enabled: Boolean,
         sdkInt: Int,
         canDrawOverlays: Boolean,
         associated: Boolean,
         networkId: Int
-    ): Boolean = enabled &&
-        associated &&
+    ): Boolean = associated &&
         networkId >= 0 &&
         isAvailable(sdkInt, canDrawOverlays)
 
     /**
-     * Why a stand-down the user asked for is not going to happen, or null when it will.
+     * Why the stand-down is not going to happen on this unit, or null when it will.
      *
-     * A toggle that silently does nothing is how a setting stops being trusted, and on 29-34 the
-     * answer is a permission the user can actually grant.
+     * Logged rather than shown: on 29-34 the answer is a permission the user can actually grant,
+     * and above that it is a fact about the unit worth having in a bug report.
      */
     fun describeUnavailable(sdkInt: Int, canDrawOverlays: Boolean): String? = when {
         isAvailable(sdkInt, canDrawOverlays) -> null
         sdkInt <= LAST_API_WITH_OVERLAY_BYPASS ->
             "This unit's Android will only let the app drop its own WiFi connection while the app " +
-                "has the \"display over other apps\" permission. Granting it enables this."
+                "has the \"display over other apps\" permission. Granting it frees the group's radio."
         else ->
-            "Android $sdkInt does not let an app drop this unit's own WiFi connection, so this " +
-                "setting cannot do anything here. Disconnecting it by hand before connecting is " +
-                "the only way to get the same effect."
+            "Android $sdkInt does not let an app drop this unit's own WiFi connection, so the " +
+                "group has to share its channel. Disconnecting this unit's WiFi by hand before " +
+                "connecting is the only way to free it."
     }
 
     /**

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiCountryPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiCountryPolicy.kt
@@ -1,0 +1,59 @@
+package com.andrerinas.openheadunit.connection.wifi.direct
+
+/**
+ * Which regulatory domain this unit's WiFi is operating under, from whatever source will say.
+ *
+ * The domain decides which 5 GHz channels a group owner may transmit on, and a channel the driver
+ * refuses is indistinguishable in a log from a channel the app asked for wrongly. Naming the country
+ * separates the two, and it is the only way to tell a reporter whose phone is in a different domain
+ * that the two do not overlap.
+ *
+ * Pure, so every source combination is a unit test rather than a device.
+ */
+object WifiCountryPolicy {
+
+    /** What the framework and the drivers use when no country has been established. */
+    private val WORLD_DOMAINS = setOf("00", "WW")
+
+    /**
+     * A source's answer as a country, or null where it did not give one.
+     *
+     * The world domain is deliberately null: it is the *absence* of a country, and reporting it as
+     * one would hide the case that most often explains a refusal. [isWorldDomain] is how a caller
+     * tells that apart from a source that simply said nothing.
+     */
+    fun normalise(raw: String?): String? {
+        val trimmed = raw?.trim()?.uppercase() ?: return null
+        if (trimmed in WORLD_DOMAINS) return null
+        if (trimmed.length != 2 || !trimmed.all { it in 'A'..'Z' }) return null
+        return trimmed
+    }
+
+    /** True for an answer that names the world domain rather than a country. */
+    fun isWorldDomain(raw: String?): Boolean = raw?.trim()?.uppercase() in WORLD_DOMAINS
+
+    /**
+     * The first source that names a country, or null when none does.
+     *
+     * Order is the caller's, and it is meant to be AOSP's own: `WifiCountryCode.pickCountryCode()`
+     * takes telephony before the baked-in default, so a log that ranks sources the same way can be
+     * read against what the framework actually did.
+     */
+    fun choose(sources: Map<String, String?>): String? =
+        sources.values.firstNotNullOfOrNull { normalise(it) }
+
+    /**
+     * How the domain reads in the line that reports a refused 5 GHz channel.
+     *
+     * Named rather than silent when nothing answered: an unset domain is itself the finding, because
+     * a driver with no country will not start a group owner on channels that need one.
+     */
+    fun describe(sources: Map<String, String?>): String {
+        val country = choose(sources)
+        if (country != null) return "regulatory domain $country"
+        if (sources.values.any { isWorldDomain(it) }) {
+            return "no regulatory domain set on this unit (world domain)"
+        }
+        return "regulatory domain unknown, nothing on this unit would say"
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiDirectManager.kt
@@ -38,6 +38,7 @@ import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.ConnectionIssue
 import com.andrerinas.openheadunit.utils.ConnectionIssues
 import com.andrerinas.openheadunit.utils.InterfaceMacReader
+import com.andrerinas.openheadunit.utils.SystemProperties
 import java.io.File
 import java.net.Inet4Address
 import java.net.InetSocketAddress
@@ -49,6 +50,14 @@ import java.net.Socket
 class WifiDirectManager(private val context: Context) : WifiP2pManager.ConnectionInfoListener, WifiP2pManager.GroupInfoListener {
 
     private companion object {
+        /** Where a head unit's baked-in WiFi country tends to live when telephony has none. */
+        private val COUNTRY_PROPERTY_KEYS = listOf(
+            "ro.boot.wificountrycode",
+            "persist.vendor.wifi.country",
+            "ro.wifi.country",
+            "persist.sys.country",
+        )
+
         private const val MAX_NATIVE_5GHZ_CREATE_RETRIES = 4
         private const val MAX_NATIVE_5GHZ_BAND_MISMATCH_RETRIES = 2
         private const val MAX_NATIVE_STANDARD_CREATE_RETRIES = 3
@@ -176,6 +185,8 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
      * Cleared by [stop] with the ladder, so a mode change asks once more.
      */
     private var legacyChannelRequestUnanswered = false
+    /** The regulatory domain dump is a fact about the hardware, so once per process is enough. */
+    private var countrySourceDumped = false
 
     /**
      * When the group refusal was last reported, so a unit refusing every attempt says so at a
@@ -1673,6 +1684,11 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                     override fun onSuccess() {
                         AppLog.i("WifiDirectManager: $bandLabel createGroup SUCCESS!")
                         noteGroupFormed()
+                        // Only a create that carried the frequency disproves the record. A group
+                        // formed on the driver's own pick is the failure it describes, not its cure.
+                        if (requestedFrequency > 0) {
+                            ConnectionIssues.clear(context, ConnectionIssue.FIVE_GHZ_CHANNEL_REFUSED)
+                        }
                         nativeGroupCreationMode =
                             if (band == NativeGroupBandPolicy.Band.GHZ_2_4) NATIVE_GROUP_MODE_24GHZ_REQUESTED
                             else NATIVE_GROUP_MODE_5GHZ_REQUESTED
@@ -1703,10 +1719,13 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         // all. The rungs matter because the request is a disallowed-frequency list, so a unit that
         // cannot host a group owner on the band it names does not land on the other one - it forms
         // no group. standardCreateGroup() is what advances the index when that happens.
+        // Before the first channel request, so a refusal below always has the domain above it.
+        logWifiCountrySourceDump()
+        val pinnedChannel = FiveGhzChannelPolicy.pinnedChannel(chosenChannel)
         val ladder = WifiP2pOperatingChannelPolicy.attemptChannels(
             sdkInt = Build.VERSION.SDK_INT,
             preference = preference,
-            chosenChannel = FiveGhzChannelPolicy.pinnedChannel(chosenChannel),
+            chosenChannel = pinnedChannel,
             supports5Ghz = supports5Ghz,
         )
         val ladderLabel = ladder.joinToString { channel ->
@@ -1723,6 +1742,23 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                     "(${ladderLabel.ifEmpty { "none" }}) has been tried, so the band goes back to " +
                     "being the driver's choice."
             )
+            // Walked across the whole window and refused every time: the unit will not host a
+            // group owner there at all, and the driver's own pick is what the setting exists to
+            // escape.
+            if (WifiP2pOperatingChannelPolicy.refusedEveryFiveGhzRung(
+                    ladder, legacyChannelAttempt, pinnedChannel
+                )
+            ) {
+                val fiveGhzRungs = ladder.filter { WifiP2pOperatingChannelPolicy.frequencyMhzFor(it) > 5000 }
+                AppLog.w(
+                    "WifiDirectManager: this unit refused a group owner on every 5 GHz channel it " +
+                        "was offered (${fiveGhzRungs.joinToString()}), ${WifiCountryPolicy.describe(wifiCountrySources())}. " +
+                        "The channel setting is not one it can honour, so the group goes up wherever " +
+                        "its driver puts it, which a phone in a stricter country may not be able to " +
+                        "see - the band is the lever left."
+                )
+                ConnectionIssues.raise(context, ConnectionIssue.FIVE_GHZ_CHANNEL_REFUSED)
+            }
             standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_LEGACY)
             return
         }
@@ -1802,6 +1838,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
 
             NativeGroupBandPolicy.NextStep.DROP_PINNED_CHANNEL -> {
                 pinnedChannelAbandoned = true
+                ConnectionIssues.raise(context, ConnectionIssue.FIVE_GHZ_CHANNEL_REFUSED)
                 AppLog.w(
                     "WifiDirectManager: $requestLabel createGroup retries exhausted ($reasonStr). This unit " +
                         "will not host a group on that channel, so the request goes back to the $bandLabel band " +
@@ -1993,6 +2030,12 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     private fun onStandardCreateSucceeded(mgr: WifiP2pManager, ch: WifiP2pManager.Channel, groupMode: String) {
         AppLog.i("WifiDirectManager: Standard createGroup SUCCESS!")
         noteGroupFormed()
+        // Read before releaseLegacyChannelRestriction() clears the flag. A group formed while the
+        // restriction stood is on the channel that was asked for, and only that disproves the
+        // record - the unrestricted create below it is the failure the record describes.
+        if (legacyChannelRestrictionApplied) {
+            ConnectionIssues.clear(context, ConnectionIssue.FIVE_GHZ_CHANNEL_REFUSED)
+        }
         nativeGroupCreationMode = groupMode
         // The platform chose the band here, so there is no mismatch to correct, and no
         // frequency was named either.
@@ -2017,8 +2060,15 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
      * 2.4 GHz social channels discovery runs on, and it is state in the supplicant that outlives
      * this app. A group that has already formed keeps its channel, so nothing is lost by clearing.
      */
-    private fun releaseLegacyChannelRestriction(mgr: WifiP2pManager, ch: WifiP2pManager.Channel) {
-        if (!legacyChannelRestrictionApplied) return
+    private fun releaseLegacyChannelRestriction(
+        mgr: WifiP2pManager,
+        ch: WifiP2pManager.Channel,
+        force: Boolean = false,
+    ) {
+        // A request that timed out may still have reached the supplicant, so a teardown clears that
+        // too. Not a bare force: clearing when nothing was ever asked for costs the compat object's
+        // whole answer timeout on the drivers that never call back, for nothing.
+        if (!legacyChannelRestrictionApplied && !(force && legacyChannelRequestUnanswered)) return
         legacyChannelRestrictionApplied = false
         WifiP2pChannelCompat.clearOperatingChannel(mgr, ch, handler) { applied, _, detail ->
             if (applied) {
@@ -2180,6 +2230,57 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     }
 
     /**
+     * Every source that might name this unit's regulatory domain, one line each.
+     *
+     * Once per process, at the first group bring-up, because it is a fact about the hardware and a
+     * reader needs it in every log: which 5 GHz channels a group owner may use is the domain's answer,
+     * not ours, and a refusal reads identically to a bug without it.
+     */
+    private fun logWifiCountrySourceDump() {
+        if (countrySourceDumped) return
+        countrySourceDumped = true
+        val sources = wifiCountrySources()
+        AppLog.i("WifiDirectManager: == WiFi regulatory domain source dump ==")
+        for ((label, value) in sources) {
+            AppLog.i("WifiDirectManager:   ${label.padEnd(34)} = ${value ?: "null"}")
+        }
+        AppLog.i("WifiDirectManager: == end, ${WifiCountryPolicy.describe(sources)} ==")
+    }
+
+    /**
+     * Ordered as `WifiCountryCode.pickCountryCode()` orders them, telephony before the baked-in
+     * default, so the dump can be read against what the framework itself would have chosen.
+     */
+    private fun wifiCountrySources(): Map<String, String?> {
+        fun attempt(read: () -> String?) = try { read()?.trim()?.ifEmpty { null } } catch (e: Exception) { "err: ${e.message}" }
+        val telephony = try {
+            context.getSystemService(Context.TELEPHONY_SERVICE) as? android.telephony.TelephonyManager
+        } catch (e: Exception) { null }
+        val sources = linkedMapOf<String, String?>(
+            "TelephonyManager.networkCountry" to attempt { telephony?.networkCountryIso },
+            "TelephonyManager.simCountry" to attempt { telephony?.simCountryIso },
+            "Settings.Global wifi_country_code" to attempt {
+                Settings.Global.getString(context.contentResolver, "wifi_country_code")
+            },
+        )
+        for (key in COUNTRY_PROPERTY_KEYS) {
+            sources["property $key"] = SystemProperties.get(key, "").trim().ifEmpty { null }
+        }
+        // Authoritative where it answers, and refused on most units: it is @hide behind
+        // CONNECTIVITY_INTERNAL from API 28. Attempted anyway for head units that run this app as
+        // system, the same bet SoftApConfigCompat makes.
+        sources["WifiManager.getCountryCode()"] = attempt {
+            val wm = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager
+            wm?.javaClass?.getMethod("getCountryCode")?.invoke(wm) as? String
+        }
+        // Last, and labelled: this is what the user set the screen to, not what the radio obeys.
+        sources["Locale.getDefault() (UI, not radio)"] = attempt {
+            java.util.Locale.getDefault().country
+        }
+        return sources
+    }
+
+    /**
      * Every BSSID source and what each answered, printed once per group.
      *
      * With nine of them in the chain, "all fallbacks failed" tells a reporter's log nothing about
@@ -2323,18 +2424,17 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         nativeRecreateCount = 0
         lastNativeGroupStatusMessage = null
         legacyChannelAttempt = 0
-        legacyChannelRequestUnanswered = false
         lastGroupRefusalReportAtMs = 0L
         churnWindowStartedAtMs = 0L
         churnEventsInWindow = 0
         churnForeignEventsInWindow = 0
         lastChurnReportAtMs = 0L
-        // Unconditional, and not gated on legacyChannelRestrictionApplied: a request that never
-        // answered may still have been applied, and the restriction is supplicant state that
-        // outlives this process.
         pinnedChannelAbandoned = false
         namedFallbackRefused = false
-        manager?.let { mgr -> channel?.let { ch -> releaseLegacyChannelRestriction(mgr, ch) } }
+        // Before legacyChannelRequestUnanswered is reset, because that flag is what tells the
+        // release a timed-out request may have left a restriction behind.
+        manager?.let { mgr -> channel?.let { ch -> releaseLegacyChannelRestriction(mgr, ch, force = true) } }
+        legacyChannelRequestUnanswered = false
         AapService.scanningState.value = false
         try { context.unregisterReceiver(receiver) } catch (e: Exception) {}
         // Follows the receiver rather than outliving it: registerReceiverIfNeeded() is a no-op while

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiP2pOperatingChannelPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiP2pOperatingChannelPolicy.kt
@@ -91,9 +91,11 @@ object WifiP2pOperatingChannelPolicy {
      *   a guarantee for a reflection.
      * @param preference the user's band choice.
      * @param chosenChannel the channel the user pinned, or [CHANNEL_UNRESTRICTED] for automatic,
-     *   which asks for [CHANNEL_LOWER]. A pinned channel replaces that first rung and nothing else:
-     *   the 2.4 GHz rung below it stays, because a disallowed-frequency list a unit cannot satisfy
-     *   costs it the group rather than the band.
+     *   which asks for [CHANNEL_LOWER] alone. A pinned channel is walked across its own UNII window
+     *   instead - see [fiveGhzWalk] - because somebody who named a channel has said the driver's own
+     *   pick does not work for them, and one refusal is not the window's answer. The 2.4 GHz rung
+     *   below it stays either way, because a disallowed-frequency list a unit cannot satisfy costs
+     *   it the group rather than the band.
      * @param supports5Ghz [WifiBandCapability.supports5Ghz], where null means the platform would not
      *   say. Only `false` drops a rung, and only under [P2pBandPreference.AUTO]: a `true` describes
      *   the station side and does not promise a group owner can be hosted there, so the ladder keeps
@@ -109,16 +111,51 @@ object WifiP2pOperatingChannelPolicy {
         if (!appliesTo(sdkInt)) return emptyList()
         // Total rather than trusting the caller: anything a group owner cannot be hosted on falls
         // back to the rung that shipped before the choice existed.
-        val fiveGhz = if (isGroupOwnerCapable(chosenChannel)) chosenChannel else CHANNEL_LOWER
+        val fiveGhz =
+            if (isGroupOwnerCapable(chosenChannel)) fiveGhzWalk(chosenChannel) else listOf(CHANNEL_LOWER)
         return when (preference) {
             // Spending the 5 GHz rung on a radio with no 5 GHz band costs a whole bring-up: the
             // request is a disallowed-frequency list, so the group is not formed on the other band,
             // it is not formed at all, and the ladder only advances on that failure.
             P2pBandPreference.AUTO ->
-                if (supports5Ghz == false) listOf(CHANNEL_24_GHZ) else listOf(fiveGhz, CHANNEL_24_GHZ)
-            P2pBandPreference.FORCE_5GHZ -> listOf(fiveGhz)
+                if (supports5Ghz == false) listOf(CHANNEL_24_GHZ) else fiveGhz + CHANNEL_24_GHZ
+            P2pBandPreference.FORCE_5GHZ -> fiveGhz
             P2pBandPreference.FORCE_2_4GHZ -> listOf(CHANNEL_24_GHZ)
         }
+    }
+
+    /**
+     * The pinned channel, then the rest of its own UNII window.
+     *
+     * A refusal is the driver saying it will not host a group owner on that frequency, and it says
+     * nothing about the three beside it, so one channel must not condemn the window the user chose.
+     * Only that window: somebody who pinned UNII-1 is escaping UNII-3, and walking into it would
+     * land them where they started.
+     */
+    private fun fiveGhzWalk(chosenChannel: Int): List<Int> {
+        val window = if (chosenChannel in UNII_1_CHANNELS) UNII_1_CHANNELS else UNII_3_CHANNELS
+        return listOf(chosenChannel) + window.filter { it != chosenChannel }
+    }
+
+    /**
+     * Whether a spent ladder means this unit will not host a group owner on 5 GHz at all.
+     *
+     * True only once every 5 GHz rung the user's pin produced has been refused, which is the one
+     * finding worth telling them about: the channel setting cannot be honoured here and the band is
+     * the lever left. An automatic pin never asks, because the driver's own choice is not a refusal.
+     *
+     * @param ladder [attemptChannels]' answer for this bring-up.
+     * @param rungsSpent how many rungs have already been tried, so equal to the ladder's 5 GHz count
+     *   means all of them were.
+     * @param pinnedChannel the *sanitized* pin
+     *   ([FiveGhzChannelPolicy.pinnedChannel][com.andrerinas.openheadunit.connection.wifi.FiveGhzChannelPolicy.pinnedChannel]),
+     *   because an unrecognised stored value runs the default ladder and must not be blamed on a
+     *   channel the user could never have chosen.
+     */
+    fun refusedEveryFiveGhzRung(ladder: List<Int>, rungsSpent: Int, pinnedChannel: Int): Boolean {
+        if (pinnedChannel == CHANNEL_UNRESTRICTED) return false
+        val fiveGhzRungs = ladder.count { frequencyMhzFor(it) > 5000 }
+        return fiveGhzRungs > 0 && rungsSpent >= fiveGhzRungs
     }
 
     /**
@@ -156,5 +193,8 @@ object WifiP2pOperatingChannelPolicy {
         channel in UNII_1_CHANNELS || channel in UNII_3_CHANNELS
 
     private val UNII_1_CHANNELS = listOf(36, 40, 44, 48)
-    private val UNII_3_CHANNELS = listOf(149, 153, 157, 161, 165)
+    // 165 is absent on purpose. createGroup asks wpa_supplicant to pick with freq=0, and
+    // wpas_p2p_select_go_freq_no_pref proposes 5180/5200/5220/5240 then 5745/5765/5785/5805 and
+    // nothing else, so 5825 cannot be reached through this API however the radio is configured.
+    private val UNII_3_CHANNELS = listOf(149, 153, 157, 161)
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/WifiLauncherNative.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/WifiLauncherNative.kt
@@ -78,8 +78,8 @@ class WifiLauncherNative : WifiLauncher {
                 softApCredentialsProvider?.start()
             } else if (wifiDirect != null) {
                 // Before the group, not after: wpa_supplicant only honours a channel while no group
-                // exists, and an associated station is what leaves it none to give. Opt-in, and a
-                // no-op on a unit that is not joined to anything.
+                // exists, and an associated station is what leaves it none to give. A no-op on a
+                // unit that is not joined to anything.
                 val stoodDown = StationStandDown.standDown(service)
 
                 // Start WiFi Direct as a "quiet host" (P2P Group for phone to join)

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/NativeAaHandshakeManager.kt
@@ -2082,7 +2082,11 @@ class NativeAaHandshakeManager(
                     val device = if (v.hasDeviceInfo()) {
                         " device=${v.deviceInfo.deviceId} lifetime=${v.deviceInfo.connectivityLifetimeId}"
                     } else ""
-                    AppLog.i("NativeAA: [RX] WifiVersionResponse v${v.major}.${v.minor} status=${WppStatus.describe(if (v.hasStatus()) v.status else null)}$device")
+                    // The phone's own answer to which band it wants (2.4-only / 5-only / dual). The
+                    // one place it says so, and the only check on a channel we cannot read back.
+                    val channelType =
+                        if (v.hasSelectedWifiChannelType()) " channelType=${v.selectedWifiChannelType}" else ""
+                    AppLog.i("NativeAA: [RX] WifiVersionResponse v${v.major}.${v.minor} status=${WppStatus.describe(if (v.hasStatus()) v.status else null)}$channelType$device")
                 }
                 WppMessageType.CONNECT_STATUS -> {
                     val s = Wireless.WifiConnectStatus.parseFrom(msg.payload)

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/NativeAaHandshakeManager.kt
@@ -1054,6 +1054,34 @@ class NativeAaHandshakeManager(
     }
 
     /**
+     * Waits out a poke already inside `socket.connect()` for [device], and says whether this one
+     * may now open its own. False means another poke has been connecting to this phone for the
+     * whole bound: a second socket to a stuck one only made every record fail.
+     */
+    private suspend fun awaitPokeSlot(device: BluetoothDevice): Boolean {
+        var waitedMs = 0L
+        while (isRunning) {
+            when (PokeOverlapPolicy.step(pokeConnectingTo, device.address, waitedMs)) {
+                PokeOverlapPolicy.Step.PROCEED -> return true
+                PokeOverlapPolicy.Step.ABANDON -> {
+                    AppLog.i("NativeAA: another poke has been connecting to ${device.name} for " +
+                        "${waitedMs}ms — not opening a second socket to it.")
+                    return false
+                }
+                PokeOverlapPolicy.Step.WAIT -> {
+                    if (waitedMs == 0L) {
+                        AppLog.i("NativeAA: another poke is already connecting to ${device.name} — " +
+                            "waiting for it rather than opening a second socket.")
+                    }
+                    delay(PokeOverlapPolicy.POLL_MS)
+                    waitedMs += PokeOverlapPolicy.POLL_MS
+                }
+            }
+        }
+        return false
+    }
+
+    /**
      * Tries each of [BluetoothWakePolicy.POKE_TARGETS] in turn, holding whichever connects for
      * [holdMs]. Returns true if any of them did, false without opening anything if either guard
      * below stands the poke down. Both poke entry points come through here, so one check covers
@@ -1379,6 +1407,11 @@ class NativeAaHandshakeManager(
                         }
                     }
 
+                    // A credential redelivery cancels this loop and starts a fresh one, and cancel
+                    // cannot interrupt a blocking connect() — so the poke we replaced may still be
+                    // inside one aimed at this same phone.
+                    if (!awaitPokeSlot(device)) continue
+
                     AppLog.i("NativeAA: Attempting active poke to device: ${device.name} (${device.address})...")
                     pokeDevice(device, holdMs = 15000)
                 }
@@ -1456,21 +1489,7 @@ class NativeAaHandshakeManager(
 
                     // pokeJob.cancel() above cannot interrupt a blocking connect(), so the
                     // automatic poke it replaced may still be inside one aimed at this same phone.
-                    // Two at once left all four records failing; wait for the radio.
-                    var overlapWaitedMs = 0L
-                    while (isRunning && isActive && PokeOverlapPolicy.step(
-                            connectingTo = pokeConnectingTo,
-                            target = address,
-                            waitedMs = overlapWaitedMs
-                        ) == PokeOverlapPolicy.Step.WAIT
-                    ) {
-                        if (overlapWaitedMs == 0L) {
-                            AppLog.i("NativeAA: another poke is already connecting to ${device.name} — " +
-                                "waiting for it rather than opening a second socket.")
-                        }
-                        delay(PokeOverlapPolicy.POLL_MS)
-                        overlapWaitedMs += PokeOverlapPolicy.POLL_MS
-                    }
+                    if (!awaitPokeSlot(device)) return@launch
 
                     // One hold used to be the whole wake, and it ended before the accept gate
                     // reopened, so the phone the driver had just left won the race back in.

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/NativeAaHandshakeManager.kt
@@ -215,6 +215,9 @@ class NativeAaHandshakeManager(
     // can fire an OS-level ACL_CONNECTED broadcast before any real handshake starts) - see
     // isAttemptInFlight().
     @Volatile private var pokeAttemptInFlight = false
+    // The address a poke is inside socket.connect() for, or null when none is. Narrower than
+    // pokeAttemptInFlight, which stays true for the whole hold as well - see PokeOverlapPolicy.
+    @Volatile private var pokeConnectingTo: String? = null
     // elapsedRealtime() when the last WifiInfoResponse (Type 3) went out, or 0 when no handoff is
     // settling. The phone spends the next several seconds associating, doing WPS and getting a
     // DHCP lease; see isHandoffSettling() and NativeHandoffPolicy.
@@ -1091,12 +1094,20 @@ class NativeAaHandshakeManager(
         pokeAttemptInFlight = true
         try {
             for (uuid in BluetoothWakePolicy.POKE_TARGETS) {
+                // cancel() cannot interrupt a blocking connect(), so a cancelled poke arrives here
+                // with its first record already spent. Stop rather than spend the second one too.
+                currentCoroutineContext().ensureActive()
                 val profile = BluetoothWakePolicy.profileName(uuid)
                 var socket: BluetoothSocket? = null
                 try {
                     socket = device.createRfcommSocketToServiceRecord(uuid)
                     AppLog.i("NativeAA: Calling socket.connect() for ${device.name} via $profile ($uuid)...")
+                    pokeConnectingTo = device.address
                     socket.connect()
+                    // Cleared before the hold, not in the finally below: the marker means "inside
+                    // connect()", and a hold that keeps it set would stall the next poke for
+                    // nothing - the phone is already awake by then.
+                    pokeConnectingTo = null
                     // Named, not just the UUID: which record we ended up on is the first thing to
                     // check when a reporter's calls come out of the phone instead of the car.
                     AppLog.i("NativeAA: Successfully poked ${device.name} via $profile. Holding ${holdMs}ms...")
@@ -1112,15 +1123,18 @@ class NativeAaHandshakeManager(
                     // physical radio right as the critical WifiStartRequest send is about to happen.
                     throw e
                 } catch (e: Exception) {
-                    // Address as well as name: getName() is null for an unbonded device, and a log line
-                    // reading "to null" names nothing at all for the reader of a bug report.
-                    AppLog.d("NativeAA: Poke via $profile to ${device.name ?: "unnamed"} (${device.address}) failed: ${e.message}")
+                    // Info, not debug: the success above is info, so a reporter at the default level
+                    // saw the attempt and never its outcome. Address as well as name, because
+                    // getName() is null for an unbonded device.
+                    AppLog.i("NativeAA: Poke via $profile to ${device.name ?: "unnamed"} (${device.address}) failed: ${e.message}")
                 } finally {
+                    pokeConnectingTo = null
                     try { socket?.close() } catch (e: Exception) {}
                 }
             }
             return false
         } finally {
+            pokeConnectingTo = null
             pokeAttemptInFlight = false
         }
     }
@@ -1438,6 +1452,24 @@ class NativeAaHandshakeManager(
                             waitedMs += 200
                         }
                         AppLog.i("NativeAA: Pre-poke credential wait completed. SSID=${credentials?.ssid}, IP=${credentials?.ip} (waited ${waitedMs}ms)")
+                    }
+
+                    // pokeJob.cancel() above cannot interrupt a blocking connect(), so the
+                    // automatic poke it replaced may still be inside one aimed at this same phone.
+                    // Two at once left all four records failing; wait for the radio.
+                    var overlapWaitedMs = 0L
+                    while (isRunning && isActive && PokeOverlapPolicy.step(
+                            connectingTo = pokeConnectingTo,
+                            target = address,
+                            waitedMs = overlapWaitedMs
+                        ) == PokeOverlapPolicy.Step.WAIT
+                    ) {
+                        if (overlapWaitedMs == 0L) {
+                            AppLog.i("NativeAA: another poke is already connecting to ${device.name} — " +
+                                "waiting for it rather than opening a second socket.")
+                        }
+                        delay(PokeOverlapPolicy.POLL_MS)
+                        overlapWaitedMs += PokeOverlapPolicy.POLL_MS
                     }
 
                     // One hold used to be the whole wake, and it ended before the accept gate
@@ -2285,6 +2317,7 @@ class NativeAaHandshakeManager(
         // this manager, and isAttemptInFlight() answers both arms of the Bluetooth arrival path, so
         // leaving it set makes the phone coming back do nothing at all.
         pokeAttemptInFlight = false
+        pokeConnectingTo = null
         // Cancel before dropping the reference, for the same reason a supersede does: the socket
         // this manager just closed does not necessarily end the coroutine reading from it.
         activeHandshakeJob?.cancel()

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/PokeOverlapPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/PokeOverlapPolicy.kt
@@ -3,17 +3,16 @@ package com.andrerinas.openheadunit.connection.wifi.modes.nativeaa
 /**
  * Whether a wake poke may open a socket while another one is already connecting to the same phone.
  *
- * `pokeJob.cancel()` cannot interrupt a blocking `socket.connect()`, so a manual poke that replaces
- * the automatic one still runs beside it. Measured on a POCO/Moto pair: two connects 235 ms apart
- * left all four RFCOMM attempts failing with `read ret: -1`, and the attempt 42 s later worked
- * first try.
+ * `pokeJob.cancel()` cannot interrupt a blocking `socket.connect()`, so a poke that replaced another
+ * still runs beside it. Measured on a POCO/Moto pair: two connects 235 ms apart left all four RFCOMM
+ * attempts failing with `read ret: -1`, and the attempt 42 s later worked first try.
  *
  * Pure and unit-tested; the sockets live in `NativeAaHandshakeManager`.
  */
 object PokeOverlapPolicy {
 
-    /** How long to wait for an in-flight connect. The observed HFP-AG refusal takes ~3.05 s. */
-    const val CONNECT_SETTLE_WAIT_MS = 4_000L
+    /** How long to wait for an in-flight connect. A phone with Bluetooth off takes 15.4 s to fail. */
+    const val CONNECT_SETTLE_WAIT_MS = 20_000L
 
     /** Poll interval while waiting. */
     const val POLL_MS = 100L
@@ -22,7 +21,10 @@ object PokeOverlapPolicy {
         /** Another poke is inside connect() for this phone; give it a moment. */
         WAIT,
 
-        /** Nothing in the way, or the wait is spent. Open the socket. */
+        /** It is still there after the whole wait. Do not add a second socket to a stuck one. */
+        ABANDON,
+
+        /** Nothing in the way. Open the socket. */
         PROCEED
     }
 
@@ -31,9 +33,10 @@ object PokeOverlapPolicy {
      * Only the same phone is worth waiting for: a poke aimed elsewhere shares no RFCOMM channel.
      */
     fun step(connectingTo: String?, target: String, waitedMs: Long): Step =
-        if (waitedMs < CONNECT_SETTLE_WAIT_MS &&
-            connectingTo != null &&
+        if (connectingTo != null &&
             target.isNotEmpty() &&
             connectingTo.equals(target, ignoreCase = true)
-        ) Step.WAIT else Step.PROCEED
+        ) {
+            if (waitedMs < CONNECT_SETTLE_WAIT_MS) Step.WAIT else Step.ABANDON
+        } else Step.PROCEED
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/PokeOverlapPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/PokeOverlapPolicy.kt
@@ -1,0 +1,39 @@
+package com.andrerinas.openheadunit.connection.wifi.modes.nativeaa
+
+/**
+ * Whether a wake poke may open a socket while another one is already connecting to the same phone.
+ *
+ * `pokeJob.cancel()` cannot interrupt a blocking `socket.connect()`, so a manual poke that replaces
+ * the automatic one still runs beside it. Measured on a POCO/Moto pair: two connects 235 ms apart
+ * left all four RFCOMM attempts failing with `read ret: -1`, and the attempt 42 s later worked
+ * first try.
+ *
+ * Pure and unit-tested; the sockets live in `NativeAaHandshakeManager`.
+ */
+object PokeOverlapPolicy {
+
+    /** How long to wait for an in-flight connect. The observed HFP-AG refusal takes ~3.05 s. */
+    const val CONNECT_SETTLE_WAIT_MS = 4_000L
+
+    /** Poll interval while waiting. */
+    const val POLL_MS = 100L
+
+    enum class Step {
+        /** Another poke is inside connect() for this phone; give it a moment. */
+        WAIT,
+
+        /** Nothing in the way, or the wait is spent. Open the socket. */
+        PROCEED
+    }
+
+    /**
+     * [connectingTo] is the address a poke is inside `socket.connect()` for, or null when none is.
+     * Only the same phone is worth waiting for: a poke aimed elsewhere shares no RFCOMM channel.
+     */
+    fun step(connectingTo: String?, target: String, waitedMs: Long): Step =
+        if (waitedMs < CONNECT_SETTLE_WAIT_MS &&
+            connectingTo != null &&
+            target.isNotEmpty() &&
+            connectingTo.equals(target, ignoreCase = true)
+        ) Step.WAIT else Step.PROCEED
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/main/ConnectionIssueBannerPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/ConnectionIssueBannerPolicy.kt
@@ -50,6 +50,7 @@ object ConnectionIssueBannerPolicy {
                 ConnectionIssue.BSSID_UNAVAILABLE,
                 ConnectionIssue.WIFI_DIRECT_GROUP_REFUSED,
                 ConnectionIssue.WIFI_DIRECT_STACK_CYCLED,
+                ConnectionIssue.FIVE_GHZ_CHANNEL_REFUSED,
                 ConnectionIssue.VIDEO_LINK_TOO_SLOW
             )
             NativeTransport.HOTSPOT -> setOf(
@@ -79,11 +80,13 @@ object ConnectionIssueBannerPolicy {
      *
      * `BLUETOOTH_SENT_NO_DATA` has no entry because its remedy is leaving Native AA, which
      * [relevantNow] already answers. `HOTSPOT_NOT_RUNNING`, `WIFI_DIRECT_GROUP_REFUSED`,
-     * `WIFI_DIRECT_STACK_CYCLED` and `VIDEO_LINK_TOO_SLOW` have none either: no setting fixes them,
-     * and an access point coming up, a group forming or a session rendering a frame disproves them
-     * outright, so those records retire themselves. Lowering the frame rate is deliberately not a
-     * remedy here: it is a guess at the ceiling, and only a session that renders proves it was
-     * enough.
+     * `WIFI_DIRECT_STACK_CYCLED`, `FIVE_GHZ_CHANNEL_REFUSED` and `VIDEO_LINK_TOO_SLOW` have none
+     * either: no setting fixes them, and an access point coming up, a group forming or a session
+     * rendering a frame disproves them outright, so those records retire themselves. The channel
+     * one is retired by a narrower event than the rest - a group formed *on the channel that was
+     * asked for*, since one on the driver's own pick is the failure it describes. Lowering the
+     * frame rate is deliberately not a remedy here: it is a guess at the ceiling, and only a
+     * session that renders proves it was enough.
      *
      * @param hotspotSsid [com.andrerinas.openheadunit.utils.Settings.hotspotSsid]
      * @param hotspotPassword [com.andrerinas.openheadunit.utils.Settings.hotspotPassword] — needed

--- a/app/src/main/java/com/andrerinas/openheadunit/main/MainActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/MainActivity.kt
@@ -992,6 +992,8 @@ class MainActivity : BaseActivity() {
                     R.string.connection_issue_banner_wifi_direct_cycled
                 ConnectionIssue.VIDEO_LINK_TOO_SLOW ->
                     R.string.connection_issue_banner_video_link_too_slow
+                ConnectionIssue.FIVE_GHZ_CHANNEL_REFUSED ->
+                    R.string.connection_issue_banner_five_ghz_channel_refused
             }
         )
         banner.setOnClickListener { openRemedyFor(issue) }
@@ -1034,6 +1036,7 @@ class MainActivity : BaseActivity() {
             ConnectionIssue.WIFI_DIRECT_GROUP_REFUSED -> getString(R.string.native_ap_transport)
             ConnectionIssue.WIFI_DIRECT_STACK_CYCLED -> getString(R.string.native_ap_transport)
             ConnectionIssue.VIDEO_LINK_TOO_SLOW -> getString(R.string.fps_limit)
+            ConnectionIssue.FIVE_GHZ_CHANNEL_REFUSED -> getString(R.string.wifi_direct_band)
         }
         startActivity(
             Intent(this, SettingsActivity::class.java)

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -28,7 +28,6 @@ import com.andrerinas.openheadunit.aap.AapService
 import com.andrerinas.openheadunit.connection.wifi.modes.nativeaa.CredentialField
 import com.andrerinas.openheadunit.input.MediaKeyRoutingPolicy
 import com.andrerinas.openheadunit.connection.wifi.direct.P2pGroupIdentityPolicy
-import com.andrerinas.openheadunit.connection.wifi.direct.StationStandDownPolicy
 import com.andrerinas.openheadunit.connection.wifi.modes.nativeaa.NativeCredentialsPreflightPolicy
 import com.andrerinas.openheadunit.connection.wifi.modes.nativeaa.NativeDriverSelectionPolicy
 import com.andrerinas.openheadunit.aap.NativeTransport
@@ -1092,29 +1091,6 @@ class SettingsFragment : Fragment() {
                 }
 
                 addWifiDirectIdentitySettings(items)
-
-                // Only where the platform would honour it. Below Android 10 anything may ask; from
-                // 10 to 14 the overlay permission is what gets past the framework's check, so the
-                // row stays and says so rather than vanishing into an unanswerable question; from
-                // 15 there is no route at all and offering the switch would be a lie.
-                val overlayGranted = AppPermissions.isOverlayGranted(requireContext())
-                if (StationStandDownPolicy.isAvailable(Build.VERSION.SDK_INT, true)) {
-                    items.add(SettingItem.ToggleSettingEntry(
-                        stableId = "standDownStationForWifiDirect",
-                        nameResId = R.string.stand_down_station,
-                        descriptionResId = R.string.stand_down_station_description,
-                        isChecked = settings.standDownStationForWifiDirect,
-                        isEnabled = overlayGranted,
-                        descriptionOverride = if (overlayGranted) null else
-                            getString(R.string.stand_down_station_needs_overlay) + " " +
-                                getString(R.string.stand_down_station_description),
-                        searchKeywords = "wifi disconnect station home network channel single radio",
-                        onCheckedChanged = { isChecked ->
-                            settings.standDownStationForWifiDirect = isChecked
-                            updateSettingsList()
-                        }
-                    ))
-                }
             }
 
             // Multi-Driver Selection settings for Native AA
@@ -3886,8 +3862,8 @@ class SettingsFragment : Fragment() {
      * Whether the group keeps its name and passphrase between bring-ups, and a way to draw new ones.
      *
      * Only where the group is ours to name: the hotspot's identity is the access point's own. The
-     * switch writes straight through, like the stand-down beside it, because it is read at the next
-     * create and nothing needs re-arming for it. The "new identity" action replaces both halves
+     * switch writes straight through rather than through the pending/apply pattern, because it is
+     * read at the next create and nothing needs re-arming for it. The "new identity" action replaces both halves
      * together, which is the one rotation a phone's saved profile survives.
      */
     private fun addWifiDirectIdentitySettings(items: MutableList<SettingItem>) {

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -3876,6 +3876,10 @@ class SettingsFragment : Fragment() {
                     .show()
             }
         ))
+        items.add(SettingItem.InfoBanner(
+            stableId = "fiveGhzChannelHint",
+            textResId = R.string.five_ghz_channel_hint
+        ))
     }
 
     /**

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/ConnectionIssues.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/ConnectionIssues.kt
@@ -61,7 +61,18 @@ enum class ConnectionIssue {
      * indefinitely. The user's levers are the frame rate, the resolution, AAC audio, and 5 GHz on a
      * radio that has it.
      */
-    VIDEO_LINK_TOO_SLOW
+    VIDEO_LINK_TOO_SLOW,
+
+    /**
+     * The unit refused a group owner on every 5 GHz channel the pinned one was walked across.
+     *
+     * Not the same as [WIFI_DIRECT_GROUP_REFUSED]: a group does form, on whatever channel the
+     * driver picks for itself. That is the failure - the setting exists because the driver's pick
+     * is one the user's phone cannot see, and a phone whose country forbids that channel does not
+     * merely refuse it, it never scans it and so never lists the network at all. The user's lever
+     * is the band, not the channel.
+     */
+    FIVE_GHZ_CHANNEL_REFUSED
 }
 
 /** An issue that is currently true, and when it was last raised. */
@@ -160,6 +171,7 @@ object ConnectionIssues {
                 ConnectionIssue.WIFI_DIRECT_GROUP_REFUSED -> settings.connectionIssueWifiDirectRefusedAtEpochMs
                 ConnectionIssue.WIFI_DIRECT_STACK_CYCLED -> settings.connectionIssueWifiDirectCycledAtEpochMs
                 ConnectionIssue.VIDEO_LINK_TOO_SLOW -> settings.connectionIssueVideoLinkTooSlowAtEpochMs
+                ConnectionIssue.FIVE_GHZ_CHANNEL_REFUSED -> settings.connectionIssueFiveGhzChannelRefusedAtEpochMs
             }
         } catch (e: Exception) {
             0L
@@ -175,6 +187,7 @@ object ConnectionIssues {
                     ConnectionIssue.WIFI_DIRECT_GROUP_REFUSED -> settings.connectionIssueWifiDirectRefusedAtEpochMs = atEpochMs
                     ConnectionIssue.WIFI_DIRECT_STACK_CYCLED -> settings.connectionIssueWifiDirectCycledAtEpochMs = atEpochMs
                     ConnectionIssue.VIDEO_LINK_TOO_SLOW -> settings.connectionIssueVideoLinkTooSlowAtEpochMs = atEpochMs
+                    ConnectionIssue.FIVE_GHZ_CHANNEL_REFUSED -> settings.connectionIssueFiveGhzChannelRefusedAtEpochMs = atEpochMs
                 }
             } catch (e: Exception) {
                 AppLog.d("ConnectionIssues: could not record $issue: ${e.message}")

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -1986,6 +1986,11 @@ class Settings(private val context: Context) {
         get() = prefs.getLong("connection-issue-video-starved", 0L)
         set(value) = prefs.edit().putLong("connection-issue-video-starved", value).apply()
 
+    /** Every 5 GHz channel the pinned one was walked across was refused a group owner. */
+    var connectionIssueFiveGhzChannelRefusedAtEpochMs: Long
+        get() = prefs.getLong("connection-issue-5ghz-channel-refused", 0L)
+        set(value) = prefs.edit().putLong("connection-issue-5ghz-channel-refused", value).apply()
+
     /**
      * When the user last dismissed the failure banner.
      *

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -513,25 +513,7 @@ class Settings(private val context: Context) {
         set(value) { prefs.edit().putBoolean("keep-dummy-vpn-during-session", value).apply() }
 
     /**
-     * Drops this unit's own WiFi association while the Native AA WiFi Direct group is brought up.
-     *
-     * On a single-radio unit an associated station leaves the group owner no free channel, so
-     * wpa_supplicant forces the group onto the station's channel or refuses to make one at all. That
-     * is the shape of a unit whose group never forms, and of one whose picture stutters because the
-     * group is sharing the home network's channel.
-     *
-     * Off by default, and deliberately not a general remedy: the same association is measured to be
-     * the *better* state once a session is running, on this same class of hardware. It is bounded to
-     * the bring-up and the network is put back on teardown. See
-     * [com.andrerinas.openheadunit.connection.wifi.direct.StationStandDownPolicy], which also holds
-     * the rule for whether the platform will honour it at all.
-     */
-    var standDownStationForWifiDirect: Boolean
-        get() = prefs.getBoolean("stand-down-station-for-wifi-direct", false)
-        set(value) { prefs.edit().putBoolean("stand-down-station-for-wifi-direct", value).apply() }
-
-    /**
-     * The network id disabled by the stand-down above, or -1 for none standing.
+     * The network id disabled by the WiFi Direct station stand-down, or -1 for none standing.
      *
      * Written before the network is disabled rather than after, so a crash in between still leaves a
      * record to restore from. Not a user setting; it exists so a force-stop cannot leave the unit

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -957,6 +957,7 @@
     <string name="narrow_band_profile_cap">خفض الفيديو على راديو 2.4 غيغاهرتز فقط</string>
     <string name="narrow_band_profile_cap_description">عندما لا يدعم WiFi هذه الوحدة نطاق 5 غيغاهرتز، اطلب من الهاتف 720p و30 إطارًا في الثانية كحد أقصى بدلاً من الإعدادات أعلاه. على وصلة كهذه أظهرت القياسات أن البث بالمعدل الكامل لا ينقل أي صورة، بينما يصمد البث الأقل. أوقف هذا الخيار للحصول على ما طلبته بالضبط.</string>
     <string name="connection_issue_banner_video_link_too_slow">تخلّى هاتفك عن الفيديو قبل وصول إطار واحد، عدة مرات متتالية. وصلة WiFi أبطأ من أن تنقل الصورة. انقر لخفض حد الإطارات إلى 30؛ كما يفيد خفض الدقة واستخدام صوت AAC.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">رفض هذا الجهاز وضع شبكة WiFi Direct على أي قناة 5 غيغاهرتز اخترتها، فبدأت على القناة التي اختارها برنامج تشغيل الواي فاي الخاص به. غالباً ما تكون تلك القناة غير مرئية للهواتف في الدول ذات القيود الأشد. اضغط هنا لضبط نطاق WiFi Direct على 2.4 غيغاهرتز، وهو مسموح في كل الدول؛ توقع جودة 720p بدلاً من 1080p عليه.</string>
     <string name="connection_issue_banner_dismiss">تجاهل</string>
     <string name="connection_issue_remedy_hotspot_query">اسم نقطة الاتصال وكلمة المرور</string>
     <string name="preflight_title">قبل الاتصال</string>
@@ -1077,6 +1078,7 @@
     <string name="five_ghz_channel">قناة 5 جيجاهرتز</string>
     <string name="five_ghz_channel_auto">تلقائي</string>
     <string name="five_ghz_channel_option">القناة %1$d (%2$d ميجاهرتز)</string>
+    <string name="five_ghz_channel_hint">القناة طلب وليست ضماناً. كثير من الأجهزة لا تنشئ الشبكة إلا على القناة التي يختارها برنامج تشغيل الواي فاي الخاص بها، ولا يمكن للتطبيق إخبارك بذلك إلا بعد المحاولة. إذا لم تنجح أي قناة 5 غيغاهرتز وظل هاتفك لا يرى الشبكة، فإن النطاق أعلاه هو الإعداد الذي سينجح.</string>
     <string name="wifi_direct_stable_identity">الاحتفاظ بنفس شبكة Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">يطلب المجموعة بنفس الاسم وكلمة المرور في كل مرة، حتى يعاود هاتفك الاتصال بشبكة معروفة بدلاً من إعداد واحدة جديدة في كل رحلة.</string>
     <string name="wifi_direct_new_identity">هوية جديدة لشبكة Wi-Fi Direct</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1077,9 +1077,6 @@
     <string name="five_ghz_channel">قناة 5 جيجاهرتز</string>
     <string name="five_ghz_channel_auto">تلقائي</string>
     <string name="five_ghz_channel_option">القناة %1$d (%2$d ميجاهرتز)</string>
-    <string name="stand_down_station">قطع اتصال Wi-Fi للوحدة أثناء الاتصال</string>
-    <string name="stand_down_station_description">يفصل هذه الوحدة عن شبكة Wi-Fi الخاصة بها قبل إنشاء مجموعة Wi-Fi Direct مباشرة، ويعيد الاتصال بها عند انتهاء الجلسة.</string>
-    <string name="stand_down_station_needs_overlay">يتطلب إذن «الظهور فوق التطبيقات الأخرى» في هذا الإصدار من أندرويد.</string>
     <string name="wifi_direct_stable_identity">الاحتفاظ بنفس شبكة Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">يطلب المجموعة بنفس الاسم وكلمة المرور في كل مرة، حتى يعاود هاتفك الاتصال بشبكة معروفة بدلاً من إعداد واحدة جديدة في كل رحلة.</string>
     <string name="wifi_direct_new_identity">هوية جديدة لشبكة Wi-Fi Direct</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -959,6 +959,7 @@
     <string name="narrow_band_profile_cap">Snížit video na rádiu jen s 2,4 GHz</string>
     <string name="narrow_band_profile_cap_description">Když Wi-Fi této jednotky nemá pásmo 5 GHz, žádat telefon nejvýše o 720p a 30 fps místo nastavení výše. Na takovém spoji bylo naměřeno, že plný datový tok nepřenesl vůbec žádný obraz, zatímco nižší vydržel. Vypněte to, pokud chcete dostat přesně to, co jste nastavili.</string>
     <string name="connection_issue_banner_video_link_too_slow">Telefon několikrát po sobě vzdal video dřív, než dorazil jediný snímek. Spoj Wi-Fi je pro přenos obrazu příliš pomalý. Klepnutím snížíte limit FPS na 30; pomůže i nižší rozlišení a zvuk AAC.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">Tato jednotka odmítla umístit síť WiFi Direct na jakýkoli kanál 5 GHz, který jsi zvolil, a spustila ji na kanálu vybraném jejím vlastním ovladačem Wi-Fi. Tento kanál telefony v zemích s přísnějšími pravidly často vůbec nevidí. Klepnutím nastavíš pásmo WiFi Direct na 2,4 GHz, které je povoleno všude; počítej na něm s 720p místo 1080p.</string>
     <string name="connection_issue_banner_dismiss">Zavřít</string>
     <string name="connection_issue_remedy_hotspot_query">Název a heslo hotspotu</string>
     <string name="preflight_title">Před připojením</string>
@@ -1079,6 +1080,7 @@
     <string name="five_ghz_channel">Kanál 5 GHz</string>
     <string name="five_ghz_channel_auto">Automaticky</string>
     <string name="five_ghz_channel_option">Kanál %1$d (%2$d MHz)</string>
+    <string name="five_ghz_channel_hint">Kanál je požadavek, nikoli záruka. Mnoho jednotek vytvoří síť jen na kanálu, který si zvolí jejich vlastní ovladač Wi-Fi, a aplikace ti to může říct až po pokusu. Pokud nefunguje žádný kanál v pásmu 5 GHz a telefon síť stále nevidí, pomůže nastavení pásma výše.</string>
     <string name="wifi_direct_stable_identity">Ponechat stejnou síť Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Vytváří skupinu pokaždé se stejným názvem a heslem, aby se telefon připojil ke známé síti bez nového nastavování při každé jízdě.</string>
     <string name="wifi_direct_new_identity">Nová identita sítě Wi-Fi Direct</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1079,9 +1079,6 @@
     <string name="five_ghz_channel">Kanál 5 GHz</string>
     <string name="five_ghz_channel_auto">Automaticky</string>
     <string name="five_ghz_channel_option">Kanál %1$d (%2$d MHz)</string>
-    <string name="stand_down_station">Odpojit vlastní Wi-Fi během připojování</string>
-    <string name="stand_down_station_description">Odpojí tuto jednotku od vlastní sítě Wi-Fi těsně před vytvořením skupiny Wi-Fi Direct a po skončení relace ji znovu připojí.</string>
-    <string name="stand_down_station_needs_overlay">Vyžaduje oprávnění «zobrazit přes ostatní aplikace» na této verzi Androidu.</string>
     <string name="wifi_direct_stable_identity">Ponechat stejnou síť Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Vytváří skupinu pokaždé se stejným názvem a heslem, aby se telefon připojil ke známé síti bez nového nastavování při každé jízdě.</string>
     <string name="wifi_direct_new_identity">Nová identita sítě Wi-Fi Direct</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -965,6 +965,7 @@
     <string name="narrow_band_profile_cap">Video bei reinem 2,4-GHz-Funk verringern</string>
     <string name="narrow_band_profile_cap_description">Wenn das WLAN dieses Geräts kein 5-GHz-Band hat, statt der Einstellungen oben höchstens 720p und 30 fps vom Telefon anfordern. Auf einer solchen Verbindung wurde gemessen, dass ein Stream mit voller Rate gar kein Bild überträgt, ein niedrigerer dagegen schon. Schalte dies aus, um genau das zu bekommen, was du eingestellt hast.</string>
     <string name="connection_issue_banner_video_link_too_slow">Dein Telefon hat das Video mehrmals hintereinander abgebrochen, bevor auch nur ein Bild ankam. Die WLAN-Verbindung ist zu langsam für das Bild. Tippe hier, um die FPS-Grenze auf 30 zu senken; eine niedrigere Auflösung und AAC-Audio helfen ebenfalls.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">Dieses Gerät hat sich geweigert, sein WiFi-Direct-Netzwerk auf einen von dir gewählten 5-GHz-Kanal zu legen, und hat es auf dem Kanal seines eigenen WLAN-Treibers gestartet. Diesen Kanal können Telefone in Ländern mit strengeren Regeln oft gar nicht sehen. Tippe hier, um das WiFi-Direct-Band auf 2,4 GHz zu setzen, das überall erlaubt ist; erwarte dort 720p statt 1080p.</string>
     <string name="connection_issue_banner_dismiss">Schließen</string>
     <string name="connection_issue_remedy_hotspot_query">Hotspot-Name und Passwort</string>
     <string name="preflight_title">Vor dem Verbinden</string>
@@ -1080,6 +1081,7 @@
     <string name="five_ghz_channel">5-GHz-Kanal</string>
     <string name="five_ghz_channel_auto">Automatisch</string>
     <string name="five_ghz_channel_option">Kanal %1$d (%2$d MHz)</string>
+    <string name="five_ghz_channel_hint">Ein Kanal ist eine Anfrage, keine Garantie. Viele Geräte erstellen das Netzwerk nur auf dem Kanal, den ihr eigener WLAN-Treiber wählt, und die App kann dir das erst nach dem Versuch sagen. Wenn kein 5-GHz-Kanal funktioniert und dein Telefon das Netzwerk weiterhin nicht sieht, ist das Band oben die Einstellung, die hilft.</string>
     <string name="wifi_direct_stable_identity">Dasselbe Wi-Fi Direct-Netzwerk beibehalten</string>
     <string name="wifi_direct_stable_identity_description">Erstellt die Gruppe jedes Mal mit demselben Namen und Passwort, sodass sich dein Smartphone wieder mit einem bekannten Netzwerk verbindet, anstatt bei jeder Fahrt neu eingerichtet zu werden. Deaktiviere dies, um bei jeder Verbindung ein neues Netzwerk zu erstellen (wie in Version 3.2 und 3.3), falls ein Smartphone das gespeicherte Netzwerk verweigert. Eine neue Identität unten auszuwählen ist die einfachere Lösung.</string>
     <string name="wifi_direct_new_identity">Neue Wi-Fi Direct-Netzwerkidentität</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1080,9 +1080,6 @@
     <string name="five_ghz_channel">5-GHz-Kanal</string>
     <string name="five_ghz_channel_auto">Automatisch</string>
     <string name="five_ghz_channel_option">Kanal %1$d (%2$d MHz)</string>
-    <string name="stand_down_station">WLAN-Verbindung dieses Geräts beim Verbinden trennen</string>
-    <string name="stand_down_station_description">Trennt dieses Headunit kurz vor dem Erstellen der Wi-Fi Direct-Gruppe vom eigenen WLAN-Netzwerk und verbindet es wieder, wenn die Sitzung endet. Bei Geräten mit nur einem WLAN-Chip bleibt für die Gruppe kein freier Kanal, sodass sie auf den Kanal dieses Netzwerks gezwungen oder ganz verweigert wird. Probiere dies aus, falls dein Smartphone nie beitritt. Die meisten bisher gemessenen Geräte laufen jedoch besser, wenn das Netzwerk verbunden bleibt. Schalte es also wieder aus, falls sich das Bild verschlechtert.</string>
-    <string name="stand_down_station_needs_overlay">Erfordert auf dieser Android-Version die Berechtigung „Über anderen Apps anzeigen“.</string>
     <string name="wifi_direct_stable_identity">Dasselbe Wi-Fi Direct-Netzwerk beibehalten</string>
     <string name="wifi_direct_stable_identity_description">Erstellt die Gruppe jedes Mal mit demselben Namen und Passwort, sodass sich dein Smartphone wieder mit einem bekannten Netzwerk verbindet, anstatt bei jeder Fahrt neu eingerichtet zu werden. Deaktiviere dies, um bei jeder Verbindung ein neues Netzwerk zu erstellen (wie in Version 3.2 und 3.3), falls ein Smartphone das gespeicherte Netzwerk verweigert. Eine neue Identität unten auszuwählen ist die einfachere Lösung.</string>
     <string name="wifi_direct_new_identity">Neue Wi-Fi Direct-Netzwerkidentität</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -1088,9 +1088,6 @@
     <string name="five_ghz_channel">Canal de 5 GHz</string>
     <string name="five_ghz_channel_auto">Automático</string>
     <string name="five_ghz_channel_option">Canal %1$d (%2$d MHz)</string>
-    <string name="stand_down_station">Desconectar del Wi-Fi propio al conectar</string>
-    <string name="stand_down_station_description">Desconecta esta unidad principal de su propia red Wi-Fi justo antes de crear el grupo Wi-Fi Direct y la vuelve a conectar al finalizar la sesión. En dispositivos de un solo chip Wi-Fi, una red conectada no deja canal libre para el grupo.</string>
-    <string name="stand_down_station_needs_overlay">Requiere el permiso «mostrar sobre otras aplicaciones» en esta versión de Android.</string>
     <string name="wifi_direct_stable_identity">Mantener la misma red Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Solicita el grupo con el mismo nombre y contraseña cada vez, para que el teléfono vuelva a conectarse a una red conocida en lugar de configurarse de nuevo en cada viaje. Desactívalo para obtener una red nueva en cada conexión si el teléfono rechaza la guardada. Probar una nueva identidad abajo es la solución más sencilla.</string>
     <string name="wifi_direct_new_identity">Nueva identidad de red Wi-Fi Direct</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -968,6 +968,7 @@
     <string name="narrow_band_profile_cap">Bajar el vídeo con radio solo de 2,4 GHz</string>
     <string name="narrow_band_profile_cap_description">Cuando el WiFi de esta unidad no tiene banda de 5 GHz, pedir al teléfono como máximo 720p y 30 fps en lugar de los ajustes de arriba. En un enlace así se midió que un flujo a plena velocidad no llevaba imagen alguna, mientras que uno más bajo sí aguantaba. Desactiva esto para recibir exactamente lo que pediste.</string>
     <string name="connection_issue_banner_video_link_too_slow">Tu teléfono abandonó el vídeo antes de que llegara un solo fotograma, varias veces seguidas. El enlace WiFi es demasiado lento para llevar la imagen. Toca para bajar el límite de FPS a 30; una resolución menor y el audio AAC también ayudan.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">Esta unidad se negó a poner su red WiFi Direct en cualquier canal de 5 GHz que elegiste, así que la creó en el que eligió su propio controlador WiFi. Ese canal a menudo es uno que los teléfonos de países más restrictivos ni siquiera pueden ver. Toca para poner la banda de WiFi Direct en 2,4 GHz, permitida en todos los países; espera 720p en lugar de 1080p.</string>
     <string name="connection_issue_banner_dismiss">Descartar</string>
     <string name="connection_issue_remedy_hotspot_query">Nombre y contraseña del punto de acceso</string>
     <string name="preflight_title">Antes de conectar</string>
@@ -1088,6 +1089,7 @@
     <string name="five_ghz_channel">Canal de 5 GHz</string>
     <string name="five_ghz_channel_auto">Automático</string>
     <string name="five_ghz_channel_option">Canal %1$d (%2$d MHz)</string>
+    <string name="five_ghz_channel_hint">Un canal es una petición, no una garantía. Muchas unidades solo crean la red en el canal que elige su propio controlador WiFi, y la aplicación solo puede decírtelo después de intentarlo. Si ningún canal de 5 GHz funciona y tu teléfono sigue sin ver la red, la banda de arriba es el ajuste que sí lo hará.</string>
     <string name="wifi_direct_stable_identity">Mantener la misma red Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Solicita el grupo con el mismo nombre y contraseña cada vez, para que el teléfono vuelva a conectarse a una red conocida en lugar de configurarse de nuevo en cada viaje. Desactívalo para obtener una red nueva en cada conexión si el teléfono rechaza la guardada. Probar una nueva identidad abajo es la solución más sencilla.</string>
     <string name="wifi_direct_new_identity">Nueva identidad de red Wi-Fi Direct</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -967,6 +967,7 @@
     <string name="narrow_band_profile_cap">Bajar el vídeo con radio solo de 2,4 GHz</string>
     <string name="narrow_band_profile_cap_description">Cuando el WiFi de esta unidad no tiene banda de 5 GHz, pedir al teléfono como máximo 720p y 30 fps en lugar de los ajustes de arriba. En un enlace así se midió que un flujo a plena velocidad no llevaba imagen alguna, mientras que uno más bajo sí aguantaba. Desactive esto para recibir exactamente lo que pidió.</string>
     <string name="connection_issue_banner_video_link_too_slow">Su teléfono abandonó el vídeo antes de que llegara un solo fotograma, varias veces seguidas. El enlace WiFi es demasiado lento para llevar la imagen. Toque para bajar el límite de FPS a 30; una resolución menor y el audio AAC también ayudan.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">Esta unidad se negó a poner su red WiFi Direct en cualquier canal de 5 GHz que elegiste, así que la creó en el que eligió su propio controlador WiFi. Ese canal a menudo es uno que los teléfonos de países más restrictivos ni siquiera pueden ver. Toca para poner la banda de WiFi Direct en 2,4 GHz, permitida en todos los países; espera 720p en lugar de 1080p.</string>
     <string name="connection_issue_banner_dismiss">Descartar</string>
     <string name="connection_issue_remedy_hotspot_query">Nombre y contraseña del punto de acceso</string>
     <string name="preflight_title">Antes de conectar</string>
@@ -1087,6 +1088,7 @@
     <string name="five_ghz_channel">Canal de 5 GHz</string>
     <string name="five_ghz_channel_auto">Automático</string>
     <string name="five_ghz_channel_option">Canal %1$d (%2$d MHz)</string>
+    <string name="five_ghz_channel_hint">Un canal es una petición, no una garantía. Muchas unidades solo crean la red en el canal que elige su propio controlador WiFi, y la aplicación solo puede decírtelo después de intentarlo. Si ningún canal de 5 GHz funciona y tu teléfono sigue sin ver la red, la banda de arriba es el ajuste que sí lo hará.</string>
     <string name="wifi_direct_stable_identity">Mantener la misma red Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Solicita el grupo con el mismo nombre y contraseña cada vez, para que el teléfono vuelva a conectarse a una red conocida en lugar de configurarse de nuevo en cada viaje. Desactívalo para obtener una red nueva en cada conexión si el teléfono rechaza la guardada. Probar una nueva identidad abajo es la solución más sencilla.</string>
     <string name="wifi_direct_new_identity">Nueva identidad de red Wi-Fi Direct</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1087,9 +1087,6 @@
     <string name="five_ghz_channel">Canal de 5 GHz</string>
     <string name="five_ghz_channel_auto">Automático</string>
     <string name="five_ghz_channel_option">Canal %1$d (%2$d MHz)</string>
-    <string name="stand_down_station">Desconectar del Wi-Fi propio al conectar</string>
-    <string name="stand_down_station_description">Desconecta esta unidad principal de su propia red Wi-Fi justo antes de crear el grupo Wi-Fi Direct y la vuelve a conectar al finalizar la sesión. En dispositivos de un solo chip Wi-Fi, una red conectada no deja canal libre para el grupo.</string>
-    <string name="stand_down_station_needs_overlay">Requiere el permiso «mostrar sobre otras aplicaciones» en esta versión de Android.</string>
     <string name="wifi_direct_stable_identity">Mantener la misma red Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Solicita el grupo con el mismo nombre y contraseña cada vez, para que el teléfono vuelva a conectarse a una red conocida en lugar de configurarse de nuevo en cada viaje. Desactívalo para obtener una red nueva en cada conexión si el teléfono rechaza la guardada. Probar una nueva identidad abajo es la solución más sencilla.</string>
     <string name="wifi_direct_new_identity">Nueva identidad de red Wi-Fi Direct</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1006,6 +1006,7 @@
     <string name="narrow_band_profile_cap">Réduire la vidéo sur une radio 2,4 GHz uniquement</string>
     <string name="narrow_band_profile_cap_description">Quand le WiFi de cet appareil n\'a pas de bande 5 GHz, demander au téléphone au maximum 720p et 30 fps au lieu des réglages ci-dessus. Sur une telle liaison, un flux à pleine cadence ne transportait aucune image lors des mesures, alors qu\'un flux réduit tenait. Désactivez ceci pour obtenir exactement ce que vous avez demandé.</string>
     <string name="connection_issue_banner_video_link_too_slow">Votre téléphone a abandonné la vidéo avant la moindre image, plusieurs fois de suite. La liaison WiFi est trop lente pour transporter l\'image. Touchez pour abaisser la limite de FPS à 30 ; une résolution plus basse et l\'audio AAC aident aussi.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">Cette unité a refusé de placer son réseau WiFi Direct sur l\'un des canaux 5 GHz que tu as choisis, elle l\'a donc créé sur celui choisi par son propre pilote WiFi. Ce canal est souvent invisible pour les téléphones des pays les plus stricts. Appuie ici pour régler la bande WiFi Direct sur 2,4 GHz, autorisée partout ; attends-toi à du 720p plutôt que du 1080p.</string>
     <string name="connection_issue_banner_dismiss">Ignorer</string>
     <string name="connection_issue_remedy_hotspot_query">Nom et mot de passe du point d\'accès</string>
     <string name="preflight_title">Avant de vous connecter</string>
@@ -1122,6 +1123,7 @@
     <string name="five_ghz_channel">Canal 5 GHz</string>
     <string name="five_ghz_channel_auto">Automatique</string>
     <string name="five_ghz_channel_option">Canal %1$d (%2$d MHz)</string>
+    <string name="five_ghz_channel_hint">Un canal est une demande, pas une garantie. Beaucoup d\'unités ne créent le réseau que sur le canal choisi par leur propre pilote WiFi, et l\'application ne peut te le dire qu\'après avoir essayé. Si aucun canal 5 GHz ne fonctionne et que ton téléphone ne voit toujours pas le réseau, c\'est la bande ci-dessus qui réglera le problème.</string>
     <string name="wifi_direct_stable_identity">Conserver le même réseau Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Demande le groupe avec le même nom et mot de passe à chaque fois, afin que votre téléphone rejoigne un réseau connu au lieu d\'en configurer un nouveau à chaque trajet. Désactivez cette option pour obtenir un nouveau réseau à chaque connexion (comme dans les versions 3.2 et 3.3) si le téléphone refuse le réseau enregistré. Essayer une nouvelle identité ci-dessous est la solution la plus simple.</string>
     <string name="wifi_direct_new_identity">Nouvelle identité réseau Wi-Fi Direct</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1122,9 +1122,6 @@
     <string name="five_ghz_channel">Canal 5 GHz</string>
     <string name="five_ghz_channel_auto">Automatique</string>
     <string name="five_ghz_channel_option">Canal %1$d (%2$d MHz)</string>
-    <string name="stand_down_station">Quitter le réseau Wi-Fi de l\'appareil lors de la connexion</string>
-    <string name="stand_down_station_description">Déconnecte cet autoradio de son propre réseau Wi-Fi juste avant la création du groupe Wi-Fi Direct, et le reconnecte à la fin de la session. Sur un appareil à puce unique, un réseau connecté ne laisse aucun canal libre au groupe, qui est forcé sur ce canal ou refusé. Essayez ceci si votre téléphone ne se connecte jamais.</string>
-    <string name="stand_down_station_needs_overlay">Nécessite l\'autorisation « afficher sur d\'autres applications » sur cette version d\'Android.</string>
     <string name="wifi_direct_stable_identity">Conserver le même réseau Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Demande le groupe avec le même nom et mot de passe à chaque fois, afin que votre téléphone rejoigne un réseau connu au lieu d\'en configurer un nouveau à chaque trajet. Désactivez cette option pour obtenir un nouveau réseau à chaque connexion (comme dans les versions 3.2 et 3.3) si le téléphone refuse le réseau enregistré. Essayer une nouvelle identité ci-dessous est la solution la plus simple.</string>
     <string name="wifi_direct_new_identity">Nouvelle identité réseau Wi-Fi Direct</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1075,9 +1075,6 @@
     <string name="five_ghz_channel">5 GHz-es csatorna</string>
     <string name="five_ghz_channel_auto">Automatikus</string>
     <string name="five_ghz_channel_option">%1$d. csatorna (%2$d MHz)</string>
-    <string name="stand_down_station">Saját Wi-Fi lekapcsolása csatlakozáskor</string>
-    <string name="stand_down_station_description">Lecsatlakoztatja a fejegységet a saját Wi-Fi hálózatáról a Wi-Fi Direct csoport létrehozása előtt, majd a munkamenet végén visszacsatlakoztatja.</string>
-    <string name="stand_down_station_needs_overlay">Ehhez az Android-verzióhoz a «megjelenítés más alkalmazások felett» engedély szükséges.</string>
     <string name="wifi_direct_stable_identity">Ugyanazon Wi-Fi Direct hálózat megtartása</string>
     <string name="wifi_direct_stable_identity_description">Minden alkalommal azonos névvel és jelszóval hozza létre a csoportot, így a telefon egy már ismert hálózathoz csatlakozik újra.</string>
     <string name="wifi_direct_new_identity">Új Wi-Fi Direct hálózati identitás</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -955,6 +955,7 @@
     <string name="narrow_band_profile_cap">Gyengébb kép csak 2,4 GHz-es rádiónál</string>
     <string name="narrow_band_profile_cap_description">Ha az egység Wi-Fi-je nem tud 5 GHz-et, a fenti beállítások helyett legfeljebb 720p és 30 fps kérése a telefontól. Ilyen kapcsolaton a mérések szerint a teljes sebességű adatfolyam egyáltalán nem vitt képet, az alacsonyabb viszont igen. Kapcsolja ki, ha pontosan a beállított értékeket szeretné.</string>
     <string name="connection_issue_banner_video_link_too_slow">A telefon egymás után többször feladta a videót, mielőtt egyetlen képkocka megérkezett volna. A Wi-Fi kapcsolat túl lassú a képhez. Érintse meg az FPS-korlát 30-ra csökkentéséhez; az alacsonyabb felbontás és az AAC hang is segít.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">Ez az egység nem volt hajlandó a WiFi Direct hálózatát egyetlen általad választott 5 GHz-es csatornára sem tenni, ezért azon indult el, amelyet a saját WiFi-illesztőprogramja választott. Ezt a csatornát a szigorúbb országokban lévő telefonok gyakran nem is látják. Koppints ide, hogy a WiFi Direct sávját 2,4 GHz-re állítsd, amelyet minden ország engedélyez; ezen 1080p helyett 720p várható.</string>
     <string name="connection_issue_banner_dismiss">Elvetés</string>
     <string name="connection_issue_remedy_hotspot_query">Hotspot neve és jelszava</string>
     <string name="preflight_title">Csatlakozás előtt</string>
@@ -1075,6 +1076,7 @@
     <string name="five_ghz_channel">5 GHz-es csatorna</string>
     <string name="five_ghz_channel_auto">Automatikus</string>
     <string name="five_ghz_channel_option">%1$d. csatorna (%2$d MHz)</string>
+    <string name="five_ghz_channel_hint">A csatorna kérés, nem garancia. Sok egység csak azon a csatornán hozza létre a hálózatot, amelyet a saját WiFi-illesztőprogramja választ, és az alkalmazás ezt csak a próbálkozás után tudja megmondani. Ha egyetlen 5 GHz-es csatorna sem működik, és a telefonod továbbra sem látja a hálózatot, a fenti sáv az a beállítás, amely segíteni fog.</string>
     <string name="wifi_direct_stable_identity">Ugyanazon Wi-Fi Direct hálózat megtartása</string>
     <string name="wifi_direct_stable_identity_description">Minden alkalommal azonos névvel és jelszóval hozza létre a csoportot, így a telefon egy már ismert hálózathoz csatlakozik újra.</string>
     <string name="wifi_direct_new_identity">Új Wi-Fi Direct hálózati identitás</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1082,9 +1082,6 @@
     <string name="five_ghz_channel">Canale a 5 GHz</string>
     <string name="five_ghz_channel_auto">Automatico</string>
     <string name="five_ghz_channel_option">Canale %1$d (%2$d MHz)</string>
-    <string name="stand_down_station">Disconnetti il Wi-Fi dell\'unità durante la connessione</string>
-    <string name="stand_down_station_description">Disconnette questa unità dalla propria rete Wi-Fi prima di creare il gruppo Wi-Fi Direct e la riconnette al termine della sessione. Utile su dispositivi con un solo chip Wi-Fi se il telefono non si connette.</string>
-    <string name="stand_down_station_needs_overlay">Richiede l\'autorizzazione «visualizzazione sopra altre app» su questa versione di Android.</string>
     <string name="wifi_direct_stable_identity">Mantieni la stessa rete Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Richiede il gruppo con lo stesso nome e password ogni volta, in modo che il telefono si riconnetta a una rete nota anziché configurarsi a ogni viaggio. Disattivalo per ottenere una nuova rete a ogni connessione se il telefono rifiuta quella salvata.</string>
     <string name="wifi_direct_new_identity">Nuova identità di rete Wi-Fi Direct</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -962,6 +962,7 @@
     <string name="narrow_band_profile_cap">Ridurre il video con radio solo a 2,4 GHz</string>
     <string name="narrow_band_profile_cap_description">Quando il WiFi di questa unità non ha la banda 5 GHz, chiedi al telefono al massimo 720p e 30 fps invece delle impostazioni qui sopra. Su un collegamento simile è stato misurato che un flusso a piena velocità non portava alcuna immagine, mentre uno più basso reggeva. Disattiva questa opzione per ottenere esattamente ciò che hai impostato.</string>
     <string name="connection_issue_banner_video_link_too_slow">Il telefono ha abbandonato il video prima che arrivasse un solo fotogramma, più volte di seguito. Il collegamento WiFi è troppo lento per trasportare l\'immagine. Tocca per abbassare il limite di FPS a 30; aiutano anche una risoluzione più bassa e l\'audio AAC.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">Questa unità ha rifiutato di mettere la sua rete WiFi Direct su qualsiasi canale a 5 GHz tu abbia scelto, quindi è partita su quello scelto dal suo driver WiFi. Spesso è un canale che i telefoni nei paesi più restrittivi non riescono nemmeno a vedere. Tocca per impostare la banda WiFi Direct su 2,4 GHz, consentita ovunque; aspettati 720p invece di 1080p.</string>
     <string name="connection_issue_banner_dismiss">Ignora</string>
     <string name="connection_issue_remedy_hotspot_query">Nome e password dell\'hotspot</string>
     <string name="preflight_title">Prima di connetterti</string>
@@ -1082,6 +1083,7 @@
     <string name="five_ghz_channel">Canale a 5 GHz</string>
     <string name="five_ghz_channel_auto">Automatico</string>
     <string name="five_ghz_channel_option">Canale %1$d (%2$d MHz)</string>
+    <string name="five_ghz_channel_hint">Un canale è una richiesta, non una garanzia. Molte unità creano la rete solo sul canale scelto dal proprio driver WiFi, e l\'app può dirtelo solo dopo aver provato. Se nessun canale a 5 GHz funziona e il telefono continua a non vedere la rete, la banda qui sopra è l\'impostazione che risolverà.</string>
     <string name="wifi_direct_stable_identity">Mantieni la stessa rete Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Richiede il gruppo con lo stesso nome e password ogni volta, in modo che il telefono si riconnetta a una rete nota anziché configurarsi a ogni viaggio. Disattivalo per ottenere una nuova rete a ogni connessione se il telefono rifiuta quella salvata.</string>
     <string name="wifi_direct_new_identity">Nuova identità di rete Wi-Fi Direct</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1083,9 +1083,6 @@
     <string name="five_ghz_channel">5GHzチャンネル</string>
     <string name="five_ghz_channel_auto">自動</string>
     <string name="five_ghz_channel_option">チャンネル %1$d (%2$d MHz)</string>
-    <string name="stand_down_station">接続中にユニット自身のWi-Fiを切断</string>
-    <string name="stand_down_station_description">Wi-Fi Directグループの作成直前にこのユニット自身のWi-Fiを切断し、セッション終了時に再接続します。</string>
-    <string name="stand_down_station_needs_overlay">このAndroidバージョンでは「他のアプリの上に重ねて表示」の権限が必要です。</string>
     <string name="wifi_direct_stable_identity">同じWi-Fi Directネットワークを維持</string>
     <string name="wifi_direct_stable_identity_description">毎回同じ名前とパスワードでグループを作成し、ドライブごとに再設定することなく既知のネットワークに再接続します。</string>
     <string name="wifi_direct_new_identity">新しいWi-Fi DirectネットワークID</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -963,6 +963,7 @@
     <string name="narrow_band_profile_cap">2.4 GHzのみの無線では映像を下げる</string>
     <string name="narrow_band_profile_cap_description">このユニットのWiFiに5 GHz帯がない場合、上の設定ではなく最大720p、30 fpsをスマートフォンに要求します。この種の回線では、フルレートの映像がまったく届かない一方、低いレートでは維持されることが確認されています。設定どおりの値を使いたい場合はオフにしてください。</string>
     <string name="connection_issue_banner_video_link_too_slow">スマートフォンが1フレームも届かないうちに映像を断念する状態が数回続きました。WiFi回線が映像を運ぶには遅すぎます。タップするとFPS上限を30に下げます。解像度を下げることやAAC音声も有効です。</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">この機器は選択したどの5 GHzチャンネルでもWiFi Directネットワークを作成せず、自身のWi-Fiドライバーが選んだチャンネルで開始しました。そのチャンネルは、規制の厳しい国のスマートフォンからは見えないことがよくあります。タップしてWiFi Directの帯域を2.4 GHzに設定してください。すべての国で許可されていますが、1080pではなく720pになります。</string>
     <string name="connection_issue_banner_dismiss">閉じる</string>
     <string name="connection_issue_remedy_hotspot_query">ホットスポット名とパスワード</string>
     <string name="preflight_title">接続前の確認</string>
@@ -1083,6 +1084,7 @@
     <string name="five_ghz_channel">5GHzチャンネル</string>
     <string name="five_ghz_channel_auto">自動</string>
     <string name="five_ghz_channel_option">チャンネル %1$d (%2$d MHz)</string>
+    <string name="five_ghz_channel_hint">チャンネルはあくまで要求であり、保証ではありません。多くの機器は自身のWi-Fiドライバーが選んだチャンネルでしかネットワークを作成せず、アプリは試した後にしかそれを伝えられません。どの5 GHzチャンネルでもうまくいかず、スマートフォンがネットワークを見つけられない場合は、上の帯域の設定が解決します。</string>
     <string name="wifi_direct_stable_identity">同じWi-Fi Directネットワークを維持</string>
     <string name="wifi_direct_stable_identity_description">毎回同じ名前とパスワードでグループを作成し、ドライブごとに再設定することなく既知のネットワークに再接続します。</string>
     <string name="wifi_direct_new_identity">新しいWi-Fi DirectネットワークID</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -940,6 +940,7 @@
     <string name="narrow_band_profile_cap">ვიდეოს დაწევა მხოლოდ 2.4 გჰც რადიოზე</string>
     <string name="narrow_band_profile_cap_description">როცა ამ მოწყობილობის WiFi-ს არ აქვს 5 გჰც დიაპაზონი, ზემოთ მითითებული პარამეტრების ნაცვლად ტელეფონს მოთხოვეთ მაქსიმუმ 720p და წამში 30 კადრი. ასეთ კავშირზე გაზომვამ აჩვენა, რომ სრული სიჩქარის ნაკადი საერთოდ არ გადმოსცემდა სურათს, დაბალი კი ინარჩუნებდა. გამორთეთ, რომ ზუსტად ის მიიღოთ, რაც მიუთითეთ.</string>
     <string name="connection_issue_banner_video_link_too_slow">თქვენმა ტელეფონმა ზედიზედ რამდენჯერმე შეწყვიტა ვიდეო ერთი კადრის მოსვლამდეც კი. WiFi კავშირი ძალიან ნელია სურათის გადასაცემად. შეეხეთ FPS-ის ზღვრის 30-მდე დასაწევად; ასევე დაეხმარება დაბალი გარჩევადობა და AAC აუდიო.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">ამ მოწყობილობამ უარი თქვა WiFi Direct ქსელის თქვენ მიერ არჩეულ რომელიმე 5 გჰც არხზე განთავსებაზე და ის საკუთარი Wi-Fi დრაივერის არჩეულ არხზე აამუშავა. ეს არხი ხშირად ისეთია, რომელსაც მკაცრი რეგულაციის ქვეყნებში ტელეფონები ვერც კი ხედავენ. შეეხეთ WiFi Direct დიაპაზონის 2.4 გჰც-ზე დასაყენებლად, რომელიც ყველა ქვეყანაშია ნებადართული; მოელოდეთ 720p-ს 1080p-ის ნაცვლად.</string>
     <string name="connection_issue_banner_dismiss">დახურვა</string>
     <string name="connection_issue_remedy_hotspot_query">Hotspot-ის სახელი და პაროლი</string>
     <string name="preflight_title">დაკავშირებამდე</string>
@@ -1060,6 +1061,7 @@
     <string name="five_ghz_channel">5 გჰც არხი</string>
     <string name="five_ghz_channel_auto">ავტომატური</string>
     <string name="five_ghz_channel_option">არხი %1$d (%2$d მგჰც)</string>
+    <string name="five_ghz_channel_hint">არხი მოთხოვნაა და არა გარანტია. ბევრი მოწყობილობა ქსელს მხოლოდ იმ არხზე ქმნის, რომელსაც მისი საკუთარი Wi-Fi დრაივერი ირჩევს, და აპლიკაციას ამის თქმა მხოლოდ ცდის შემდეგ შეუძლია. თუ არცერთი 5 გჰც არხი არ მუშაობს და თქვენი ტელეფონი ქსელს კვლავ ვერ ხედავს, ზემოთ მოცემული დიაპაზონია ის პარამეტრი, რომელიც უშველის.</string>
     <string name="wifi_direct_stable_identity">იგივე Wi-Fi Direct ქსელის შენარჩუნება</string>
     <string name="wifi_direct_stable_identity_description">ყოველ ჯერზე იყენებს ჯგუფის იგივე სახელსა და პაროლს, რათა ტელეფონი ნაცნობ ქსელს დაუკავშირდეს.</string>
     <string name="wifi_direct_new_identity">ახალი Wi-Fi Direct ქსელის იდენტიფიკატორი</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -1060,9 +1060,6 @@
     <string name="five_ghz_channel">5 გჰც არხი</string>
     <string name="five_ghz_channel_auto">ავტომატური</string>
     <string name="five_ghz_channel_option">არხი %1$d (%2$d მგჰც)</string>
-    <string name="stand_down_station">საკუთარი Wi-Fi-ს გათიშვა დაკავშირებისას</string>
-    <string name="stand_down_station_description">თიშავს ამ მოწყობილობას საკუთარი Wi-Fi ქსელიდან Wi-Fi Direct ჯგუფის შექმნამდე და ხელახლა აკავშირებს სესიის დასრულებისას.</string>
-    <string name="stand_down_station_needs_overlay">საჭიროებს ნებართვას «სხვა აპებზე ჩვენება» Android-ის ამ ვერსიაზე.</string>
     <string name="wifi_direct_stable_identity">იგივე Wi-Fi Direct ქსელის შენარჩუნება</string>
     <string name="wifi_direct_stable_identity_description">ყოველ ჯერზე იყენებს ჯგუფის იგივე სახელსა და პაროლს, რათა ტელეფონი ნაცნობ ქსელს დაუკავშირდეს.</string>
     <string name="wifi_direct_new_identity">ახალი Wi-Fi Direct ქსელის იდენტიფიკატორი</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -956,6 +956,7 @@
     <string name="narrow_band_profile_cap">2.4GHz 전용 무선에서 영상 낮추기</string>
     <string name="narrow_band_profile_cap_description">이 기기의 WiFi에 5GHz 대역이 없으면 위 설정 대신 최대 720p, 30fps를 휴대전화에 요청합니다. 이런 연결에서는 최대 속도 스트림이 화면을 전혀 전달하지 못하고 낮춘 스트림은 유지되는 것으로 측정되었습니다. 설정한 값 그대로 받으려면 끄세요.</string>
     <string name="connection_issue_banner_video_link_too_slow">휴대전화가 프레임이 하나도 도착하기 전에 영상을 포기하는 일이 연달아 여러 번 있었습니다. WiFi 연결이 화면을 전달하기에 너무 느립니다. 탭하면 FPS 제한을 30으로 낮춥니다. 해상도를 낮추거나 AAC 오디오를 쓰는 것도 도움이 됩니다.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">이 기기는 선택한 어떤 5GHz 채널에도 WiFi Direct 네트워크를 올리지 않고, 자체 Wi-Fi 드라이버가 고른 채널에서 시작했습니다. 그 채널은 규제가 엄격한 국가의 휴대폰에서는 아예 보이지 않는 경우가 많습니다. 탭하여 WiFi Direct 대역을 모든 국가에서 허용되는 2.4GHz로 설정하세요. 이 대역에서는 1080p가 아닌 720p로 예상됩니다.</string>
     <string name="connection_issue_banner_dismiss">닫기</string>
     <string name="connection_issue_remedy_hotspot_query">핫스팟 이름 및 비밀번호</string>
     <string name="preflight_title">연결 전 확인</string>
@@ -1076,6 +1077,7 @@
     <string name="five_ghz_channel">5GHz 채널</string>
     <string name="five_ghz_channel_auto">자동</string>
     <string name="five_ghz_channel_option">채널 %1$d (%2$d MHz)</string>
+    <string name="five_ghz_channel_hint">채널은 요청일 뿐 보장이 아닙니다. 많은 기기는 자체 Wi-Fi 드라이버가 선택한 채널에서만 네트워크를 만들며, 앱은 시도한 뒤에야 이를 알려줄 수 있습니다. 어떤 5GHz 채널도 작동하지 않고 휴대폰이 여전히 네트워크를 찾지 못한다면, 위의 대역 설정이 해결해 줍니다.</string>
     <string name="wifi_direct_stable_identity">동일한 Wi-Fi Direct 네트워크 유지</string>
     <string name="wifi_direct_stable_identity_description">매번 동일한 이름과 비밀번호로 그룹을 생성하여 주행마다 새로 설정할 필요 없이 기존 네트워크에 다시 연결합니다.</string>
     <string name="wifi_direct_new_identity">새 Wi-Fi Direct 네트워크 식별자</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1076,9 +1076,6 @@
     <string name="five_ghz_channel">5GHz 채널</string>
     <string name="five_ghz_channel_auto">자동</string>
     <string name="five_ghz_channel_option">채널 %1$d (%2$d MHz)</string>
-    <string name="stand_down_station">연결 시 자체 Wi-Fi 연결 해제</string>
-    <string name="stand_down_station_description">Wi-Fi Direct 그룹 생성 직전에 본 기기의 Wi-Fi 네트워크를 해제하고 세션 종료 시 다시 연결합니다.</string>
-    <string name="stand_down_station_needs_overlay">이 Android 버전에서는 «다른 앱 위에 표시» 권한이 필요합니다.</string>
     <string name="wifi_direct_stable_identity">동일한 Wi-Fi Direct 네트워크 유지</string>
     <string name="wifi_direct_stable_identity_description">매번 동일한 이름과 비밀번호로 그룹을 생성하여 주행마다 새로 설정할 필요 없이 기존 네트워크에 다시 연결합니다.</string>
     <string name="wifi_direct_new_identity">새 Wi-Fi Direct 네트워크 식별자</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -959,6 +959,7 @@
     <string name="narrow_band_profile_cap">Lagere video bij een radio met alleen 2,4 GHz</string>
     <string name="narrow_band_profile_cap_description">Als de wifi van dit apparaat geen 5GHz-band heeft, vraag de telefoon dan om maximaal 720p en 30 fps in plaats van de instellingen hierboven. Op zo\'n verbinding bleek uit metingen dat een stream op volle snelheid helemaal geen beeld doorgaf, terwijl een lagere het wel volhield. Zet dit uit om precies te krijgen wat je hebt ingesteld.</string>
     <string name="connection_issue_banner_video_link_too_slow">Je telefoon heeft de video meerdere keren achter elkaar opgegeven voordat er ook maar één beeld binnenkwam. De wifi-verbinding is te traag voor het beeld. Tik om de FPS-limiet naar 30 te verlagen; een lagere resolutie en AAC-audio helpen ook.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">Deze unit weigerde het WiFi Direct-netwerk op een door jou gekozen 5 GHz-kanaal te zetten en startte het op het kanaal dat de eigen wifi-driver koos. Dat kanaal is vaak een kanaal dat telefoons in strengere landen niet eens kunnen zien. Tik hier om de WiFi Direct-band op 2,4 GHz te zetten, wat overal is toegestaan; verwacht daar 720p in plaats van 1080p.</string>
     <string name="connection_issue_banner_dismiss">Sluiten</string>
     <string name="connection_issue_remedy_hotspot_query">Hotspot-naam en wachtwoord</string>
     <string name="preflight_title">Voordat je verbindt</string>
@@ -1079,6 +1080,7 @@
     <string name="five_ghz_channel">5 GHz-kanaal</string>
     <string name="five_ghz_channel_auto">Automatisch</string>
     <string name="five_ghz_channel_option">Kanaal %1$d (%2$d MHz)</string>
+    <string name="five_ghz_channel_hint">Een kanaal is een verzoek, geen garantie. Veel units maken het netwerk alleen aan op het kanaal dat hun eigen wifi-driver kiest, en de app kan je dat pas na een poging vertellen. Werkt geen enkel 5 GHz-kanaal en ziet je telefoon het netwerk nog steeds niet, dan is de band hierboven de instelling die dat wel oplost.</string>
     <string name="wifi_direct_stable_identity">Hetzelfde Wi-Fi Direct-netwerk behouden</string>
     <string name="wifi_direct_stable_identity_description">Vraagt de groep telkens op met dezelfde naam en wachtwoord, zodat je telefoon opnieuw verbindt met een bekend netwerk. Schakel dit uit als je telefoon het opgeslagen netwerk blijft weigeren.</string>
     <string name="wifi_direct_new_identity">Nieuwe Wi-Fi Direct-netwerkidentiteit</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1079,9 +1079,6 @@
     <string name="five_ghz_channel">5 GHz-kanaal</string>
     <string name="five_ghz_channel_auto">Automatisch</string>
     <string name="five_ghz_channel_option">Kanaal %1$d (%2$d MHz)</string>
-    <string name="stand_down_station">Verbinding met eigen Wi-Fi verbreken tijdens verbinden</string>
-    <string name="stand_down_station_description">Verbreekt de verbinding met het eigen Wi-Fi-netwerk net voordat de Wi-Fi Direct-groep wordt aangemaakt en herstelt deze na de sessie. Handig bij apparaten met één Wi-Fi-chip.</string>
-    <string name="stand_down_station_needs_overlay">Vereist de toestemming «weergeven over andere apps» op deze Android-versie.</string>
     <string name="wifi_direct_stable_identity">Hetzelfde Wi-Fi Direct-netwerk behouden</string>
     <string name="wifi_direct_stable_identity_description">Vraagt de groep telkens op met dezelfde naam en wachtwoord, zodat je telefoon opnieuw verbindt met een bekend netwerk. Schakel dit uit als je telefoon het opgeslagen netwerk blijft weigeren.</string>
     <string name="wifi_direct_new_identity">Nieuwe Wi-Fi Direct-netwerkidentiteit</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1078,9 +1078,6 @@
     <string name="five_ghz_channel">Kanał 5 GHz</string>
     <string name="five_ghz_channel_auto">Automatyczny</string>
     <string name="five_ghz_channel_option">Kanał %1$d (%2$d MHz)</string>
-    <string name="stand_down_station">Odłącz od własnego Wi-Fi podczas łączenia</string>
-    <string name="stand_down_station_description">Odłącza tę stację od własnej sieci Wi-Fi tuż przed utworzeniem grupy Wi-Fi Direct i łączy ponownie po zakończeniu sesji. Przydatne w urządzeniach z jednym układem Wi-Fi.</string>
-    <string name="stand_down_station_needs_overlay">Wymaga uprawnienia «wyświetlanie nad innymi aplikacjami» w tej wersji Androida.</string>
     <string name="wifi_direct_stable_identity">Zachowaj tę samą sieć Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Używa tej samej nazwy i hasła grupy za każdym razem, dzięki czemu telefon łączy się ze znaną siecią bez ponownej konfiguracji przy każdej jeździe.</string>
     <string name="wifi_direct_new_identity">Nowa tożsamość sieci Wi-Fi Direct</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -958,6 +958,7 @@
     <string name="narrow_band_profile_cap">Niższy obraz przy radiu tylko 2,4 GHz</string>
     <string name="narrow_band_profile_cap_description">Gdy Wi-Fi tego urządzenia nie ma pasma 5 GHz, żądaj od telefonu najwyżej 720p i 30 kl./s zamiast ustawień powyżej. Na takim łączu zmierzono, że strumień o pełnej przepływności nie przenosił obrazu w ogóle, a niższy działał. Wyłącz to, aby dostać dokładnie to, co ustawiono.</string>
     <string name="connection_issue_banner_video_link_too_slow">Telefon kilka razy z rzędu porzucił obraz, zanim dotarła choć jedna klatka. Łącze Wi-Fi jest za wolne, aby przenieść obraz. Dotknij, aby obniżyć limit FPS do 30; pomoże też niższa rozdzielczość i dźwięk AAC.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">To urządzenie odmówiło umieszczenia sieci WiFi Direct na jakimkolwiek wybranym przez ciebie kanale 5 GHz i uruchomiło ją na kanale wybranym przez własny sterownik Wi-Fi. Tego kanału telefony w krajach o surowszych przepisach często w ogóle nie widzą. Dotknij, aby ustawić pasmo WiFi Direct na 2,4 GHz, dozwolone we wszystkich krajach; spodziewaj się na nim 720p zamiast 1080p.</string>
     <string name="connection_issue_banner_dismiss">Zamknij</string>
     <string name="connection_issue_remedy_hotspot_query">Nazwa i hasło hotspotu</string>
     <string name="preflight_title">Przed połączeniem</string>
@@ -1078,6 +1079,7 @@
     <string name="five_ghz_channel">Kanał 5 GHz</string>
     <string name="five_ghz_channel_auto">Automatyczny</string>
     <string name="five_ghz_channel_option">Kanał %1$d (%2$d MHz)</string>
+    <string name="five_ghz_channel_hint">Kanał to prośba, a nie gwarancja. Wiele urządzeń tworzy sieć tylko na kanale wybranym przez własny sterownik Wi-Fi, a aplikacja może ci to powiedzieć dopiero po próbie. Jeśli żaden kanał 5 GHz nie działa, a telefon nadal nie widzi sieci, to pasmo powyżej jest ustawieniem, które pomoże.</string>
     <string name="wifi_direct_stable_identity">Zachowaj tę samą sieć Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Używa tej samej nazwy i hasła grupy za każdym razem, dzięki czemu telefon łączy się ze znaną siecią bez ponownej konfiguracji przy każdej jeździe.</string>
     <string name="wifi_direct_new_identity">Nowa tożsamość sieci Wi-Fi Direct</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1080,9 +1080,6 @@
     <string name="five_ghz_channel">Canal de 5 GHz</string>
     <string name="five_ghz_channel_auto">Automático</string>
     <string name="five_ghz_channel_option">Canal %1$d (%2$d MHz)</string>
-    <string name="stand_down_station">Desconectar do Wi-Fi próprio ao conectar</string>
-    <string name="stand_down_station_description">Desconecta esta central de sua própria rede Wi-Fi pouco antes de criar o grupo Wi-Fi Direct e reconecta ao finalizar a sessão. Útil em aparelhos com um único chip Wi-Fi se o telefone não se conectar.</string>
-    <string name="stand_down_station_needs_overlay">Requer a permissão «sobrepor a outros apps» nesta versão do Android.</string>
     <string name="wifi_direct_stable_identity">Manter a mesma rede Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Solicita o grupo com o mesmo nome e senha todas as vezes, para que o telefone se reconecte a uma rede conhecida em vez de ser configurado a cada viagem. Desative para gerar uma nova rede a cada conexão se o telefone rejeitar a rede salva.</string>
     <string name="wifi_direct_new_identity">Nova identidade de rede Wi-Fi Direct</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -960,6 +960,7 @@
     <string name="narrow_band_profile_cap">Reduzir o vídeo em rádio somente 2,4 GHz</string>
     <string name="narrow_band_profile_cap_description">Quando o WiFi desta unidade não tem faixa de 5 GHz, pedir ao telefone no máximo 720p e 30 fps em vez das configurações acima. Em um enlace assim, mediu-se que um fluxo em taxa cheia não levava imagem alguma, enquanto um mais baixo se manteve. Desative isto para receber exatamente o que você pediu.</string>
     <string name="connection_issue_banner_video_link_too_slow">Seu telefone desistiu do vídeo antes de chegar um único quadro, várias vezes seguidas. O enlace WiFi é lento demais para carregar a imagem. Toque para baixar o limite de FPS para 30; resolução menor e áudio AAC também ajudam.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">Esta unidade se recusou a colocar sua rede WiFi Direct em qualquer canal de 5 GHz que você escolheu, então ela subiu no canal escolhido pelo próprio driver WiFi. Esse canal muitas vezes é um que telefones em países mais restritivos nem conseguem ver. Toque para definir a banda do WiFi Direct em 2,4 GHz, permitida em todos os países; espere 720p em vez de 1080p nela.</string>
     <string name="connection_issue_banner_dismiss">Fechar</string>
     <string name="connection_issue_remedy_hotspot_query">Nome e senha do ponto de acesso</string>
     <string name="preflight_title">Antes de conectar</string>
@@ -1080,6 +1081,7 @@
     <string name="five_ghz_channel">Canal de 5 GHz</string>
     <string name="five_ghz_channel_auto">Automático</string>
     <string name="five_ghz_channel_option">Canal %1$d (%2$d MHz)</string>
+    <string name="five_ghz_channel_hint">Um canal é um pedido, não uma garantia. Muitas unidades só criam a rede no canal escolhido pelo próprio driver WiFi, e o aplicativo só pode te dizer isso depois de tentar. Se nenhum canal de 5 GHz funcionar e seu telefone continuar sem ver a rede, a banda acima é o ajuste que vai resolver.</string>
     <string name="wifi_direct_stable_identity">Manter a mesma rede Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Solicita o grupo com o mesmo nome e senha todas as vezes, para que o telefone se reconecte a uma rede conhecida em vez de ser configurado a cada viagem. Desative para gerar uma nova rede a cada conexão se o telefone rejeitar a rede salva.</string>
     <string name="wifi_direct_new_identity">Nova identidade de rede Wi-Fi Direct</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -956,6 +956,7 @@
     <string name="narrow_band_profile_cap">Video redus pe radio doar de 2,4 GHz</string>
     <string name="narrow_band_profile_cap_description">Când Wi-Fi-ul acestei unități nu are banda de 5 GHz, cere telefonului cel mult 720p și 30 fps în locul setărilor de mai sus. Pe o astfel de legătură s-a măsurat că fluxul la rată completă nu transporta deloc imagine, în timp ce unul mai mic rezista. Dezactivați pentru a primi exact ce ați cerut.</string>
     <string name="connection_issue_banner_video_link_too_slow">Telefonul a renunțat la video de mai multe ori la rând, înainte să ajungă vreun cadru. Legătura Wi-Fi este prea lentă pentru imagine. Atingeți pentru a coborî limita de FPS la 30; ajută și o rezoluție mai mică, precum și sunetul AAC.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">Această unitate a refuzat să pună rețeaua WiFi Direct pe oricare canal de 5 GHz ales de tine, așa că a pornit-o pe cel ales de propriul driver WiFi. Acel canal este adesea unul pe care telefoanele din țările mai stricte nici măcar nu îl văd. Atinge pentru a seta banda WiFi Direct la 2,4 GHz, permisă în toate țările; așteaptă-te la 720p în loc de 1080p.</string>
     <string name="connection_issue_banner_dismiss">Închide</string>
     <string name="connection_issue_remedy_hotspot_query">Nume și parolă hotspot</string>
     <string name="preflight_title">Înainte de conectare</string>
@@ -1076,6 +1077,7 @@
     <string name="five_ghz_channel">Canal 5 GHz</string>
     <string name="five_ghz_channel_auto">Automat</string>
     <string name="five_ghz_channel_option">Canal %1$d (%2$d MHz)</string>
+    <string name="five_ghz_channel_hint">Un canal este o cerere, nu o garanție. Multe unități creează rețeaua doar pe canalul ales de propriul driver WiFi, iar aplicația îți poate spune asta abia după încercare. Dacă niciun canal de 5 GHz nu funcționează și telefonul tot nu vede rețeaua, banda de mai sus este setarea care va rezolva.</string>
     <string name="wifi_direct_stable_identity">Păstrează aceeași rețea Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Solicită grupul cu același nume și parolă de fiecare dată, astfel încât telefonul să se reconecteze la o rețea cunoscută fără reconfigurare la fiecare călătorie.</string>
     <string name="wifi_direct_new_identity">Nouă identitate de rețea Wi-Fi Direct</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1076,9 +1076,6 @@
     <string name="five_ghz_channel">Canal 5 GHz</string>
     <string name="five_ghz_channel_auto">Automat</string>
     <string name="five_ghz_channel_option">Canal %1$d (%2$d MHz)</string>
-    <string name="stand_down_station">Deconectează de la Wi-Fi propriu la conectare</string>
-    <string name="stand_down_station_description">Deconectează unitatea de la propria rețea Wi-Fi înainte de a crea grupul Wi-Fi Direct și o reconectează la sfârșitul sesiunii.</string>
-    <string name="stand_down_station_needs_overlay">Necesită permisiunea «afișare peste alte aplicații» pe această versiune de Android.</string>
     <string name="wifi_direct_stable_identity">Păstrează aceeași rețea Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Solicită grupul cu același nume și parolă de fiecare dată, astfel încât telefonul să se reconecteze la o rețea cunoscută fără reconfigurare la fiecare călătorie.</string>
     <string name="wifi_direct_new_identity">Nouă identitate de rețea Wi-Fi Direct</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -958,6 +958,7 @@
     <string name="narrow_band_profile_cap">Снижать видео при радио только 2,4 ГГц</string>
     <string name="narrow_band_profile_cap_description">Когда у Wi-Fi этого устройства нет диапазона 5 ГГц, запрашивать у телефона не более 720p и 30 кадр/с вместо настроек выше. На такой линии связи измерения показали, что поток на полной скорости не передавал изображение вовсе, а более низкий работал. Отключите, чтобы получать именно то, что вы задали.</string>
     <string name="connection_issue_banner_video_link_too_slow">Ваш телефон несколько раз подряд прекращал видео, не дождавшись ни одного кадра. Соединение Wi-Fi слишком медленное для изображения. Нажмите, чтобы снизить ограничение FPS до 30; также помогут меньшее разрешение и звук AAC.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">Это устройство отказалось разместить сеть WiFi Direct на любом выбранном вами канале 5 ГГц и запустило её на канале, который выбрал его собственный драйвер Wi-Fi. Этот канал часто не виден телефонам в странах со строгими правилами. Нажмите, чтобы установить диапазон WiFi Direct на 2,4 ГГц, который разрешён во всех странах; ожидайте 720p вместо 1080p.</string>
     <string name="connection_issue_banner_dismiss">Закрыть</string>
     <string name="connection_issue_remedy_hotspot_query">Имя и пароль точки доступа</string>
     <string name="preflight_title">Перед подключением</string>
@@ -1078,6 +1079,7 @@
     <string name="five_ghz_channel">Канал 5 ГГц</string>
     <string name="five_ghz_channel_auto">Автоматически</string>
     <string name="five_ghz_channel_option">Канал %1$d (%2$d МГц)</string>
+    <string name="five_ghz_channel_hint">Канал является запросом, а не гарантией. Многие устройства создают сеть только на том канале, который выбирает их собственный драйвер Wi-Fi, и приложение может сообщить об этом лишь после попытки. Если ни один канал 5 ГГц не работает и телефон по-прежнему не видит сеть, поможет настройка диапазона выше.</string>
     <string name="wifi_direct_stable_identity">Сохранять ту же сеть Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Создает группу с одним и тем же именем и паролем, чтобы телефон подключался к уже известной сети без повторной настройки при каждой поездке.</string>
     <string name="wifi_direct_new_identity">Новые параметры сети Wi-Fi Direct</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1078,9 +1078,6 @@
     <string name="five_ghz_channel">Канал 5 ГГц</string>
     <string name="five_ghz_channel_auto">Автоматически</string>
     <string name="five_ghz_channel_option">Канал %1$d (%2$d МГц)</string>
-    <string name="stand_down_station">Отключать собственный Wi-Fi при подключении</string>
-    <string name="stand_down_station_description">Отключает магнитолу от собственной сети Wi-Fi перед созданием группы Wi-Fi Direct и подключает обратно после завершения сеанса.</string>
-    <string name="stand_down_station_needs_overlay">Требуется разрешение «поверх других приложений» на этой версии Android.</string>
     <string name="wifi_direct_stable_identity">Сохранять ту же сеть Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Создает группу с одним и тем же именем и паролем, чтобы телефон подключался к уже известной сети без повторной настройки при каждой поездке.</string>
     <string name="wifi_direct_new_identity">Новые параметры сети Wi-Fi Direct</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -954,6 +954,7 @@
     <string name="narrow_band_profile_cap">Yalnızca 2,4 GHz radyoda videoyu düşür</string>
     <string name="narrow_band_profile_cap_description">Bu cihazın Wi-Fi\'ında 5 GHz bandı yoksa, yukarıdaki ayarlar yerine telefondan en fazla 720p ve 30 fps iste. Böyle bir bağlantıda tam hızlı akışın hiç görüntü taşımadığı, daha düşüğünün ise tutunduğu ölçüldü. İstediğiniz ayarların aynen uygulanması için bunu kapatın.</string>
     <string name="connection_issue_banner_video_link_too_slow">Telefonunuz üst üste birkaç kez, tek bir kare bile gelmeden videodan vazgeçti. Wi-Fi bağlantısı görüntüyü taşıyamayacak kadar yavaş. FPS sınırını 30\'a düşürmek için dokunun; daha düşük çözünürlük ve AAC ses de yardımcı olur.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">Bu ünite WiFi Direct ağını seçtiğin hiçbir 5 GHz kanalına koymayı reddetti ve kendi WiFi sürücüsünün seçtiği kanalda başlattı. Bu kanal çoğu zaman daha katı ülkelerdeki telefonların göremediği bir kanaldır. WiFi Direct bandını her ülkede izin verilen 2,4 GHz olarak ayarlamak için dokun; burada 1080p yerine 720p bekle.</string>
     <string name="connection_issue_banner_dismiss">Kapat</string>
     <string name="connection_issue_remedy_hotspot_query">Erişim noktası adı ve şifresi</string>
     <string name="preflight_title">Bağlanmadan önce</string>
@@ -1074,6 +1075,7 @@
     <string name="five_ghz_channel">5 GHz kanalı</string>
     <string name="five_ghz_channel_auto">Otomatik</string>
     <string name="five_ghz_channel_option">Kanal %1$d (%2$d MHz)</string>
+    <string name="five_ghz_channel_hint">Kanal bir istektir, garanti değildir. Birçok ünite ağı yalnızca kendi WiFi sürücüsünün seçtiği kanalda oluşturur ve uygulama bunu ancak denedikten sonra söyleyebilir. Hiçbir 5 GHz kanalı işe yaramıyorsa ve telefonun ağı hâlâ göremiyorsa, çözecek olan ayar yukarıdaki banttır.</string>
     <string name="wifi_direct_stable_identity">Aynı Wi-Fi Direct ağını koru</string>
     <string name="wifi_direct_stable_identity_description">Her sürüşte yeni bir kurulum yerine, telefonunuzun bildiği bir ağa yeniden bağlanması için grubu her seferinde aynı ad ve şifreyle ister.</string>
     <string name="wifi_direct_new_identity">Yeni Wi-Fi Direct ağ kimliği</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1074,9 +1074,6 @@
     <string name="five_ghz_channel">5 GHz kanalı</string>
     <string name="five_ghz_channel_auto">Otomatik</string>
     <string name="five_ghz_channel_option">Kanal %1$d (%2$d MHz)</string>
-    <string name="stand_down_station">Bağlanırken ünitenin kendi Wi-Fi ağından ayrıl</string>
-    <string name="stand_down_station_description">Wi-Fi Direct grubu oluşturulmadan hemen önce bu ana ünitenin kendi Wi-Fi ağından bağlantısını keser ve oturum bittiğinde yeniden bağlar.</string>
-    <string name="stand_down_station_needs_overlay">Bu Android sürümünde «diğer uygulamaların üzerinde görüntüleme» izni gerektirir.</string>
     <string name="wifi_direct_stable_identity">Aynı Wi-Fi Direct ağını koru</string>
     <string name="wifi_direct_stable_identity_description">Her sürüşte yeni bir kurulum yerine, telefonunuzun bildiği bir ağa yeniden bağlanması için grubu her seferinde aynı ad ve şifreyle ister.</string>
     <string name="wifi_direct_new_identity">Yeni Wi-Fi Direct ağ kimliği</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1080,9 +1080,6 @@
     <string name="five_ghz_channel">Канал 5 ГГц</string>
     <string name="five_ghz_channel_auto">Автоматично</string>
     <string name="five_ghz_channel_option">Канал %1$d (%2$d МГц)</string>
-    <string name="stand_down_station">Відключати власний Wi-Fi під час з\'єднання</string>
-    <string name="stand_down_station_description">Відключає цей пристрій від власної мережі Wi-Fi перед створенням групи Wi-Fi Direct та відновлює з\'єднання після сеансу.</string>
-    <string name="stand_down_station_needs_overlay">Потрібен дозвіл «відображення поверх інших додатків» на цій версії Android.</string>
     <string name="wifi_direct_stable_identity">Зберігати ту саму мережу Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Запитує групу з тим самим ім\'ям та паролем щоразу, щоб телефон підключався до знайомої мережі без повторного налаштування.</string>
     <string name="wifi_direct_new_identity">Нова ідентичність мережі Wi-Fi Direct</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -960,6 +960,7 @@
     <string name="narrow_band_profile_cap">Знижувати відео на радіо лише 2,4 ГГц</string>
     <string name="narrow_band_profile_cap_description">Коли Wi-Fi цього пристрою не має діапазону 5 ГГц, запитувати в телефона щонайбільше 720p і 30 кадр/с замість налаштувань вище. На такому з\'єднанні виміряно, що потік на повній швидкості не передавав зображення взагалі, а нижчий працював. Вимкніть, щоб отримувати саме те, що ви задали.</string>
     <string name="connection_issue_banner_video_link_too_slow">Ваш телефон кілька разів поспіль припиняв відео ще до першого кадру. З\'єднання Wi-Fi надто повільне для зображення. Натисніть, щоб знизити обмеження FPS до 30; також допоможуть менша роздільність і звук AAC.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">Цей пристрій відмовився розмістити мережу WiFi Direct на будь-якому обраному тобою каналі 5 ГГц і запустив її на каналі, який обрав його власний драйвер Wi-Fi. Цей канал часто не видно телефонам у країнах зі суворішими правилами. Торкніться, щоб встановити діапазон WiFi Direct на 2,4 ГГц, дозволений у всіх країнах; очікуйте 720p замість 1080p.</string>
     <string name="connection_issue_banner_dismiss">Закрити</string>
     <string name="connection_issue_remedy_hotspot_query">Назва та пароль точки доступу</string>
     <string name="preflight_title">Перед підключенням</string>
@@ -1080,6 +1081,7 @@
     <string name="five_ghz_channel">Канал 5 ГГц</string>
     <string name="five_ghz_channel_auto">Автоматично</string>
     <string name="five_ghz_channel_option">Канал %1$d (%2$d МГц)</string>
+    <string name="five_ghz_channel_hint">Канал є запитом, а не гарантією. Багато пристроїв створюють мережу лише на тому каналі, який обирає їхній власний драйвер Wi-Fi, і застосунок може повідомити про це тільки після спроби. Якщо жоден канал 5 ГГц не працює, а телефон досі не бачить мережу, допоможе налаштування діапазону вище.</string>
     <string name="wifi_direct_stable_identity">Зберігати ту саму мережу Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Запитує групу з тим самим ім\'ям та паролем щоразу, щоб телефон підключався до знайомої мережі без повторного налаштування.</string>
     <string name="wifi_direct_new_identity">Нова ідентичність мережі Wi-Fi Direct</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -962,6 +962,7 @@
     <string name="narrow_band_profile_cap">Giảm video khi sóng chỉ có 2,4 GHz</string>
     <string name="narrow_band_profile_cap_description">Khi Wi-Fi của thiết bị này không có băng tần 5 GHz, yêu cầu điện thoại tối đa 720p và 30 fps thay cho các cài đặt ở trên. Trên đường truyền như vậy, đo được luồng ở tốc độ đầy đủ không mang được hình ảnh nào, còn luồng thấp hơn thì trụ được. Tắt tùy chọn này để nhận đúng những gì bạn đã đặt.</string>
     <string name="connection_issue_banner_video_link_too_slow">Điện thoại đã bỏ dở video trước khi có dù chỉ một khung hình, nhiều lần liên tiếp. Đường truyền Wi-Fi quá chậm để tải hình ảnh. Nhấn để hạ giới hạn FPS xuống 30; giảm độ phân giải và dùng âm thanh AAC cũng có ích.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">Thiết bị này đã từ chối đặt mạng WiFi Direct trên bất kỳ kênh 5 GHz nào bạn chọn, nên nó khởi tạo trên kênh do trình điều khiển WiFi của chính nó chọn. Kênh đó thường là kênh mà điện thoại ở các nước có quy định nghiêm ngặt hơn thậm chí không thấy được. Chạm để đặt băng tần WiFi Direct thành 2,4 GHz, được phép ở mọi quốc gia; hãy chờ đợi 720p thay vì 1080p.</string>
     <string name="connection_issue_banner_dismiss">Bỏ qua</string>
     <string name="connection_issue_remedy_hotspot_query">Tên và mật khẩu điểm phát sóng</string>
     <string name="preflight_title">Trước khi kết nối</string>
@@ -1082,6 +1083,7 @@
     <string name="five_ghz_channel">Kênh 5 GHz</string>
     <string name="five_ghz_channel_auto">Tự động</string>
     <string name="five_ghz_channel_option">Kênh %1$d (%2$d MHz)</string>
+    <string name="five_ghz_channel_hint">Kênh chỉ là một yêu cầu, không phải điều bảo đảm. Nhiều thiết bị chỉ tạo mạng trên kênh do trình điều khiển WiFi của chính nó chọn, và ứng dụng chỉ có thể cho bạn biết điều đó sau khi đã thử. Nếu không kênh 5 GHz nào hoạt động và điện thoại vẫn không thấy mạng, băng tần ở trên là thiết lập sẽ giải quyết được.</string>
     <string name="wifi_direct_stable_identity">Giữ nguyên mạng Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Tạo nhóm với cùng tên và mật khẩu mỗi lần để điện thoại kết nối lại với mạng đã biết mà không cần thiết lập lại ở mỗi chuyến đi.</string>
     <string name="wifi_direct_new_identity">Danh tính mạng Wi-Fi Direct mới</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1082,9 +1082,6 @@
     <string name="five_ghz_channel">Kênh 5 GHz</string>
     <string name="five_ghz_channel_auto">Tự động</string>
     <string name="five_ghz_channel_option">Kênh %1$d (%2$d MHz)</string>
-    <string name="stand_down_station">Ngắt kết nối Wi-Fi riêng khi kết nối</string>
-    <string name="stand_down_station_description">Ngắt kết nối màn hình khỏi mạng Wi-Fi riêng ngay trước khi tạo nhóm Wi-Fi Direct và kết nối lại sau khi phiên kết thúc.</string>
-    <string name="stand_down_station_needs_overlay">Cần có quyền «hiển thị trên các ứng dụng khác» trên phiên bản Android này.</string>
     <string name="wifi_direct_stable_identity">Giữ nguyên mạng Wi-Fi Direct</string>
     <string name="wifi_direct_stable_identity_description">Tạo nhóm với cùng tên và mật khẩu mỗi lần để điện thoại kết nối lại với mạng đã biết mà không cần thiết lập lại ở mỗi chuyến đi.</string>
     <string name="wifi_direct_new_identity">Danh tính mạng Wi-Fi Direct mới</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -958,6 +958,7 @@
     <string name="narrow_band_profile_cap">僅有 2.4 GHz 無線時降低影像</string>
     <string name="narrow_band_profile_cap_description">當此主機的 WiFi 沒有 5 GHz 頻段時，改為向手機要求最高 720p 與 30 fps，而非上方的設定。實測顯示在這種連線上，全速串流完全傳不出畫面，較低的設定則能維持。若要完全依照您的設定，請關閉此選項。</string>
     <string name="connection_issue_banner_video_link_too_slow">手機連續多次在第一個影格送達前就放棄影像。WiFi 連線太慢，無法承載畫面。輕觸以將 FPS 上限降為 30；降低解析度與改用 AAC 音訊也有幫助。</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">這台主機拒絕將 WiFi Direct 網路建立在你所選的任何 5 GHz 頻道上，因此改用它自己的 WiFi 驅動程式挑選的頻道。該頻道往往是法規較嚴格國家的手機根本看不到的頻道。點選以將 WiFi Direct 頻段設為 2.4 GHz，這是所有國家都允許的頻段；在該頻段上預期為 720p 而非 1080p。</string>
     <string name="connection_issue_banner_dismiss">關閉</string>
     <string name="connection_issue_remedy_hotspot_query">熱點名稱與密碼</string>
     <string name="preflight_title">連線前檢查</string>
@@ -1078,6 +1079,7 @@
     <string name="five_ghz_channel">5 GHz 頻道</string>
     <string name="five_ghz_channel_auto">自動</string>
     <string name="five_ghz_channel_option">頻道 %1$d (%2$d MHz)</string>
+    <string name="five_ghz_channel_hint">頻道只是請求，並非保證。許多主機只會在自己的 WiFi 驅動程式所選的頻道上建立網路，而應用程式只能在嘗試之後才能告訴你結果。如果沒有任何 5 GHz 頻道可用，而手機仍然看不到網路，上方的頻段才是能解決問題的設定。</string>
     <string name="wifi_direct_stable_identity">保持相同的 Wi-Fi Direct 網路</string>
     <string name="wifi_direct_stable_identity_description">每次都使用相同的名稱和密碼建立群組，讓您的手機重新連接已知的網路，而無需在每次行程中重新設定。</string>
     <string name="wifi_direct_new_identity">新的 Wi-Fi Direct 網路識別碼</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1078,9 +1078,6 @@
     <string name="five_ghz_channel">5 GHz 頻道</string>
     <string name="five_ghz_channel_auto">自動</string>
     <string name="five_ghz_channel_option">頻道 %1$d (%2$d MHz)</string>
-    <string name="stand_down_station">連線時中斷車機本身的 Wi-Fi</string>
-    <string name="stand_down_station_description">在建立 Wi-Fi Direct 群組前中斷車機與其自身 Wi-Fi 網路的連線，並在工作階段結束後重新連線。</string>
-    <string name="stand_down_station_needs_overlay">在此 Android 版本上需要「顯示在其他應用程式上層」的權限。</string>
     <string name="wifi_direct_stable_identity">保持相同的 Wi-Fi Direct 網路</string>
     <string name="wifi_direct_stable_identity_description">每次都使用相同的名稱和密碼建立群組，讓您的手機重新連接已知的網路，而無需在每次行程中重新設定。</string>
     <string name="wifi_direct_new_identity">新的 Wi-Fi Direct 網路識別碼</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -804,9 +804,6 @@
     <string name="five_ghz_channel_auto">Automatic</string>
     <string name="five_ghz_channel_option">Channel %1$d (%2$d MHz)</string>
     <string name="five_ghz_channel_hint">A channel is a request, not a guarantee. Many units will only host a network where their own WiFi driver chooses, and the app can only tell you so after trying. If no 5 GHz channel works and your phone still cannot see the network, the band above is the setting that will.</string>
-    <string name="stand_down_station">Leave this unit\'s WiFi network while connecting</string>
-    <string name="stand_down_station_description">Disconnects this head unit from its own WiFi network just before the WiFi Direct group is created, and reconnects it when the session ends. On a single-radio unit a joined network leaves the group no free channel, so the group is forced onto that network\'s channel or is refused outright. Try this if your phone never joins. Note that most units measured so far run better with the network joined, so turn it back off if the picture gets worse.</string>
-    <string name="stand_down_station_needs_overlay">Needs the \"display over other apps\" permission on this Android version.</string>
     <string name="wifi_direct_stable_identity">Keep the same WiFi Direct network</string>
     <string name="wifi_direct_stable_identity_description">Asks for the group with the same name and password every time, so your phone rejoins a network it already knows instead of being set up for a new one on every drive. Turn it off to get a new network on every connection, which is how versions 3.2 and 3.3 worked, if a phone keeps refusing the saved one. Trying a new identity below is the lighter fix.</string>
     <string name="wifi_direct_new_identity">New WiFi Direct network identity</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -803,6 +803,7 @@
     <string name="five_ghz_channel">5 GHz channel</string>
     <string name="five_ghz_channel_auto">Automatic</string>
     <string name="five_ghz_channel_option">Channel %1$d (%2$d MHz)</string>
+    <string name="five_ghz_channel_hint">A channel is a request, not a guarantee. Many units will only host a network where their own WiFi driver chooses, and the app can only tell you so after trying. If no 5 GHz channel works and your phone still cannot see the network, the band above is the setting that will.</string>
     <string name="stand_down_station">Leave this unit\'s WiFi network while connecting</string>
     <string name="stand_down_station_description">Disconnects this head unit from its own WiFi network just before the WiFi Direct group is created, and reconnects it when the session ends. On a single-radio unit a joined network leaves the group no free channel, so the group is forced onto that network\'s channel or is refused outright. Try this if your phone never joins. Note that most units measured so far run better with the network joined, so turn it back off if the picture gets worse.</string>
     <string name="stand_down_station_needs_overlay">Needs the \"display over other apps\" permission on this Android version.</string>
@@ -997,6 +998,7 @@
     <string name="narrow_band_profile_cap">Lower video on a 2.4 GHz-only radio</string>
     <string name="narrow_band_profile_cap_description">When this unit\'s WiFi has no 5 GHz band, ask the phone for at most 720p and 30 fps instead of the settings above. On such a link a full-rate stream was measured to carry no picture at all, while a lower one held. Turn this off to be given what you asked for.</string>
     <string name="connection_issue_banner_video_link_too_slow">Your phone gave up on the video before a single frame arrived, several times in a row. The WiFi link is too slow to carry the picture. Tap to lower the FPS limit to 30; a lower resolution and AAC audio also help.</string>
+    <string name="connection_issue_banner_five_ghz_channel_refused">This unit refused to put its WiFi Direct network on any 5 GHz channel you chose, so it went up on the one its own WiFi driver picked. That channel is often one phones in stricter countries cannot even see. Tap to set the WiFi Direct band to 2.4 GHz, which every country allows; expect 720p rather than 1080p on it.</string>
     <string name="connection_issue_banner_dismiss">Dismiss</string>
     <!-- What the hotspot banner types into the settings search. Both override rows carry it
          as a search keyword, so this one string is what makes the tap reach the pair. -->

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/WirelessBringUpDeferralPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/WirelessBringUpDeferralPolicyTest.kt
@@ -1,0 +1,78 @@
+package com.andrerinas.openheadunit.connection.wifi
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the narrow trigger. A wireless-only unit and a unit with a permanently attached peripheral
+ * must both arm wireless exactly as they did before this existed.
+ */
+class WirelessBringUpDeferralPolicyTest {
+
+    @Test
+    fun `an empty bus arms wireless immediately`() {
+        assertFalse(
+            WirelessBringUpDeferralPolicy.shouldDefer(
+                accessoryDeviceOnBus = false,
+                switchInFlight = false,
+                msSinceFirstDeferral = 0L,
+            )
+        )
+    }
+
+    /**
+     * The regression this policy is most likely to cause: an audio or Bluetooth adapter left
+     * plugged in is neither of the two things asked about, so it costs nothing.
+     */
+    @Test
+    fun `a peripheral that is not in accessory mode and not switching defers nothing`() {
+        assertFalse(
+            WirelessBringUpDeferralPolicy.shouldDefer(
+                accessoryDeviceOnBus = false,
+                switchInFlight = false,
+                msSinceFirstDeferral = 4_000L,
+            )
+        )
+    }
+
+    @Test
+    fun `an accessory-mode device defers the bring-up`() {
+        assertTrue(
+            WirelessBringUpDeferralPolicy.shouldDefer(
+                accessoryDeviceOnBus = true,
+                switchInFlight = false,
+                msSinceFirstDeferral = 0L,
+            )
+        )
+    }
+
+    @Test
+    fun `a switch in flight defers the bring-up before the device re-enumerates`() {
+        assertTrue(
+            WirelessBringUpDeferralPolicy.shouldDefer(
+                accessoryDeviceOnBus = false,
+                switchInFlight = true,
+                msSinceFirstDeferral = 0L,
+            )
+        )
+    }
+
+    @Test
+    fun `the budget releases a dongle that never negotiates`() {
+        assertTrue(
+            WirelessBringUpDeferralPolicy.shouldDefer(
+                accessoryDeviceOnBus = true,
+                switchInFlight = true,
+                msSinceFirstDeferral = WirelessBringUpDeferralPolicy.DEFER_BUDGET_MS - 1,
+            )
+        )
+        assertFalse(
+            WirelessBringUpDeferralPolicy.shouldDefer(
+                accessoryDeviceOnBus = true,
+                switchInFlight = true,
+                msSinceFirstDeferral = WirelessBringUpDeferralPolicy.DEFER_BUDGET_MS,
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/StationStandDownPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/StationStandDownPolicyTest.kt
@@ -34,20 +34,10 @@ class StationStandDownPolicyTest {
     // --- shouldStandDown ---
 
     @Test
-    fun `stands down when enabled and joined on a platform that allows it`() {
+    fun `stands down when joined on a platform that allows it, with nothing to ask`() {
         assertTrue(
             StationStandDownPolicy.shouldStandDown(
-                enabled = true, sdkInt = 27, canDrawOverlays = false,
-                associated = true, networkId = 3
-            )
-        )
-    }
-
-    @Test
-    fun `never when the setting is off`() {
-        assertFalse(
-            StationStandDownPolicy.shouldStandDown(
-                enabled = false, sdkInt = 27, canDrawOverlays = true,
+                sdkInt = 27, canDrawOverlays = false,
                 associated = true, networkId = 3
             )
         )
@@ -57,7 +47,7 @@ class StationStandDownPolicyTest {
     fun `never when nothing is joined`() {
         assertFalse(
             StationStandDownPolicy.shouldStandDown(
-                enabled = true, sdkInt = 27, canDrawOverlays = true,
+                sdkInt = 27, canDrawOverlays = true,
                 associated = false, networkId = 3
             )
         )
@@ -67,7 +57,7 @@ class StationStandDownPolicyTest {
     fun `never on a hidden network id, which is what a redacted read looks like`() {
         assertFalse(
             StationStandDownPolicy.shouldStandDown(
-                enabled = true, sdkInt = 27, canDrawOverlays = true,
+                sdkInt = 27, canDrawOverlays = true,
                 associated = true, networkId = -1
             )
         )
@@ -77,10 +67,23 @@ class StationStandDownPolicyTest {
     fun `never where the platform would refuse the call`() {
         assertFalse(
             StationStandDownPolicy.shouldStandDown(
-                enabled = true, sdkInt = 35, canDrawOverlays = true,
+                sdkInt = 35, canDrawOverlays = true,
                 associated = true, networkId = 3
             )
         )
+    }
+
+    @Test
+    fun `the platform gate is the whole of it once a network is joined`() {
+        for (sdk in 21..36) {
+            for (overlay in listOf(false, true)) {
+                assertEquals(
+                    "api $sdk overlay=$overlay",
+                    StationStandDownPolicy.isAvailable(sdk, overlay),
+                    StationStandDownPolicy.shouldStandDown(sdk, overlay, associated = true, networkId = 3)
+                )
+            }
+        }
     }
 
     // --- describeUnavailable: exactly the complement of isAvailable ---

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiCountryPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiCountryPolicyTest.kt
@@ -1,0 +1,94 @@
+package com.andrerinas.openheadunit.connection.wifi.direct
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WifiCountryPolicyTest {
+
+    // --- normalise ---
+
+    @Test
+    fun `a country is upper-cased and trimmed`() {
+        assertEquals("EG", WifiCountryPolicy.normalise("eg"))
+        assertEquals("CN", WifiCountryPolicy.normalise("  cn  "))
+        assertEquals("DE", WifiCountryPolicy.normalise("DE"))
+    }
+
+    @Test
+    fun `the world domain is an absent country, not a country`() {
+        assertNull(WifiCountryPolicy.normalise("00"))
+        assertNull(WifiCountryPolicy.normalise("WW"))
+        assertNull(WifiCountryPolicy.normalise("ww"))
+    }
+
+    @Test
+    fun `anything that is not two letters names nothing`() {
+        assertNull(WifiCountryPolicy.normalise(null))
+        assertNull(WifiCountryPolicy.normalise(""))
+        assertNull(WifiCountryPolicy.normalise("   "))
+        assertNull(WifiCountryPolicy.normalise("USA"))
+        assertNull(WifiCountryPolicy.normalise("E"))
+        assertNull(WifiCountryPolicy.normalise("E1"))
+        // What a failed read puts in the map: it must never be mistaken for a country.
+        assertNull(WifiCountryPolicy.normalise("err: SecurityException"))
+    }
+
+    @Test
+    fun `the world domain is told apart from a source that said nothing`() {
+        assertTrue(WifiCountryPolicy.isWorldDomain("00"))
+        assertTrue(WifiCountryPolicy.isWorldDomain(" ww "))
+        assertFalse(WifiCountryPolicy.isWorldDomain("EG"))
+        assertFalse(WifiCountryPolicy.isWorldDomain(null))
+    }
+
+    // --- choose: first source that names one wins ---
+
+    @Test
+    fun `the earliest source that names a country is the answer`() {
+        val sources = linkedMapOf(
+            "telephony" to null,
+            "settings" to "  ",
+            "property" to "cn",
+            "locale" to "US",
+        )
+        assertEquals("CN", WifiCountryPolicy.choose(sources))
+    }
+
+    @Test
+    fun `a world domain earlier in the order does not win over a real country later`() {
+        val sources = linkedMapOf("telephony" to "00", "property" to "eg")
+        assertEquals("EG", WifiCountryPolicy.choose(sources))
+    }
+
+    @Test
+    fun `nothing named means null`() {
+        assertNull(WifiCountryPolicy.choose(linkedMapOf("a" to null, "b" to "", "c" to "00")))
+        assertNull(WifiCountryPolicy.choose(emptyMap()))
+    }
+
+    // --- describe: the three outcomes a log line has to distinguish ---
+
+    @Test
+    fun `a named country reads as itself`() {
+        assertEquals(
+            "regulatory domain CN",
+            WifiCountryPolicy.describe(linkedMapOf("property" to "cn"))
+        )
+    }
+
+    @Test
+    fun `an unset domain is reported as the finding it is`() {
+        val why = WifiCountryPolicy.describe(linkedMapOf("telephony" to null, "property" to "00"))
+        assertTrue(why, why.contains("world domain"))
+    }
+
+    @Test
+    fun `silence from every source is not claimed to be the world domain`() {
+        val why = WifiCountryPolicy.describe(linkedMapOf("telephony" to null, "property" to ""))
+        assertTrue(why, why.contains("unknown"))
+        assertFalse(why, why.contains("world domain"))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiP2pOperatingChannelPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiP2pOperatingChannelPolicyTest.kt
@@ -142,7 +142,7 @@ class WifiP2pOperatingChannelPolicyTest {
     fun `5 GHz only never names a 2_4 GHz channel, on either range`() {
         assertEquals(listOf(36), WifiP2pOperatingChannelPolicy.attemptChannels(api27, P2pBandPreference.FORCE_5GHZ))
         assertEquals(
-            listOf(149),
+            listOf(149, 153, 157, 161),
             WifiP2pOperatingChannelPolicy.attemptChannels(api27, P2pBandPreference.FORCE_5GHZ, chosenChannel = WifiP2pOperatingChannelPolicy.CHANNEL_UPPER)
         )
         for (chosen in listOf(0, 36, 40, 44, 48, 149)) {
@@ -166,15 +166,60 @@ class WifiP2pOperatingChannelPolicyTest {
     }
 
     @Test
-    fun `a chosen channel replaces the 5 GHz rung and nothing else`() {
+    fun `a chosen channel is walked across its own window, and the 2_4 GHz rung survives`() {
         // The 2.4 GHz rung has to survive: the request is a disallowed-frequency list, so a unit
         // that cannot host a group owner on the named channel forms no group at all, and this rung
         // is the only thing that stops a wrong choice being a dead unit.
-        for (channel in listOf(36, 40, 44, 48, 149)) {
+        val windows = mapOf(
+            36 to listOf(36, 40, 44, 48),
+            40 to listOf(40, 36, 44, 48),
+            44 to listOf(44, 36, 40, 48),
+            48 to listOf(48, 36, 40, 44),
+            149 to listOf(149, 153, 157, 161),
+        )
+        for ((channel, walk) in windows) {
             assertEquals(
-                listOf(channel, 6),
+                "chosen=$channel",
+                walk + 6,
                 WifiP2pOperatingChannelPolicy.attemptChannels(api27, P2pBandPreference.AUTO, channel)
             )
+            assertEquals(
+                "chosen=$channel, 5 GHz only",
+                walk,
+                WifiP2pOperatingChannelPolicy.attemptChannels(api27, P2pBandPreference.FORCE_5GHZ, channel)
+            )
+        }
+    }
+
+    @Test
+    fun `a walk never leaves the window the user chose`() {
+        // Somebody who pinned UNII-1 is escaping UNII-3. Walking into it would land them on the
+        // channel the setting exists to avoid, which is the failure this ladder is answering.
+        for (chosen in listOf(36, 40, 44, 48)) {
+            val walk = WifiP2pOperatingChannelPolicy.attemptChannels(api27, P2pBandPreference.FORCE_5GHZ, chosen)
+            assertEquals("chosen=$chosen", listOf(36, 40, 44, 48).sorted(), walk.sorted())
+        }
+        assertEquals(
+            listOf(149, 153, 157, 161),
+            WifiP2pOperatingChannelPolicy.attemptChannels(api27, P2pBandPreference.FORCE_5GHZ, 149).sorted()
+        )
+    }
+
+    @Test
+    fun `no rung names a channel the platform picker cannot produce`() {
+        // createGroup asks with freq=0, so wpas_p2p_select_go_freq_no_pref does the choosing and it
+        // proposes 5180-5240 then 5745-5805 and nothing else. 5825 is unreachable however the
+        // radio is configured, so naming 165 would spend a bring-up that can never succeed.
+        val producible = setOf(5180, 5200, 5220, 5240, 5745, 5765, 5785, 5805, 2437)
+        for (chosen in listOf(0, 36, 40, 44, 48, 149)) {
+            for (preference in P2pBandPreference.values()) {
+                for (channel in WifiP2pOperatingChannelPolicy.attemptChannels(api27, preference, chosen)) {
+                    assertTrue(
+                        "channel $channel is not one the picker proposes",
+                        WifiP2pOperatingChannelPolicy.frequencyMhzFor(channel) in producible
+                    )
+                }
+            }
         }
     }
 
@@ -229,7 +274,7 @@ class WifiP2pOperatingChannelPolicyTest {
     @Test
     fun `the upper band is only reached when it is asked for`() {
         assertEquals(
-            listOf(149, 6),
+            listOf(149, 153, 157, 161, 6),
             WifiP2pOperatingChannelPolicy.attemptChannels(api27, P2pBandPreference.AUTO, chosenChannel = WifiP2pOperatingChannelPolicy.CHANNEL_UPPER),
         )
         assertEquals(
@@ -254,5 +299,62 @@ class WifiP2pOperatingChannelPolicyTest {
         // owner asked for one of those cannot start at all. Both channels here sit outside it.
         assertTrue(WifiP2pOperatingChannelPolicy.CHANNEL_LOWER < 52)
         assertTrue(WifiP2pOperatingChannelPolicy.CHANNEL_UPPER > 140)
+    }
+
+    // --- refusedEveryFiveGhzRung: the banner's question ---
+
+    @Test
+    fun `a pinned window refused to its last rung is what raises the banner`() {
+        val ladder = WifiP2pOperatingChannelPolicy.attemptChannels(
+            sdkInt = 28, preference = P2pBandPreference.FORCE_5GHZ, chosenChannel = 44
+        )
+        assertEquals(listOf(44, 36, 40, 48), ladder)
+        for (spent in 0..3) {
+            assertFalse(
+                "rung $spent of ${ladder.size} still to try",
+                WifiP2pOperatingChannelPolicy.refusedEveryFiveGhzRung(ladder, spent, 44)
+            )
+        }
+        assertTrue(WifiP2pOperatingChannelPolicy.refusedEveryFiveGhzRung(ladder, 4, 44))
+    }
+
+    @Test
+    fun `the 2_4 GHz rung under AUTO is not a 5 GHz refusal, and does not delay one`() {
+        val ladder = WifiP2pOperatingChannelPolicy.attemptChannels(
+            sdkInt = 28, preference = P2pBandPreference.AUTO, chosenChannel = 149
+        )
+        assertEquals(listOf(149, 153, 157, 161, WifiP2pOperatingChannelPolicy.CHANNEL_24_GHZ), ladder)
+        // Asked the moment the four 5 GHz rungs are spent, with 2.4 GHz still to come: the finding
+        // is about the band the setting names, not about the ladder running out.
+        assertFalse(WifiP2pOperatingChannelPolicy.refusedEveryFiveGhzRung(ladder, 3, 149))
+        assertTrue(WifiP2pOperatingChannelPolicy.refusedEveryFiveGhzRung(ladder, 4, 149))
+        assertTrue(WifiP2pOperatingChannelPolicy.refusedEveryFiveGhzRung(ladder, 5, 149))
+    }
+
+    @Test
+    fun `an automatic pin never raises it, however the ladder ends`() {
+        val ladder = WifiP2pOperatingChannelPolicy.attemptChannels(
+            sdkInt = 28, preference = P2pBandPreference.AUTO,
+            chosenChannel = WifiP2pOperatingChannelPolicy.CHANNEL_UNRESTRICTED
+        )
+        for (spent in 0..ladder.size + 1) {
+            assertFalse(
+                "spent $spent",
+                WifiP2pOperatingChannelPolicy.refusedEveryFiveGhzRung(
+                    ladder, spent, WifiP2pOperatingChannelPolicy.CHANNEL_UNRESTRICTED
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `a ladder with no 5 GHz rung cannot produce a 5 GHz refusal`() {
+        val ladder = WifiP2pOperatingChannelPolicy.attemptChannels(
+            sdkInt = 28, preference = P2pBandPreference.FORCE_2_4GHZ, chosenChannel = 44
+        )
+        assertEquals(listOf(WifiP2pOperatingChannelPolicy.CHANNEL_24_GHZ), ladder)
+        assertFalse(WifiP2pOperatingChannelPolicy.refusedEveryFiveGhzRung(ladder, 1, 44))
+        // The same holds for the empty ladder an Android 10+ device produces.
+        assertFalse(WifiP2pOperatingChannelPolicy.refusedEveryFiveGhzRung(emptyList(), 9, 44))
     }
 }

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/PokeOverlapPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/PokeOverlapPolicyTest.kt
@@ -1,0 +1,70 @@
+package com.andrerinas.openheadunit.connection.wifi.modes.nativeaa
+
+import com.andrerinas.openheadunit.connection.wifi.modes.nativeaa.PokeOverlapPolicy.Step
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PokeOverlapPolicyTest {
+
+    private val phone = "A0:46:5A:97:E4:95"
+    private val otherPhone = "B1:57:6B:A8:F5:06"
+
+    @Test
+    fun `nothing connecting, so the poke goes straight out`() {
+        assertEquals(Step.PROCEED, PokeOverlapPolicy.step(connectingTo = null, target = phone, waitedMs = 0))
+    }
+
+    @Test
+    fun `a connect to the same phone is waited for`() {
+        assertEquals(Step.WAIT, PokeOverlapPolicy.step(connectingTo = phone, target = phone, waitedMs = 0))
+    }
+
+    @Test
+    fun `case in an address does not decide it`() {
+        assertEquals(
+            Step.WAIT,
+            PokeOverlapPolicy.step(connectingTo = phone.lowercase(), target = phone, waitedMs = 0)
+        )
+    }
+
+    @Test
+    fun `a connect to another phone shares no channel, so it is not waited for`() {
+        assertEquals(
+            Step.PROCEED,
+            PokeOverlapPolicy.step(connectingTo = otherPhone, target = phone, waitedMs = 0)
+        )
+    }
+
+    @Test
+    fun `an unknown target is not matched against anything`() {
+        assertEquals(Step.PROCEED, PokeOverlapPolicy.step(connectingTo = phone, target = "", waitedMs = 0))
+    }
+
+    @Test
+    fun `the wait is bounded, so a stuck connect cannot hold the poke forever`() {
+        assertEquals(
+            Step.WAIT,
+            PokeOverlapPolicy.step(
+                connectingTo = phone,
+                target = phone,
+                waitedMs = PokeOverlapPolicy.CONNECT_SETTLE_WAIT_MS - 1
+            )
+        )
+        assertEquals(
+            Step.PROCEED,
+            PokeOverlapPolicy.step(
+                connectingTo = phone,
+                target = phone,
+                waitedMs = PokeOverlapPolicy.CONNECT_SETTLE_WAIT_MS
+            )
+        )
+    }
+
+    @Test
+    fun `the bound outlasts the measured HFP-AG refusal`() {
+        // The refusal that started the second connect took 3050ms on the reporter's pair.
+        assertTrue(PokeOverlapPolicy.CONNECT_SETTLE_WAIT_MS > 3_050L)
+        assertTrue(PokeOverlapPolicy.POLL_MS in 1..PokeOverlapPolicy.CONNECT_SETTLE_WAIT_MS)
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/PokeOverlapPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/PokeOverlapPolicyTest.kt
@@ -51,10 +51,42 @@ class PokeOverlapPolicyTest {
                 waitedMs = PokeOverlapPolicy.CONNECT_SETTLE_WAIT_MS - 1
             )
         )
+    }
+
+    @Test
+    fun `a connect still in flight after the whole wait is abandoned, not raced`() {
+        assertEquals(
+            Step.ABANDON,
+            PokeOverlapPolicy.step(
+                connectingTo = phone,
+                target = phone,
+                waitedMs = PokeOverlapPolicy.CONNECT_SETTLE_WAIT_MS
+            )
+        )
+        assertEquals(
+            Step.ABANDON,
+            PokeOverlapPolicy.step(
+                connectingTo = phone,
+                target = phone,
+                waitedMs = PokeOverlapPolicy.CONNECT_SETTLE_WAIT_MS * 10
+            )
+        )
+    }
+
+    @Test
+    fun `only the same phone is ever abandoned for`() {
         assertEquals(
             Step.PROCEED,
             PokeOverlapPolicy.step(
-                connectingTo = phone,
+                connectingTo = otherPhone,
+                target = phone,
+                waitedMs = PokeOverlapPolicy.CONNECT_SETTLE_WAIT_MS
+            )
+        )
+        assertEquals(
+            Step.PROCEED,
+            PokeOverlapPolicy.step(
+                connectingTo = null,
                 target = phone,
                 waitedMs = PokeOverlapPolicy.CONNECT_SETTLE_WAIT_MS
             )
@@ -62,9 +94,9 @@ class PokeOverlapPolicyTest {
     }
 
     @Test
-    fun `the bound outlasts the measured HFP-AG refusal`() {
-        // The refusal that started the second connect took 3050ms on the reporter's pair.
-        assertTrue(PokeOverlapPolicy.CONNECT_SETTLE_WAIT_MS > 3_050L)
+    fun `the bound outlasts a connect to a phone whose Bluetooth is off`() {
+        // That connect runs the full RFCOMM timeout: 15.40-15.46s, measured three times on the rig.
+        assertTrue(PokeOverlapPolicy.CONNECT_SETTLE_WAIT_MS > 15_460L)
         assertTrue(PokeOverlapPolicy.POLL_MS in 1..PokeOverlapPolicy.CONNECT_SETTLE_WAIT_MS)
     }
 }


### PR DESCRIPTION
## Why

- A pinned 5 GHz channel was only ever a request, so the group still landed wherever the driver chose.
- A channel the phone's region cannot scan looks exactly like a broken handshake: the phone answers everything, then never joins.
- Nothing told the user that had happened.
- `onCreate` armed WiFi Direct, the 5288 server and the BT poke before looking at the USB bus, so a plugged-in dongle got all of it raised and torn straight back down.

## What changed

**5 GHz channel selection** (`connection/wifi/direct/`)

- Walk the pinned channel across its whole window instead of trying it once.
- `WifiP2pOperatingChannelPolicy` now owns the attempt ladder and the refusal verdict, with tests.
- Clear a channel restriction the platform never confirmed.
- New `WifiCountryPolicy` names the unit's regulatory domain in logs.
- Log the channel type the phone asks for.

**Bring-up** (`connection/wifi/`, `aap/AapService.kt`)

- Leaving this unit's own WiFi network is now unconditional rather than a toggle, still bounded to the bring-up and reversed afterwards.
- Removes the `standDownStationForWifiDirect` setting and its UI row.
- New `WirelessBringUpDeferralPolicy`: a USB projection attempt in flight holds the wireless bring-up for up to 8s.

**User-facing**

- New `FIVE_GHZ_CHANNEL_REFUSED` banner: says the unit refused every 5 GHz channel offered and points at 2.4 GHz.
- Hint under the 5 GHz channel picker that a channel is a request, not a guarantee.
- Both new strings localized across all 20 locales.