### PR TITLE
Feat/automation command surface

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,30 @@ android {
 
     println("Detected available locales: $availableLocales")
 
+    // Which commit an APK was built from. versionName and versionCode do not move between two
+    // candidates of the same fix, so they cannot identify a build; this can. A "-dirty" suffix
+    // means the tree had uncommitted changes, which is the other thing worth knowing.
+    val gitDescription: String = try {
+        fun git(vararg args: String): String {
+            val process = ProcessBuilder(listOf("git") + args)
+                .directory(rootDir)
+                .redirectErrorStream(true)
+                .start()
+            val text = process.inputStream.bufferedReader().readText().trim()
+            return if (process.waitFor() == 0) text else ""
+        }
+        val sha = git("rev-parse", "--short=12", "HEAD")
+        when {
+            sha.isEmpty() -> "unknown"
+            git("status", "--porcelain").isNotEmpty() -> "$sha-dirty"
+            else -> sha
+        }
+    } catch (e: Exception) {
+        "unknown"
+    }
+
+    println("Building from commit: $gitDescription")
+
     sourceSets {
         getByName("main") {
             assets.srcDirs("${project.layout.buildDirectory.get().asFile}/generated/assets/root")
@@ -84,6 +108,7 @@ android {
         // Store available locales in BuildConfig for runtime access
         // This is scanned at build time from values-XX directories
         buildConfigField("String", "AVAILABLE_LOCALES", "\"${availableLocales.joinToString(",")}\"")
+        buildConfigField("String", "GIT_SHA", "\"$gitDescription\"")
 
         externalNativeBuild {
             cmake {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -239,6 +239,45 @@
 
         <!-- Handles proprietary headunit command intents (com.android.music.*,
              com.syu.*, etc). MEDIA_BUTTON is handled by MediaButtonReceiver above. -->
+        <!-- The command surface for automation tools and shell scripts. A receiver rather than
+             an activity because Tasker and MacroDroid can send to one without holding "Display
+             over other apps", which an activity target needs on Android 10+. The configuring
+             actions are refused unless the user turns on "Allow external configuration". -->
+        <receiver
+            android:name=".automation.AutomationReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.andrerinas.openheadunit.ACTION_CONNECT" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_DISCONNECT" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_START_SELF_MODE" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_STOP_SERVICE" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_EXIT" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_SET_NIGHT_MODE" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_START_WIRELESS" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_STOP_WIRELESS" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_START_WIRELESS_SCAN" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_NATIVE_AA_POKE" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_NATIVE_AA_CANCEL_POKE" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_NEARBY_CONNECT" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_CHECK_USB" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_REFRESH_SENSORS" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_RESTART_AUDIO" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_RAISE_PROJECTION" />
+                <action android:name="com.andrerinas.openheadunit.aap.action.REFRESH_SENSORS" />
+                <action android:name="com.andrerinas.openheadunit.aap.action.RESTART_AUDIO" />
+                <action android:name="com.andrerinas.openheadunit.aap.action.RAISE_PROJECTION" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_QUERY_STATE" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_SET_SETTINGS" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_GET_SETTINGS" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_RESET_SETTINGS" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_SET_LOG_LEVEL" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_START_LOG_CAPTURE" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_STOP_LOG_CAPTURE" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_EXPORT_LOG" />
+                <action android:name="com.andrerinas.openheadunit.ACTION_LOG_MARKER" />
+            </intent-filter>
+        </receiver>
+
         <receiver
             android:name=".app.RemoteControlReceiver"
             android:exported="true">

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -65,6 +65,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.SystemClock
+import com.andrerinas.openheadunit.contract.SessionStateIntent
 import android.app.NotificationManager
 import android.graphics.PixelFormat
 import android.media.AudioAttributes
@@ -242,6 +243,15 @@ class AapService : Service() {
      */
     private var isDestroying = false
     private var hasEverConnected = false
+
+    /**
+     * Set by a `no_ui` automation command, which asks for the session without the screen.
+     * Consumed by the next raise only, so an ordinary reconnect still comes to the front.
+     */
+    @Volatile private var suppressNextProjectionRaise = false
+
+    /** When the live session started projecting, for [SessionStateIntent.EXTRA_UPTIME_MS]. */
+    @Volatile private var projectingSinceMs = 0L
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
     private var wifiLock: WifiManager.WifiLock? = null
 
@@ -911,6 +921,10 @@ class AapService : Service() {
         StationStandDown.restore(this)
         setupCarMode()
         setupNightMode()
+        commManager.onSessionFailure = { reason ->
+            emitSessionState(SessionStateIntent.STATE_FAILED, reason)
+            projectingSinceMs = 0L
+        }
         observeConnectionState()
         registerReceivers()
 
@@ -981,6 +995,30 @@ class AapService : Service() {
     }
 
     /**
+     * Tells automation tools what the session is doing. Implicit and unguarded, because automation
+     * apps cannot hold an app-declared permission; it carries no credentials and never names the phone.
+     */
+    private fun emitSessionState(state: String, reason: String = SessionStateIntent.REASON_NONE) {
+        // isLoopbackSession, not selfLauncherManager.isActive: the launcher flag is set before the
+        // launchers run and outlives a launch that never connected, which is exactly the state this
+        // reports on. A loopback session is a socket session too, so it has to be asked first.
+        val transport = when {
+            commManager.isLoopbackSession -> "self"
+            commManager.isWirelessSession -> "wifi"
+            commManager.isConnected -> "usb"
+            else -> "unknown"
+        }
+        val uptime =
+            if (projectingSinceMs == 0L) 0L else SystemClock.elapsedRealtime() - projectingSinceMs
+        AppLog.i("AapService: session state $state${if (reason.isEmpty()) "" else " ($reason)"}")
+        try {
+            sendBroadcast(SessionStateIntent(state, transport, reason, uptime))
+        } catch (e: Exception) {
+            AppLog.w("AapService: could not broadcast session state: ${e.message}")
+        }
+    }
+
+    /**
      * Single observer for all [CommManager.ConnectionState] transitions.
      *
      * Uses [hasEverConnected] to skip the initial [ConnectionState.Disconnected] emission
@@ -990,8 +1028,11 @@ class AapService : Service() {
         serviceScope.launch {
             commManager.connectionState.collect { state ->
                 when (state) {
+                    is CommManager.ConnectionState.Connecting ->
+                        emitSessionState(SessionStateIntent.STATE_CONNECTING)
                     is CommManager.ConnectionState.Connected -> {
                         sessionConnectedAt = SystemClock.elapsedRealtime()
+                        emitSessionState(SessionStateIntent.STATE_CONNECTED)
                         onConnected()
                     }
                     is CommManager.ConnectionState.HandshakeComplete -> {
@@ -999,7 +1040,9 @@ class AapService : Service() {
                     }
                     is CommManager.ConnectionState.TransportStarted -> {
                         hasEverConnected = true
+                        projectingSinceMs = SystemClock.elapsedRealtime()
                         usbLauncherManager.projectionHandshakeFailures = 0
+                        emitSessionState(SessionStateIntent.STATE_PROJECTING)
                         sendBroadcast(Intent(ACTION_REQUEST_NIGHT_MODE_UPDATE).apply {
                             setPackage(packageName)
                         })
@@ -1019,7 +1062,18 @@ class AapService : Service() {
                         }
                     }
                     is CommManager.ConnectionState.Disconnected -> {
-                        if (hasEverConnected) onDisconnected(state)
+                        if (hasEverConnected) {
+                            emitSessionState(
+                                SessionStateIntent.STATE_DISCONNECTED,
+                                when {
+                                    state.isUserExit -> SessionStateIntent.REASON_USER_EXIT
+                                    !state.isClean -> SessionStateIntent.REASON_LINK_LOST
+                                    else -> SessionStateIntent.REASON_PHONE_LEFT
+                                }
+                            )
+                            projectingSinceMs = 0L
+                            onDisconnected(state)
+                        }
                     }
                     else -> {}
                 }
@@ -1249,6 +1303,12 @@ class AapService : Service() {
     private fun launchAapProjectionActivity(allowNotificationFallback: Boolean = true) {
         if (App.isPiPActive) {
             AppLog.i("AapService: Skipping projection launch because PiP is active")
+            return
+        }
+
+        if (suppressNextProjectionRaise) {
+            suppressNextProjectionRaise = false
+            AppLog.i("AapService: Not raising the projection, a no_ui command asked for the session only")
             return
         }
 
@@ -2243,6 +2303,12 @@ class AapService : Service() {
             return START_NOT_STICKY
         }
 
+        // An automation command may ask for the session without the screen; latch it before any
+        // branch below can reach a raise.
+        if (intent?.getBooleanExtra(EXTRA_NO_UI, false) == true) {
+            suppressNextProjectionRaise = true
+        }
+
         // Handle stop before re-posting the notification to avoid a flash
         if (intent?.action == ACTION_STOP_SERVICE) {
             AppLog.i("Stop action received. Broadcasting finish request to activities.")
@@ -2850,6 +2916,8 @@ class AapService : Service() {
          *  60 seconds filters out normal screen timeouts while catching any hibernate/quick boot. */
         private const val HIBERNATE_WAKE_THRESHOLD_MS = 60_000L
 
+        /** Ask for the session without raising the projection. See [suppressNextProjectionRaise]. */
+        const val EXTRA_NO_UI = "no_ui"
         const val EXTRA_MAC = "extra_mac"
         const val EXTRA_ENDPOINT_ID = "extra_endpoint_id"
     }

--- a/app/src/main/java/com/andrerinas/openheadunit/automation/AutomationCommandPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/automation/AutomationCommandPolicy.kt
@@ -1,0 +1,194 @@
+package com.andrerinas.openheadunit.automation
+
+import com.andrerinas.openheadunit.aap.AapService
+import com.andrerinas.openheadunit.contract.HeadUnitCommand
+
+/**
+ * Decides what an incoming automation command should do. The receiver and the deep-link activity
+ * both run the effects this returns, so the two doors cannot answer the same command differently.
+ */
+object AutomationCommandPolicy {
+
+    /** The subset of an `Intent` a command can read. Abstract so a test can pass a plain map. */
+    interface Extras {
+        fun string(key: String): String?
+        fun flag(key: String): Boolean
+    }
+
+    /** The parts of the app's state that change what a command does. */
+    data class State(
+        /** "Allow external configuration" — off by default, and gates every configuring verb. */
+        val externalConfigAllowed: Boolean
+    )
+
+    sealed interface Effect {
+        /** Send [action] to [AapService]. */
+        data class StartService(
+            val action: String,
+            val stringExtras: Map<String, String> = emptyMap(),
+            val flagExtras: Map<String, Boolean> = emptyMap()
+        ) : Effect
+
+        /** Open a TCP session to a head unit server. Paired with a [StartService] of the same name. */
+        data class ConnectSocket(val ip: String, val port: Int) : Effect
+
+        data class SetNightMode(val mode: String) : Effect
+
+        data class ImportSettings(val json: String?, val path: String?) : Effect
+        data class ExportSettings(val path: String?) : Effect
+        object ResetSettings : Effect
+
+        data class SetLogLevel(val level: String) : Effect
+        object StartLogCapture : Effect
+        object StopLogCapture : Effect
+        data class ExportLog(val path: String?) : Effect
+        data class LogMarker(val text: String) : Effect
+
+        object QueryState : Effect
+
+        /** Nothing was done, and [reason] says why. Reported back on the ordered-broadcast result. */
+        data class Refuse(val reason: String) : Effect
+    }
+
+    /** Port of Android Auto's built-in head unit server, which is what an `ip` command targets. */
+    const val HEADUNIT_SERVER_PORT = 5277
+
+    private val NIGHT_MODES = setOf("day", "night", "auto")
+
+    private val LOG_LEVELS = setOf("verbose", "debug", "info", "warn", "error", "silent")
+
+    /**
+     * Verbs that rewrite the unit's configuration or drive the log capture. Writing a log marker is
+     * not one: it reads and changes nothing, and gating it made it useless for the job it exists
+     * for, which is separating two runs inside one capture before the switch is ever turned on.
+     */
+    private val CONFIGURING = setOf(
+        HeadUnitCommand.ACTION_SET_SETTINGS,
+        HeadUnitCommand.ACTION_GET_SETTINGS,
+        HeadUnitCommand.ACTION_RESET_SETTINGS,
+        HeadUnitCommand.ACTION_SET_LOG_LEVEL,
+        HeadUnitCommand.ACTION_START_LOG_CAPTURE,
+        HeadUnitCommand.ACTION_STOP_LOG_CAPTURE,
+        HeadUnitCommand.ACTION_EXPORT_LOG
+    )
+
+    /** Commands that need no extras and map straight onto a service action. */
+    private val PLAIN_RELAYS = mapOf(
+        HeadUnitCommand.ACTION_DISCONNECT to AapService.ACTION_DISCONNECT,
+        HeadUnitCommand.ACTION_STOP_SERVICE to AapService.ACTION_STOP_SERVICE,
+        HeadUnitCommand.ACTION_EXIT to AapService.ACTION_STOP_SERVICE,
+        HeadUnitCommand.ACTION_START_WIRELESS to AapService.ACTION_START_WIRELESS,
+        HeadUnitCommand.ACTION_STOP_WIRELESS to AapService.ACTION_STOP_WIRELESS,
+        HeadUnitCommand.ACTION_START_WIRELESS_SCAN to AapService.ACTION_START_WIRELESS_SCAN,
+        HeadUnitCommand.ACTION_CHECK_USB to AapService.ACTION_CHECK_USB,
+        HeadUnitCommand.ACTION_REFRESH_SENSORS to AapService.ACTION_REFRESH_SENSORS,
+        HeadUnitCommand.ACTION_RESTART_AUDIO to AapService.ACTION_RESTART_AUDIO,
+        HeadUnitCommand.ACTION_RAISE_PROJECTION to AapService.ACTION_RAISE_PROJECTION,
+        // Relayed by its own name rather than an AapService constant: the handler ships with the
+        // driver-selection feature, and the two strings are the same either way.
+        HeadUnitCommand.ACTION_NATIVE_AA_CANCEL_POKE to HeadUnitCommand.ACTION_NATIVE_AA_CANCEL_POKE,
+        // These three were the internal service actions before this surface existed, so both
+        // spellings are answered: the documented one, and the one already in people's scripts.
+        HeadUnitCommand.LEGACY_ACTION_REFRESH_SENSORS to AapService.ACTION_REFRESH_SENSORS,
+        HeadUnitCommand.LEGACY_ACTION_RESTART_AUDIO to AapService.ACTION_RESTART_AUDIO,
+        HeadUnitCommand.LEGACY_ACTION_RAISE_PROJECTION to AapService.ACTION_RAISE_PROJECTION
+    )
+
+    fun effectsFor(action: String?, extras: Extras, state: State): List<Effect> {
+        if (action == null) return listOf(Effect.Refuse("no action"))
+
+        if (action in CONFIGURING && !state.externalConfigAllowed) {
+            return listOf(
+                Effect.Refuse("external configuration is off; turn on \"Allow external configuration\" in Settings")
+            )
+        }
+
+        PLAIN_RELAYS[action]?.let { return listOf(Effect.StartService(it)) }
+
+        return when (action) {
+            HeadUnitCommand.ACTION_CONNECT -> connect(extras)
+            HeadUnitCommand.ACTION_START_SELF_MODE -> listOf(
+                Effect.StartService(
+                    AapService.ACTION_START_SELF_MODE,
+                    flagExtras = mapOf(AapService.EXTRA_NO_UI to extras.flag(HeadUnitCommand.EXTRA_NO_UI))
+                )
+            )
+            HeadUnitCommand.ACTION_SET_NIGHT_MODE -> nightMode(extras)
+            HeadUnitCommand.ACTION_NATIVE_AA_POKE -> requiring(extras, HeadUnitCommand.EXTRA_MAC) { mac ->
+                Effect.StartService(
+                    AapService.ACTION_NATIVE_AA_POKE,
+                    stringExtras = mapOf(AapService.EXTRA_MAC to mac)
+                )
+            }
+            HeadUnitCommand.ACTION_NEARBY_CONNECT -> requiring(extras, HeadUnitCommand.EXTRA_ENDPOINT_ID) { id ->
+                Effect.StartService(
+                    AapService.ACTION_NEARBY_CONNECT,
+                    stringExtras = mapOf(AapService.EXTRA_ENDPOINT_ID to id)
+                )
+            }
+            HeadUnitCommand.ACTION_QUERY_STATE -> listOf(Effect.QueryState)
+
+            HeadUnitCommand.ACTION_SET_SETTINGS -> settingsImport(extras)
+            HeadUnitCommand.ACTION_GET_SETTINGS ->
+                listOf(Effect.ExportSettings(extras.string(HeadUnitCommand.EXTRA_PATH)))
+            HeadUnitCommand.ACTION_RESET_SETTINGS -> listOf(Effect.ResetSettings)
+            HeadUnitCommand.ACTION_SET_LOG_LEVEL -> logLevel(extras)
+            HeadUnitCommand.ACTION_START_LOG_CAPTURE -> listOf(Effect.StartLogCapture)
+            HeadUnitCommand.ACTION_STOP_LOG_CAPTURE -> listOf(Effect.StopLogCapture)
+            HeadUnitCommand.ACTION_EXPORT_LOG ->
+                listOf(Effect.ExportLog(extras.string(HeadUnitCommand.EXTRA_PATH)))
+            HeadUnitCommand.ACTION_LOG_MARKER -> requiring(extras, HeadUnitCommand.EXTRA_TEXT) {
+                Effect.LogMarker(it)
+            }
+
+            else -> listOf(Effect.Refuse("unknown action $action"))
+        }
+    }
+
+    /**
+     * With an address this opens a TCP session to Android Auto's head unit server; without one it
+     * means "connect to whatever is there", which is the USB check.
+     */
+    private fun connect(extras: Extras): List<Effect> {
+        val ip = extras.string(HeadUnitCommand.EXTRA_IP)?.trim()
+        if (ip.isNullOrEmpty()) return listOf(Effect.StartService(AapService.ACTION_CHECK_USB))
+        return listOf(
+            Effect.StartService(
+                AapService.ACTION_CONNECT_SOCKET,
+                flagExtras = mapOf(AapService.EXTRA_NO_UI to extras.flag(HeadUnitCommand.EXTRA_NO_UI))
+            ),
+            Effect.ConnectSocket(ip, HEADUNIT_SERVER_PORT)
+        )
+    }
+
+    private fun nightMode(extras: Extras): List<Effect> {
+        val mode = extras.string(HeadUnitCommand.EXTRA_STATE)?.lowercase()
+        if (mode !in NIGHT_MODES) {
+            return listOf(Effect.Refuse("state must be one of ${NIGHT_MODES.joinToString("/")}"))
+        }
+        return listOf(Effect.SetNightMode(mode!!))
+    }
+
+    private fun logLevel(extras: Extras): List<Effect> {
+        val level = extras.string(HeadUnitCommand.EXTRA_LEVEL)?.lowercase()
+        if (level !in LOG_LEVELS) {
+            return listOf(Effect.Refuse("level must be one of ${LOG_LEVELS.joinToString("/")}"))
+        }
+        return listOf(Effect.SetLogLevel(level!!))
+    }
+
+    private fun settingsImport(extras: Extras): List<Effect> {
+        val json = extras.string(HeadUnitCommand.EXTRA_JSON)
+        val path = extras.string(HeadUnitCommand.EXTRA_PATH)
+        if (json.isNullOrBlank() && path.isNullOrBlank()) {
+            return listOf(Effect.Refuse("one of json or path is required"))
+        }
+        return listOf(Effect.ImportSettings(json, path))
+    }
+
+    private fun requiring(extras: Extras, key: String, build: (String) -> Effect): List<Effect> {
+        val value = extras.string(key)?.trim()
+        if (value.isNullOrEmpty()) return listOf(Effect.Refuse("$key is required"))
+        return listOf(build(value))
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/automation/AutomationEffectRunner.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/automation/AutomationEffectRunner.kt
@@ -1,0 +1,213 @@
+package com.andrerinas.openheadunit.automation
+
+import android.content.Context
+import android.content.Intent
+import android.os.Environment
+import androidx.core.content.ContextCompat
+import com.andrerinas.openheadunit.App
+import com.andrerinas.openheadunit.AppComponent
+import com.andrerinas.openheadunit.BuildConfig
+import com.andrerinas.openheadunit.aap.AapService
+import com.andrerinas.openheadunit.utils.AppLog
+import com.andrerinas.openheadunit.utils.LogExporter
+import com.andrerinas.openheadunit.utils.Settings
+import com.andrerinas.openheadunit.utils.SettingsBackupManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.json.JSONObject
+import java.io.File
+
+/**
+ * Carries out what [AutomationCommandPolicy] decided. Shared by [AutomationReceiver] and the
+ * deep-link activity so the two entry points cannot answer the same command differently.
+ */
+object AutomationEffectRunner {
+
+    /** Runs [effects], filling [reply] with anything worth reporting. Returns false if any refused. */
+    fun run(context: Context, effects: List<AutomationCommandPolicy.Effect>, reply: JSONObject): Boolean {
+        val component = App.provide(context)
+        var ok = true
+
+        for (effect in effects) {
+            when (effect) {
+                is AutomationCommandPolicy.Effect.Refuse -> {
+                    ok = false
+                    reply.put("error", effect.reason)
+                    AppLog.w("Automation: refused - ${effect.reason}")
+                }
+                is AutomationCommandPolicy.Effect.StartService -> startService(context, effect)
+                is AutomationCommandPolicy.Effect.ConnectSocket ->
+                    CoroutineScope(Dispatchers.IO).launch {
+                        component.commManager.connect(effect.ip, effect.port)
+                    }
+                is AutomationCommandPolicy.Effect.SetNightMode ->
+                    setNightMode(context, component.settings, effect.mode)
+                is AutomationCommandPolicy.Effect.ImportSettings -> importSettings(context, effect, reply)
+                is AutomationCommandPolicy.Effect.ExportSettings ->
+                    if (!exportSettings(context, effect, reply)) ok = false
+                AutomationCommandPolicy.Effect.ResetSettings ->
+                    reply.put("reset", SettingsBackupManager.resetFromContext(context).resetKeys)
+                is AutomationCommandPolicy.Effect.SetLogLevel -> {
+                    component.settings.exporterLogLevel = logLevelOf(effect.level)
+                    reply.put("level", effect.level)
+                }
+                AutomationCommandPolicy.Effect.StartLogCapture ->
+                    LogExporter.startCapture(context, component.settings.exporterLogLevel)
+                AutomationCommandPolicy.Effect.StopLogCapture -> LogExporter.stopCapture()
+                is AutomationCommandPolicy.Effect.ExportLog ->
+                    if (!exportLog(context, component.settings, effect, reply)) ok = false
+                is AutomationCommandPolicy.Effect.LogMarker ->
+                    // One fixed shape, so two arms of a test round can share a capture and still be
+                    // told apart. WARN so it survives an INFO-filtered export.
+                    AppLog.w("AutomationMarker: ${effect.text}")
+                AutomationCommandPolicy.Effect.QueryState -> putState(component, reply)
+            }
+        }
+        return ok
+    }
+
+    private fun startService(context: Context, effect: AutomationCommandPolicy.Effect.StartService) {
+        ContextCompat.startForegroundService(
+            context,
+            Intent(context, AapService::class.java).apply {
+                action = effect.action
+                effect.stringExtras.forEach { (k, v) -> putExtra(k, v) }
+                effect.flagExtras.forEach { (k, v) -> putExtra(k, v) }
+            }
+        )
+    }
+
+    private fun setNightMode(context: Context, settings: Settings, mode: String) {
+        settings.nightMode = when (mode) {
+            "day" -> Settings.NightMode.DAY
+            "night" -> Settings.NightMode.NIGHT
+            else -> Settings.NightMode.AUTO
+        }
+        ContextCompat.startForegroundService(
+            context,
+            Intent(context, AapService::class.java).apply {
+                action = AapService.ACTION_REQUEST_NIGHT_MODE_UPDATE
+            }
+        )
+    }
+
+    private fun importSettings(
+        context: Context,
+        effect: AutomationCommandPolicy.Effect.ImportSettings,
+        reply: JSONObject
+    ) {
+        val result = if (!effect.json.isNullOrBlank()) {
+            SettingsBackupManager.importFromJson(context, effect.json)
+        } else {
+            SettingsBackupManager.importFromFile(context, File(effect.path!!))
+        }
+        reply.put("imported", result.importedKeys)
+            .put("skipped", result.skippedKeys)
+            .put("restartNeeded", SettingsBackupManager.requiresProjectionRestart(result.changedKeys))
+    }
+
+    private fun exportSettings(
+        context: Context,
+        effect: AutomationCommandPolicy.Effect.ExportSettings,
+        reply: JSONObject
+    ): Boolean {
+        val exported = JSONObject(SettingsBackupManager.exportFromContext(context))
+        val withheld = redact(exported)
+
+        if (effect.path.isNullOrBlank()) {
+            reply.put("settings", exported)
+        } else {
+            if (!AutomationOutputPolicy.mayWriteTo(effect.path, writableRoots(context), externalStorageRoot())) {
+                reply.put("error", AutomationOutputPolicy.writeRefusedReason(effect.path))
+                return false
+            }
+            reply.put(
+                "file",
+                SettingsBackupManager.writeBackupFile(File(effect.path), exported.toString()).absolutePath
+            )
+        }
+        if (withheld > 0) reply.put("withheld", withheld)
+        return true
+    }
+
+    /**
+     * Strips the credential-bearing settings out of an export, in place, returning how many went.
+     * The count is reported so a partial export is not mistaken for unset keys.
+     */
+    private fun redact(exported: JSONObject): Int {
+        val settings = exported.optJSONObject("settings") ?: return 0
+        var withheld = 0
+        for (key in AutomationOutputPolicy.WITHHELD_KEYS) {
+            if (settings.has(key)) {
+                settings.remove(key)
+                withheld++
+            }
+        }
+        return withheld
+    }
+
+    /** Where an export may land: collected off the device, never back into the app's own storage. */
+    private fun writableRoots(context: Context): List<String> = listOfNotNull(
+        context.getExternalFilesDir(null)?.absolutePath,
+        @Suppress("DEPRECATION")
+        Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)?.absolutePath
+    )
+
+    /** What `/sdcard` and friends actually point at on this device, or null if it is unavailable. */
+    @Suppress("DEPRECATION")
+    private fun externalStorageRoot(): String? =
+        runCatching { Environment.getExternalStorageDirectory()?.absolutePath }.getOrNull()
+
+    private fun exportLog(
+        context: Context,
+        settings: Settings,
+        effect: AutomationCommandPolicy.Effect.ExportLog,
+        reply: JSONObject
+    ): Boolean {
+        val target = effect.path
+        if (!target.isNullOrBlank() &&
+            !AutomationOutputPolicy.mayWriteTo(target, writableRoots(context), externalStorageRoot())
+        ) {
+            reply.put("error", AutomationOutputPolicy.writeRefusedReason(target))
+            return false
+        }
+        // The save suspends and a receiver must not block, so the reply says where to look rather
+        // than waiting for the write.
+        CoroutineScope(Dispatchers.IO).launch {
+            val file = LogExporter.saveLogToPublicFile(context, settings.exporterLogLevel)
+            if (file != null && !target.isNullOrBlank()) {
+                runCatching { file.copyTo(File(target), overwrite = true) }
+                    .onFailure { AppLog.w("Automation: could not copy the log to $target: ${it.message}") }
+            }
+            AppLog.i("Automation: log export finished (${file?.absolutePath ?: "no file"})")
+        }
+        reply.put("exporting", true)
+        return true
+    }
+
+    /**
+     * The answer to "which build is this, and what is it doing" in one call. The commit is what
+     * makes it useful: version name and code do not move between two candidates of the same fix.
+     */
+    private fun putState(component: AppComponent, reply: JSONObject) {
+        val comm = component.commManager
+        reply.put("versionName", BuildConfig.VERSION_NAME)
+            .put("versionCode", BuildConfig.VERSION_CODE)
+            .put("commit", BuildConfig.GIT_SHA)
+            .put("flavor", BuildConfig.FLAVOR)
+            .put("connected", comm.isConnected)
+            .put("wireless", comm.isWirelessSession)
+            .put("wifiMode", component.settings.wifiConnectionMode.toString())
+            .put("state", comm.connectionState.value.let { it::class.java.simpleName })
+    }
+
+    private fun logLevelOf(level: String) = when (level) {
+        "verbose" -> LogExporter.LogLevel.VERBOSE
+        "debug" -> LogExporter.LogLevel.DEBUG
+        "info" -> LogExporter.LogLevel.INFO
+        "warn" -> LogExporter.LogLevel.WARNING
+        "error" -> LogExporter.LogLevel.ERROR
+        else -> LogExporter.LogLevel.SILENT
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/automation/AutomationOutputPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/automation/AutomationOutputPolicy.kt
@@ -1,0 +1,75 @@
+package com.andrerinas.openheadunit.automation
+
+/**
+ * Guards what a configuring command may hand out or write. "Allow external configuration" is one
+ * switch that stays on once turned on, so it decides whether the door opens and this decides what
+ * may go through it.
+ */
+object AutomationOutputPolicy {
+
+    /**
+     * Settings withheld from an exported copy: the AP passphrase in clear text, and the keys naming
+     * the car's network and the phones paired to it. Reading these needs a shell and settings.xml.
+     */
+    val WITHHELD_KEYS = setOf(
+        "hotspot-password",
+        "hotspot-ssid",
+        "auto-start-wifi-ssid",
+        "auto-start-bt-macs",
+        "auto-start-bt-name",
+        "auto-disconnect-bt-macs",
+        "native-poke-bt-macs",
+        "static-bssid"
+    )
+
+    /** Directory names an automation command may write into, relative to external storage. */
+    private const val LOG_DIR = "OpenHeadunitLogs"
+
+    /**
+     * Whether [path] is somewhere a command may write. The write runs with the app's own privileges,
+     * so an unconstrained path would let a caller put chosen bytes into private storage. Only places
+     * an export can be collected from pass: [allowedRoots], or [LOG_DIR] under one.
+     */
+    fun mayWriteTo(
+        path: String,
+        allowedRoots: List<String>,
+        externalStorageRoot: String? = null
+    ): Boolean {
+        val normalized = canonicalize(normalize(path) ?: return false, externalStorageRoot)
+        // A path that climbs out of an allowed root must not pass because it started inside one.
+        if (normalized.contains("/../") || normalized.endsWith("/..")) return false
+
+        return allowedRoots.filter { it.isNotBlank() }.any { root ->
+            val normalizedRoot = normalize(root)?.trimEnd('/') ?: return@any false
+            normalized.startsWith("$normalizedRoot/")
+        }
+    }
+
+    /** Symlinks Android keeps to primary external storage; a caller may reasonably use any of them. */
+    val EXTERNAL_STORAGE_ALIASES = listOf("/sdcard", "/mnt/sdcard", "/storage/self/primary")
+
+    /** The reason [mayWriteTo] gives when it refuses, phrased for whoever sent the command. */
+    fun writeRefusedReason(path: String): String =
+        "$path is not a directory this app may write to; use the app's Downloads or files directory"
+
+    private fun normalize(path: String): String? {
+        val trimmed = path.trim()
+        if (trimmed.isEmpty() || !trimmed.startsWith("/")) return null
+        return trimmed.replace(Regex("/+"), "/")
+    }
+
+    /**
+     * Rewrites a primary-external-storage symlink onto the real path the roots are expressed in.
+     * Without this the everyday `/sdcard/Download/...` is refused, which fails safe but reads as
+     * a bug to whoever typed it.
+     */
+    private fun canonicalize(path: String, externalStorageRoot: String?): String {
+        val root = externalStorageRoot?.let { normalize(it) }?.trimEnd('/')
+        if (root.isNullOrEmpty()) return path
+        for (alias in EXTERNAL_STORAGE_ALIASES) {
+            if (path == alias) return root
+            if (path.startsWith("$alias/")) return root + path.removePrefix(alias)
+        }
+        return path
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/automation/AutomationReceiver.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/automation/AutomationReceiver.kt
@@ -1,0 +1,49 @@
+package com.andrerinas.openheadunit.automation
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.andrerinas.openheadunit.App
+import com.andrerinas.openheadunit.utils.AppLog
+import org.json.JSONObject
+
+/**
+ * The app's command surface for automation tools and shell scripts. A receiver rather than an
+ * activity because a broadcast needs no "Display over other apps"; `AutomationActivity` is the same
+ * vocabulary for deep links. Replies land on the ordered-broadcast result, so `am` prints `data=`;
+ * a sender that cannot send ordered reads state from `SessionStateIntent` instead.
+ */
+class AutomationReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val action = intent.action
+        AppLog.i("AutomationReceiver: $action")
+
+        val effects = AutomationCommandPolicy.effectsFor(
+            action,
+            IntentExtras(intent),
+            AutomationCommandPolicy.State(
+                externalConfigAllowed = App.provide(context).settings.allowExternalConfiguration
+            )
+        )
+
+        val reply = JSONObject().put("action", action ?: "")
+
+        val ok = try {
+            AutomationEffectRunner.run(context, effects, reply)
+        } catch (e: Exception) {
+            reply.put("error", e.message ?: e.javaClass.simpleName)
+            AppLog.e("AutomationReceiver: $action failed: ${e.message}", e)
+            false
+        }
+
+        reply.put("ok", ok)
+        // Answered inline, not through goAsync(): that detaches the pending result and setResultData
+        // then throws. The two background effects are best effort either way, and every command that
+        // matters starts a foreground service that keeps the process up.
+        if (isOrderedBroadcast) {
+            resultCode = if (ok) 0 else 1
+            resultData = reply.toString()
+        }
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/automation/IntentExtras.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/automation/IntentExtras.kt
@@ -1,0 +1,23 @@
+package com.andrerinas.openheadunit.automation
+
+import android.content.Intent
+
+/**
+ * Reads command arguments off an `Intent`, with [overrides] taking precedence. The overrides carry a
+ * deep link's query parameters, which are not extras but mean the same thing, so a command reads its
+ * arguments identically however it arrives.
+ */
+class IntentExtras(
+    private val intent: Intent,
+    private val overrides: Map<String, String> = emptyMap()
+) : AutomationCommandPolicy.Extras {
+
+    override fun string(key: String): String? = overrides[key] ?: intent.getStringExtra(key)
+
+    // `am broadcast --ez` gives a real boolean and Tasker's Send Intent gives the string "true";
+    // accept both rather than making the caller know which tool they are in.
+    override fun flag(key: String): Boolean =
+        overrides[key]?.lowercase() == "true" ||
+            intent.getBooleanExtra(key, false) ||
+            intent.getStringExtra(key)?.lowercase() == "true"
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
@@ -174,6 +174,13 @@ class CommManager(
     /** The endpoint [silentPeerFailures] is counting; a different one starts its own streak. */
     @Volatile private var silentPeerEndpoint: String? = null
     var onUpdateUiConfigReplyReceived: (() -> Unit)? = null
+
+    /**
+     * Called where a failure is discovered, not from a [connectionState] collector.
+     * [ConnectionState.Error] never reaches one: the flow is conflated and a synchronous
+     * `disconnect()` follows the emit, so the value has moved on before any collector resumes.
+     */
+    var onSessionFailure: ((reason: String) -> Unit)? = null
     @Volatile private var _connection: ProjectionConnection? = null
 
     /**
@@ -275,6 +282,7 @@ class CommManager(
 
         val usbManager = context.getSystemService(Context.USB_SERVICE) as UsbManager
         if (!usbManager.hasPermission(device)) {
+            onSessionFailure?.invoke("connect_failed")
             _connectionState.emit(ConnectionState.Error("USB permission not granted for device"))
             return@withContext
         }
@@ -300,6 +308,7 @@ class CommManager(
                 _connectionState.emit(ConnectionState.Disconnected())
             }
         } catch (e: Exception) {
+            onSessionFailure?.invoke("connect_failed")
             _connectionState.emit(ConnectionState.Error("Connection failed: ${e.message}"))
             disconnect()
         }
@@ -350,6 +359,7 @@ class CommManager(
                 _connectionState.emit(ConnectionState.Disconnected())
             }
         } catch (e: Exception) {
+            onSessionFailure?.invoke("connect_failed")
             _connectionState.emit(ConnectionState.Error("Connection failed: ${e.message}"))
             disconnect()
         }
@@ -381,6 +391,7 @@ class CommManager(
                 _connectionState.emit(ConnectionState.Disconnected())
             }
         } catch (e: Exception) {
+            onSessionFailure?.invoke("connect_failed")
             _connectionState.emit(ConnectionState.Error("Connection failed: ${e.message}"))
             disconnect()
         }
@@ -451,18 +462,21 @@ class CommManager(
                 } else {
                     val silent = transport?.lastHandshakeFailure == AapTransport.HandshakeFailure.PEER_SILENT
                     noteHandshakeOutcome(silent)
+                    onSessionFailure?.invoke(if (silent) "peer_silent" else "handshake_failed")
                     _connectionState.emit(
                         ConnectionState.Error(if (silent) ERROR_HANDSHAKE_PEER_SILENT else "Handshake failed")
                     )
                     disconnect()
                 }
             } else {
+                onSessionFailure?.invoke("handshake_failed")
                 _connectionState.emit(ConnectionState.Error("Starting handshake without connection"))
             }
         } catch (e: Exception) {
             // An exception is never the silent-peer case; clear the streak rather than leaving it
             // to age into a backoff that no longer describes what is happening.
             noteHandshakeOutcome(silent = false)
+            onSessionFailure?.invoke("handshake_failed")
             _connectionState.emit(ConnectionState.Error("Handshake failed: ${e.message}"))
             disconnect()
         }

--- a/app/src/main/java/com/andrerinas/openheadunit/main/AutomationActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/AutomationActivity.kt
@@ -1,147 +1,87 @@
 package com.andrerinas.openheadunit.main
 
-import android.os.Bundle
 import android.content.Intent
-import android.os.Build
+import android.net.Uri
+import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
-import androidx.lifecycle.lifecycleScope
 import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.aap.AapProjectionActivity
-import com.andrerinas.openheadunit.aap.AapService
+import com.andrerinas.openheadunit.automation.AutomationCommandPolicy
+import com.andrerinas.openheadunit.automation.AutomationEffectRunner
+import com.andrerinas.openheadunit.automation.IntentExtras
+import com.andrerinas.openheadunit.contract.HeadUnitCommand
 import com.andrerinas.openheadunit.utils.AppLog
-import com.andrerinas.openheadunit.utils.Settings
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import org.json.JSONObject
 
 /**
- * A transparent activity that handles App Shortcuts and Deep Links.
- * It translates incoming intents into service actions for AapService.
+ * Handles App Shortcuts and `headunit://` deep links, sharing every decision and action with
+ * `AutomationReceiver`. It exists because those can only target an activity, and because the Self
+ * Mode pre-launch below needs a foreground window. Prefer the receiver where either will do.
  */
 class AutomationActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        
+
         // Invisible activity
         window.setBackgroundDrawableResource(android.R.color.transparent)
 
         val data = intent.data
-        val action = intent.action
-        
-        AppLog.i("AutomationActivity: Received intent. Action: $action, Data: $data")
-        
-        if (data?.scheme == "headunit") {
-            handleUri(data)
-        } else {
-            val state = intent.getStringExtra("state")
-            handleAction(action, state)
+        AppLog.i("AutomationActivity: Received intent. Action: ${intent.action}, Data: $data")
+
+        val action = if (data?.scheme == "headunit") actionFor(data.host) else intent.action
+        if (action != null) {
+            runCommand(action, if (data?.scheme == "headunit") queryParameters(data) else emptyMap())
         }
-        
+
         finish()
     }
 
-    private fun handleUri(data: android.net.Uri) {
-        when (data.host) {
-            "connect" -> {
-                val ip = data.getQueryParameter("ip")
-                if (!ip.isNullOrEmpty()) {
-                    ContextCompat.startForegroundService(this, Intent(this, AapService::class.java).apply {
-                        action = AapService.ACTION_CONNECT_SOCKET
-                    })
-                    lifecycleScope.launch(Dispatchers.IO) { App.provide(this@AutomationActivity).commManager.connect(ip, 5277) }
-                } else {
-                    val autoIntent = Intent(this, AapService::class.java).apply {
-                        this.action = AapService.ACTION_CHECK_USB
-                    }
-                    ContextCompat.startForegroundService(this, autoIntent)
-                }
-            }
-            "disconnect" -> {
-                val stopIntent = Intent(this, AapService::class.java).apply {
-                    this.action = AapService.ACTION_DISCONNECT
-                }
-                ContextCompat.startForegroundService(this, stopIntent)
-            }
-            "exit" -> {
-                val exitIntent = Intent(this, AapService::class.java).apply {
-                    this.action = AapService.ACTION_STOP_SERVICE
-                }
-                ContextCompat.startForegroundService(this, exitIntent)
-                // Broadcast a finish request to close MainActivity if it's open
-                sendBroadcast(Intent("com.andrerinas.openheadunit.ACTION_FINISH_ACTIVITIES"))
-            }
-            "nightmode" -> {
-                val state = data.getQueryParameter("state")
-                applyNightMode(state)
-            }
-        }
+    /** `headunit://connect?ip=…`, `disconnect`, `exit`, `nightmode?state=…`. */
+    private fun actionFor(host: String?): String? = when (host) {
+        "connect" -> HeadUnitCommand.ACTION_CONNECT
+        "disconnect" -> HeadUnitCommand.ACTION_DISCONNECT
+        "exit" -> HeadUnitCommand.ACTION_STOP_SERVICE
+        "nightmode" -> HeadUnitCommand.ACTION_SET_NIGHT_MODE
+        else -> null
     }
 
-    private fun handleAction(incomingAction: String?, incomingState: String?) {
-        when (incomingAction) {
-            "com.andrerinas.openheadunit.ACTION_SET_NIGHT_MODE" -> applyNightMode(incomingState)
-            "com.andrerinas.openheadunit.ACTION_CONNECT" -> {
-                val autoIntent = Intent(this, AapService::class.java).apply {
-                    this.action = AapService.ACTION_CHECK_USB
-                }
-                ContextCompat.startForegroundService(this, autoIntent)
-            }
-            "com.andrerinas.openheadunit.ACTION_DISCONNECT" -> {
-                val stopIntent = Intent(this, AapService::class.java).apply {
-                    this.action = AapService.ACTION_DISCONNECT
-                }
-                ContextCompat.startForegroundService(this, stopIntent)
-            }
-            "com.andrerinas.openheadunit.ACTION_START_SELF_MODE" -> {
-                val selfIntent = Intent(this, AapService::class.java).apply {
-                    this.action = AapService.ACTION_START_SELF_MODE
-                }
-                ContextCompat.startForegroundService(this, selfIntent)
+    /**
+     * A deep link carries arguments as query parameters, not extras, so they go to [IntentExtras] as
+     * overrides. Passing all of them keeps this door accepting exactly what the receiver does.
+     */
+    private fun queryParameters(data: Uri): Map<String, String> =
+        data.queryParameterNames.mapNotNull { name ->
+            data.getQueryParameter(name)?.let { name to it }
+        }.toMap()
 
-                // [FIX] Launch AapProjectionActivity NOW, while AutomationActivity is
-                // still in the foreground. This is critical on Android 10+ where
-                // background activity launches are silently blocked: by the time
-                // AapService finishes the Self Mode handshake and calls
-                // launchAapProjectionActivity(), the app has no foreground window and
-                // the launch often fails, leaving the user at the launcher.
-                //
-                // Starting AapProjectionActivity from this foreground context is always
-                // allowed. Its loading overlay will display while Self Mode negotiates;
-                // once the handshake completes AapService will reorder it to front
-                // (it's already there) and start streaming.
-                try {
-                    startActivity(
-                        AapProjectionActivity.intent(this).apply {
-                            addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
-                        }
-                    )
-                } catch (e: Exception) {
-                    AppLog.w("AutomationActivity: Could not pre-launch AapProjectionActivity: ${e.message}")
-                }
-            }
-            "com.andrerinas.openheadunit.ACTION_STOP_SERVICE",
-            "com.andrerinas.openheadunit.ACTION_EXIT" -> {
-                val exitIntent = Intent(this, AapService::class.java).apply {
-                    this.action = AapService.ACTION_STOP_SERVICE
-                }
-                ContextCompat.startForegroundService(this, exitIntent)
-                sendBroadcast(Intent("com.andrerinas.openheadunit.ACTION_FINISH_ACTIVITIES").apply {
-                    setPackage(packageName)
-                })
-            }
-        }
+    private fun runCommand(action: String, overrides: Map<String, String>) {
+        val effects = AutomationCommandPolicy.effectsFor(
+            action,
+            IntentExtras(intent, overrides),
+            AutomationCommandPolicy.State(
+                externalConfigAllowed = App.provide(this).settings.allowExternalConfiguration
+            )
+        )
+        AutomationEffectRunner.run(this, effects, JSONObject())
+
+        if (action == HeadUnitCommand.ACTION_START_SELF_MODE) preLaunchProjection()
     }
 
-    private fun applyNightMode(state: String?) {
-        val appSettings = App.provide(this).settings
-        when (state?.lowercase()) {
-            "day" -> appSettings.nightMode = Settings.NightMode.DAY
-            "night" -> appSettings.nightMode = Settings.NightMode.NIGHT
-            "auto" -> appSettings.nightMode = Settings.NightMode.AUTO
+    /**
+     * [FIX] Launch the projection now, while this activity still has a foreground window: Android 10+
+     * silently blocks the background launch AapService would otherwise make once the Self Mode
+     * handshake finishes, leaving the user at the launcher. This is the one thing a broadcast cannot
+     * do, and the reason this activity is more than a second spelling of the receiver.
+     */
+    private fun preLaunchProjection() {
+        try {
+            startActivity(
+                AapProjectionActivity.intent(this).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+                }
+            )
+        } catch (e: Exception) {
+            AppLog.w("AutomationActivity: Could not pre-launch AapProjectionActivity: ${e.message}")
         }
-        val updateIntent = Intent(this, AapService::class.java).apply {
-            this.action = AapService.ACTION_REQUEST_NIGHT_MODE_UPDATE
-        }
-        ContextCompat.startForegroundService(this, updateIntent)
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -2419,6 +2419,20 @@ class SettingsFragment : Fragment() {
             ))
         }
 
+        // Sits beside the log settings because those are half of what it unlocks: with this off,
+        // another app can still connect and disconnect, but cannot rewrite this unit's setup or
+        // drive the capture.
+        items.add(SettingItem.ToggleSettingEntry(
+            stableId = "allowExternalConfiguration",
+            nameResId = R.string.allow_external_configuration,
+            descriptionResId = R.string.allow_external_configuration_description,
+            isChecked = settings.allowExternalConfiguration,
+            onCheckedChanged = { isChecked ->
+                settings.allowExternalConfiguration = isChecked
+                updateSettingsList()
+            }
+        ))
+
         val logLevels = LogExporter.LogLevel.entries
         val logLevelNames = logLevels.map { it.name.lowercase().replaceFirstChar { c -> c.uppercase() } }.toTypedArray()
         items.add(SettingItem.SettingEntry(

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/LogExporter.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/LogExporter.kt
@@ -134,7 +134,10 @@ object LogExporter {
         val settings = Settings(context)
         return "LogExporter: session | " +
             "build=${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE}) " +
-            "${BuildConfig.FLAVOR}/${BuildConfig.BUILD_TYPE} | " +
+            "${BuildConfig.FLAVOR}/${BuildConfig.BUILD_TYPE} " +
+            // The commit is the only field that separates two candidates of the same fix: the
+            // version name and code do not move between them.
+            "commit=${BuildConfig.GIT_SHA} | " +
             "device=${Build.MANUFACTURER} ${Build.MODEL} board=${Build.BOARD} api=${Build.VERSION.SDK_INT} | " +
             "video=codec:${settings.videoCodec} fps:${settings.fpsLimit} resId:${settings.resolutionId} " +
             "view:${settings.viewMode.name} forceSw:${settings.forceSoftwareDecoding} " +

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -245,6 +245,13 @@ class Settings(private val context: Context) {
         set(value) { prefs.edit().putBoolean(KEY_LOG_CAPTURE_ENABLED, value).apply() }
     val logLevel: Int get() = exporterLogLevel.logLevel
 
+    // Lets another app on the device rewrite this unit's settings and drive the log capture through
+    // AutomationReceiver. Off by default: the control verbs are harmless to fire by accident, these
+    // are not.
+    var allowExternalConfiguration: Boolean
+        get() = prefs.getBoolean(KEY_ALLOW_EXTERNAL_CONFIGURATION, false)
+        set(value) = prefs.edit().putBoolean(KEY_ALLOW_EXTERNAL_CONFIGURATION, value).apply()
+
     var viewMode: ViewMode
         get() {
             val value = prefs.getInt("view-mode", 1)
@@ -1403,6 +1410,7 @@ class Settings(private val context: Context) {
 
         /** SharedPreferences key; also used by [com.andrerinas.openheadunit.aap.AapService] for change listener. */
         const val KEY_LOG_LEVEL = "log-level"
+        const val KEY_ALLOW_EXTERNAL_CONFIGURATION = "allow-external-configuration"
         const val KEY_LOG_SOURCE = "log-source"
         const val KEY_LOG_LOCATION = "log-location"
         /** Persist whether log capture should be active across restarts. */

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
@@ -70,6 +70,21 @@ object SettingsBackupManager {
         "night-mode-threshold-brightness" to ValueType.INT,
         "key-codes" to ValueType.STRING_SET,
         Settings.KEY_LOG_LEVEL to ValueType.INT,
+        // Where the log comes from and where it lands. A round that asks for a particular capture
+        // has to be able to seed these the same way it seeds the level.
+        Settings.KEY_LOG_SOURCE to ValueType.INT,
+        Settings.KEY_LOG_LOCATION to ValueType.INT,
+        // Lets an automation tool configure this unit at all, so it has to survive a reinstall or
+        // the tool goes silent with no indication why.
+        Settings.KEY_ALLOW_EXTERNAL_CONFIGURATION to ValueType.BOOLEAN,
+        // The video fault injector and its dosage. Not user settings, but a test round sets them
+        // per arm, and carrying them is what lets a whole arm be written in one call.
+        "debug-video-fault-injection" to ValueType.INT,
+        "debug-video-fault-rate" to ValueType.INT,
+        "debug-video-fault-budget" to ValueType.INT,
+        "debug-video-low-latency" to ValueType.BOOLEAN,
+        "debug-video-feed-hold-ms" to ValueType.INT,
+        "debug-force-memory-profile" to ValueType.STRING,
         "view-mode" to ValueType.INT,
         Settings.KEY_SCREEN_ORIENTATION to ValueType.INT,
         "dpi-pixel-density" to ValueType.INT,

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -364,6 +364,8 @@
     <string name="fullscreen_immersive_avoid_notch">غامر (تجنب النوتش)</string>
     <string name="fullscreen_immersive_avoid_notch_desc">يخفي جميع الأعمدة ويضيف حشوة لمنع تغطية العرض بواسطة النوتش أو الانقطاع.</string>
     <string name="fullscreen_status_only">إخفاء شريط الحالة فقط</string>
+    <string name="allow_external_configuration">السماح بالتهيئة الخارجية</string>
+    <string name="allow_external_configuration_description">اسمح لتطبيقات الأتمتة مثل Tasker أو MacroDroid بتغيير الإعدادات وضبط مستوى السجل وتصدير السجلات. الاتصال وقطع الاتصال يعملان دائمًا؛ هذا يخص فقط الأوامر التي تغيّر طريقة إعداد الوحدة.</string>
     <string name="log_level">مستوى السجل</string>
     <string name="log_level_description">اختر مستوى تفصيل مخرجات السجل للتصحيح.</string>
     <string name="log_source">مصدر السجلات</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -364,6 +364,8 @@
     <string name="fullscreen_immersive_avoid_notch">Imerzivní (Vyhnout se Notch)</string>
     <string name="fullscreen_immersive_avoid_notch_desc">Skryje všechny lišty a přidá odsazení, aby se zabránilo zakrytí projekce výřezem (Notch).</string>
     <string name="fullscreen_status_only">Skrýt pouze stavovou lištu</string>
+    <string name="allow_external_configuration">Povolit externí konfiguraci</string>
+    <string name="allow_external_configuration_description">Umožní automatizačním aplikacím jako Tasker nebo MacroDroid měnit nastavení, nastavit úroveň protokolu a exportovat protokoly. Připojení a odpojení funguje vždy; toto se týká pouze příkazů, které mění nastavení jednotky.</string>
     <string name="log_level">Úroveň protokolování</string>
     <string name="log_level_description">Vyberte úroveň podrobnosti výstupu protokolu pro ladění.</string>
     <string name="log_source">Zdroj logů</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -157,6 +157,8 @@
     <string name="back">Zurück</string>
     <string name="debug_mode">Debug Modus</string>
     <string name="debug_mode_description">Erweitertes Logging aktivieren</string>
+    <string name="allow_external_configuration">Externe Konfiguration zulassen</string>
+    <string name="allow_external_configuration_description">Erlaubt Automatisierungs-Apps wie Tasker oder MacroDroid, Einstellungen zu ändern, das Log-Level zu setzen und Logs zu exportieren. Verbinden und Trennen funktioniert immer; dies betrifft nur Befehle, die die Einrichtung der Haupteinheit ändern.</string>
     <string name="log_level">Log-Level</string>
     <string name="log_level_description">Filtert den Detailgrad beim Log-Export</string>
     <string name="log_source">Logquelle</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -364,6 +364,8 @@
     <string name="fullscreen_immersive_avoid_notch">Inmersivo (Evitar Notch)</string>
     <string name="fullscreen_immersive_avoid_notch_desc">Oculta todas las barras y agrega espaciado para evitar que la proyección sea cubierta por el Notch/Recorte.</string>
     <string name="fullscreen_status_only">Ocultar solo barra de estado</string>
+    <string name="allow_external_configuration">Permitir configuración externa</string>
+    <string name="allow_external_configuration_description">Permite que aplicaciones de automatización como Tasker o MacroDroid cambien ajustes, definan el nivel de log y exporten logs. Conectar y desconectar siempre funciona; esto solo afecta a los comandos que cambian la configuración de la unidad.</string>
     <string name="log_level">Nivel de log</string>
     <string name="log_level_description">Elija el nivel de detalle de los mensajes de log para depuración.</string>
     <string name="log_source">Fuente de registro</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -364,6 +364,8 @@
     <string name="fullscreen_immersive_avoid_notch">Inmersivo (Evitar Notch)</string>
     <string name="fullscreen_immersive_avoid_notch_desc">Oculta todas las barras y agrega espaciado para evitar que la proyección sea cubierta por el Notch/Recorte.</string>
     <string name="fullscreen_status_only">Ocultar solo barra de estado</string>
+    <string name="allow_external_configuration">Permitir configuración externa</string>
+    <string name="allow_external_configuration_description">Permite que aplicaciones de automatización como Tasker o MacroDroid cambien ajustes, definan el nivel de log y exporten logs. Conectar y desconectar siempre funciona; esto solo afecta a los comandos que cambian la configuración de la unidad.</string>
     <string name="log_level">Nivel de log</string>
     <string name="log_level_description">Elija el nivel de detalle de los mensajes de log para depuración.</string>
     <string name="log_source">Fuente de registro</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -295,6 +295,8 @@
     <string name="back">Retour</string>
     <string name="debug_mode">Mode débogage</string>
     <string name="debug_mode_description">Activer plus de journaux (Logging)</string>
+    <string name="allow_external_configuration">Autoriser la configuration externe</string>
+    <string name="allow_external_configuration_description">Permet aux applications d\'automatisation comme Tasker ou MacroDroid de modifier les réglages, de définir le niveau de journalisation et d\'exporter les journaux. La connexion et la déconnexion fonctionnent toujours ; cela ne concerne que les commandes qui modifient la configuration de l\'autoradio.</string>
     <string name="log_level">Niveau de journalisation</string>
     <string name="log_level_description">Filtrer le niveau de journalisation lors de l\'exportation</string>
     <string name="log_source">Source du journal</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -363,6 +363,8 @@
     <string name="fullscreen_immersive_avoid_notch">Immerzív (Notch elkerülése)</string>
     <string name="fullscreen_immersive_avoid_notch_desc">Elrejti az összes sávot, és kitöltést ad hozzá, hogy megakadályozza a vetítés Notch/Kivágás általi lefedését.</string>
     <string name="fullscreen_status_only">Csak az állapotsor elrejtése</string>
+    <string name="allow_external_configuration">Külső konfiguráció engedélyezése</string>
+    <string name="allow_external_configuration_description">Lehetővé teszi az automatizáló alkalmazásoknak, például a Taskernek vagy a MacroDroidnak, hogy módosítsák a beállításokat, beállítsák a naplózási szintet és exportálják a naplókat. A csatlakozás és a bontás mindig működik; ez csak a fejegység beállítását módosító parancsokra vonatkozik.</string>
     <string name="log_level">Naplózási szint</string>
     <string name="log_level_description">A hibaelhárításhoz szükséges részletesség beállítása.</string>
     <string name="log_source">Naplóforrás</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -127,6 +127,8 @@
     <string name="back">Indietro</string>
     <string name="debug_mode">Modalità Debug</string>
     <string name="debug_mode_description">Attiva più log</string>
+    <string name="allow_external_configuration">Consenti configurazione esterna</string>
+    <string name="allow_external_configuration_description">Permette ad app di automazione come Tasker o MacroDroid di modificare le impostazioni, impostare il livello di log ed esportare i log. Connessione e disconnessione funzionano sempre; questo riguarda solo i comandi che cambiano la configurazione dell\'unità.</string>
     <string name="log_level">Livello Log</string>
     <string name="log_level_description">Filtra livello log durante l\'esportazione</string>
     <string name="log_source">Origine dei log</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -127,6 +127,8 @@
     <string name="back">戻る</string>
     <string name="debug_mode">デバッグモード</string>
     <string name="debug_mode_description">ログのエクスポート</string>
+    <string name="allow_external_configuration">外部からの設定変更を許可</string>
+    <string name="allow_external_configuration_description">Tasker や MacroDroid などの自動化アプリが設定の変更、ログレベルの設定、ログのエクスポートを行えるようにします。接続と切断は常に可能です。これはヘッドユニットの設定を変更するコマンドにのみ適用されます。</string>
     <string name="log_level">ログレベル</string>
     <string name="log_level_description">エクスポート時にログレベルをフィルタリングする</string>
     <string name="log_source">ログソース</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -132,6 +132,8 @@
     <string name="back">უკან</string>
     <string name="debug_mode">გამართვის რეჟიმი (Debug)</string>
     <string name="debug_mode_description">ლოგირების გაძლიერება</string>
+    <string name="allow_external_configuration">გარე კონფიგურაციის დაშვება</string>
+    <string name="allow_external_configuration_description">საშუალებას აძლევს ავტომატიზაციის აპებს, როგორიცაა Tasker ან MacroDroid, შეცვალონ პარამეტრები, დააყენონ ჟურნალის დონე და გაიტანონ ჟურნალები. დაკავშირება და გათიშვა ყოველთვის მუშაობს; ეს ეხება მხოლოდ იმ ბრძანებებს, რომლებიც ცვლიან მოწყობილობის კონფიგურაციას.</string>
     <string name="log_level">ლოგის დონე</string>
     <string name="log_level_description">ლოგის დონის ფილტრაცია ექსპორტისას</string>
     <string name="log_source">ლოგის წყარო</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -131,6 +131,8 @@
     <string name="back">뒤로</string>
     <string name="debug_mode">디버그 모드</string>
     <string name="debug_mode_description">자세한 로그 기록을 활성화합니다.</string>
+    <string name="allow_external_configuration">외부 설정 변경 허용</string>
+    <string name="allow_external_configuration_description">Tasker나 MacroDroid 같은 자동화 앱이 설정을 변경하고 로그 수준을 지정하며 로그를 내보낼 수 있도록 합니다. 연결과 연결 해제는 항상 동작하며, 이 설정은 헤드유닛 구성을 바꾸는 명령에만 적용됩니다.</string>
     <string name="log_level">로그 레벨</string>
     <string name="log_level_description">내보낼 로그 레벨을 선택합니다.</string>
     <string name="log_source">로그 수집 방식</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -361,6 +361,8 @@
     <string name="fullscreen_immersive_avoid_notch">Immersief (Notch vermijden)</string>
     <string name="fullscreen_immersive_avoid_notch_desc">Verbergt alle balken en voegt opvulling toe om te voorkomen dat de projectie wordt afgedekt door de Notch/Uitsparing.</string>
     <string name="fullscreen_status_only">Alleen statusbalk verbergen</string>
+    <string name="allow_external_configuration">Externe configuratie toestaan</string>
+    <string name="allow_external_configuration_description">Laat automatiseringsapps zoals Tasker of MacroDroid instellingen wijzigen, het logniveau instellen en logs exporteren. Verbinden en verbreken werkt altijd; dit geldt alleen voor opdrachten die de configuratie van de headunit wijzigen.</string>
     <string name="log_level">Logboekniveau</string>
     <string name="log_level_description">Kies het detailniveau van de loguitvoer voor foutopsporing.</string>
     <string name="log_source">Logbron</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -362,6 +362,8 @@
     <string name="fullscreen_immersive_avoid_notch">Immersyjny (Unikaj Notch)</string>
     <string name="fullscreen_immersive_avoid_notch_desc">Ukrywa wszystkie paski i dodaje wypełnienie, aby zapobiec zasłanianiu projekcji przez Notch/Wycięcie.</string>
     <string name="fullscreen_status_only">Ukryj tylko pasek stanu</string>
+    <string name="allow_external_configuration">Zezwalaj na konfigurację zewnętrzną</string>
+    <string name="allow_external_configuration_description">Pozwala aplikacjom automatyzującym, takim jak Tasker czy MacroDroid, zmieniać ustawienia, ustawiać poziom logowania i eksportować logi. Łączenie i rozłączanie działa zawsze; dotyczy to tylko poleceń zmieniających konfigurację urządzenia.</string>
     <string name="log_level">Poziom logowania</string>
     <string name="log_level_description">Wybierz poziom szczegółowości logów do debugowania.</string>
     <string name="log_source">Źródło logów</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -362,6 +362,8 @@
     <string name="fullscreen_immersive_avoid_notch">Imersivo (Evitar Notch)</string>
     <string name="fullscreen_immersive_avoid_notch_desc">Oculta todas as barras e adiciona preenchimento para evitar que a projeção seja coberta pelo Notch/Recorte.</string>
     <string name="fullscreen_status_only">Ocultar apenas a barra de status</string>
+    <string name="allow_external_configuration">Permitir configuração externa</string>
+    <string name="allow_external_configuration_description">Permite que aplicativos de automação como Tasker ou MacroDroid alterem configurações, definam o nível de log e exportem logs. Conectar e desconectar sempre funciona; isto vale apenas para comandos que mudam a configuração da central.</string>
     <string name="log_level">Nível de Log</string>
     <string name="log_level_description">Escolha o nível de detalhe da saída de log para depuração.</string>
     <string name="log_source">Fonte de logs</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -123,6 +123,8 @@
     <string name="back">Înapoi</string>
     <string name="debug_mode">Mod depanare (Debug)</string>
     <string name="debug_mode_description">Activează loguri detaliate</string>
+    <string name="allow_external_configuration">Permite configurarea externă</string>
+    <string name="allow_external_configuration_description">Permite aplicațiilor de automatizare precum Tasker sau MacroDroid să modifice setările, să seteze nivelul de jurnalizare și să exporte jurnalele. Conectarea și deconectarea funcționează întotdeauna; aceasta se aplică doar comenzilor care schimbă configurația unității.</string>
     <string name="log_level">Nivel logare</string>
     <string name="log_level_description">Filtrează nivelul logurilor la export</string>
     <string name="log_source">Sursă de jurnalizare</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -365,6 +365,8 @@
     <string name="fullscreen_immersive_avoid_notch">Иммерсивный (Избегать выреза)</string>
     <string name="fullscreen_immersive_avoid_notch_desc">Скрывает все полосы и добавляет отступы, чтобы предотвратить перекрытие проекции вырезом или челкой.</string>
     <string name="fullscreen_status_only">Скрыть только строку состояния</string>
+    <string name="allow_external_configuration">Разрешить внешнюю настройку</string>
+    <string name="allow_external_configuration_description">Позволяет приложениям автоматизации, таким как Tasker или MacroDroid, менять настройки, задавать уровень журнала и экспортировать журналы. Подключение и отключение работают всегда; это касается только команд, изменяющих настройку головного устройства.</string>
     <string name="log_level">Уровень логирования</string>
     <string name="log_level_description">Фильтр уровня логирования при экспорте.</string>
     <string name="log_source">Источник логов</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -128,6 +128,8 @@
     <string name="back">Geri</string>
     <string name="debug_mode">Hata Ayıklama Modu</string>
     <string name="debug_mode_description">Daha fazla günlük kaydı (Log) tut</string>
+    <string name="allow_external_configuration">Harici yapılandırmaya izin ver</string>
+    <string name="allow_external_configuration_description">Tasker veya MacroDroid gibi otomasyon uygulamalarının ayarları değiştirmesine, günlük seviyesini belirlemesine ve günlükleri dışa aktarmasına izin verir. Bağlanma ve bağlantıyı kesme her zaman çalışır; bu yalnızca ünitenin yapılandırmasını değiştiren komutlar için geçerlidir.</string>
     <string name="log_level">Günlük Seviyesi</string>
     <string name="log_level_description">Dışa aktarırken günlük seviyesini filtrele</string>
     <string name="log_source">Günlük kaynağı</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -362,6 +362,8 @@
     <string name="fullscreen_immersive_avoid_notch">Іммерсивний (Уникати вирізу)</string>
     <string name="fullscreen_immersive_avoid_notch_desc">Приховує всі панелі та додає відступи, щоб запобігти перекриттю проекції вирізом або чубчиком.</string>
     <string name="fullscreen_status_only">Приховати лише рядок стану</string>
+    <string name="allow_external_configuration">Дозволити зовнішнє налаштування</string>
+    <string name="allow_external_configuration_description">Дозволяє застосункам автоматизації, як-от Tasker чи MacroDroid, змінювати налаштування, задавати рівень журналу та експортувати журнали. Підключення й відключення працюють завжди; це стосується лише команд, які змінюють налаштування головного пристрою.</string>
     <string name="log_level">Рівень логування</string>
     <string name="log_level_description">Виберіть рівень деталізації виводу логів для налагодження.</string>
     <string name="log_source">Джерело логів</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -128,6 +128,8 @@
     <string name="back">Quay lại</string>
     <string name="debug_mode">Chế độ gỡ lỗi</string>
     <string name="debug_mode_description">Bật/tắt ghi log chi tiết</string>
+    <string name="allow_external_configuration">Cho phép cấu hình từ bên ngoài</string>
+    <string name="allow_external_configuration_description">Cho phép các ứng dụng tự động hoá như Tasker hoặc MacroDroid thay đổi cài đặt, đặt mức nhật ký và xuất nhật ký. Kết nối và ngắt kết nối luôn hoạt động; mục này chỉ áp dụng cho các lệnh thay đổi cấu hình của đầu máy.</string>
     <string name="log_level">Mức log</string>
     <string name="log_level_description">Lọc mức log khi xuất</string>
     <string name="start_log_capture">Bắt đầu ghi log</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -361,6 +361,8 @@
     <string name="fullscreen_immersive_avoid_notch">沈浸模式 (避開瀏海)</string>
     <string name="fullscreen_immersive_avoid_notch_desc">隱藏所有工具列並增加間距，以防止投影被瀏海或切口遮擋。</string>
     <string name="fullscreen_status_only">僅隱藏狀態列</string>
+    <string name="allow_external_configuration">允許外部設定</string>
+    <string name="allow_external_configuration_description">讓 Tasker 或 MacroDroid 等自動化應用程式變更設定、設定記錄層級並匯出記錄。連線與中斷連線一律可用；此項僅適用於會變更主機設定的指令。</string>
     <string name="log_level">日誌級別</string>
     <string name="log_level_description">選擇日誌輸出的詳細程度以進行偵錯。</string>
     <string name="log_source">日誌來源</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -338,6 +338,8 @@
     <string name="back">Back</string>
     <string name="debug_mode">Debug Mode</string>
     <string name="debug_mode_description">Toggle more Logging</string>
+    <string name="allow_external_configuration">Allow external configuration</string>
+    <string name="allow_external_configuration_description">Let automation apps such as Tasker or MacroDroid change settings, set the log level and export logs. Connecting and disconnecting always works; this is only for commands that change how the head unit is set up.</string>
     <string name="log_level">Log Level</string>
     <string name="log_level_description">Filter log level when exporting</string>
     <string name="log_source">Log Source</string>

--- a/app/src/test/java/com/andrerinas/openheadunit/automation/AutomationCommandPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/automation/AutomationCommandPolicyTest.kt
@@ -1,0 +1,336 @@
+package com.andrerinas.openheadunit.automation
+
+import com.andrerinas.openheadunit.aap.AapService
+import com.andrerinas.openheadunit.contract.HeadUnitCommand
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutomationCommandPolicyTest {
+
+    private val open = AutomationCommandPolicy.State(externalConfigAllowed = true)
+    private val closed = AutomationCommandPolicy.State(externalConfigAllowed = false)
+
+    private class Extras(private val values: Map<String, String> = emptyMap()) :
+        AutomationCommandPolicy.Extras {
+        override fun string(key: String): String? = values[key]
+        override fun flag(key: String): Boolean = values[key]?.lowercase() == "true"
+    }
+
+    private fun effects(
+        action: String?,
+        extras: Map<String, String> = emptyMap(),
+        state: AutomationCommandPolicy.State = closed
+    ) = AutomationCommandPolicy.effectsFor(action, Extras(extras), state)
+
+    private fun single(
+        action: String?,
+        extras: Map<String, String> = emptyMap(),
+        state: AutomationCommandPolicy.State = closed
+    ): AutomationCommandPolicy.Effect = effects(action, extras, state).single()
+
+    // --- the gate -------------------------------------------------------------------------------
+
+    /**
+     * The whole point of the split: control is open, configuration is not. A caller that can start
+     * a session must not also be able to silently rewrite the unit's setup.
+     */
+    @Test
+    fun `configuring verbs are refused while external configuration is off`() {
+        val configuring = listOf(
+            HeadUnitCommand.ACTION_SET_SETTINGS,
+            HeadUnitCommand.ACTION_GET_SETTINGS,
+            HeadUnitCommand.ACTION_RESET_SETTINGS,
+            HeadUnitCommand.ACTION_SET_LOG_LEVEL,
+            HeadUnitCommand.ACTION_START_LOG_CAPTURE,
+            HeadUnitCommand.ACTION_STOP_LOG_CAPTURE,
+            HeadUnitCommand.ACTION_EXPORT_LOG
+        )
+        for (action in configuring) {
+            assertTrue(
+                "$action should be refused with the gate off",
+                single(action, mapOf(HeadUnitCommand.EXTRA_TEXT to "x")) is AutomationCommandPolicy.Effect.Refuse
+            )
+        }
+    }
+
+    @Test
+    fun `control verbs work with the gate off`() {
+        assertEquals(
+            AutomationCommandPolicy.Effect.StartService(AapService.ACTION_DISCONNECT),
+            single(HeadUnitCommand.ACTION_DISCONNECT)
+        )
+        assertEquals(
+            AutomationCommandPolicy.Effect.StartService(AapService.ACTION_START_WIRELESS),
+            single(HeadUnitCommand.ACTION_START_WIRELESS)
+        )
+    }
+
+    @Test
+    fun `the gate opens the configuring verbs`() {
+        assertEquals(
+            AutomationCommandPolicy.Effect.ResetSettings,
+            single(HeadUnitCommand.ACTION_RESET_SETTINGS, state = open)
+        )
+    }
+
+    // --- relays ---------------------------------------------------------------------------------
+
+    /**
+     * The public stop action is not the string the service uses internally, and sending either one
+     * to the wrong side is a no-op, so the mapping is the whole of this command.
+     */
+    @Test
+    fun `both stop aliases reach the service's own stop action`() {
+        assertEquals(
+            AutomationCommandPolicy.Effect.StartService(AapService.ACTION_STOP_SERVICE),
+            single(HeadUnitCommand.ACTION_STOP_SERVICE)
+        )
+        assertEquals(
+            AutomationCommandPolicy.Effect.StartService(AapService.ACTION_STOP_SERVICE),
+            single(HeadUnitCommand.ACTION_EXIT)
+        )
+    }
+
+    @Test
+    fun `every relayed verb maps onto a real service action`() {
+        val expected = mapOf(
+            HeadUnitCommand.ACTION_DISCONNECT to AapService.ACTION_DISCONNECT,
+            HeadUnitCommand.ACTION_START_WIRELESS to AapService.ACTION_START_WIRELESS,
+            HeadUnitCommand.ACTION_STOP_WIRELESS to AapService.ACTION_STOP_WIRELESS,
+            HeadUnitCommand.ACTION_START_WIRELESS_SCAN to AapService.ACTION_START_WIRELESS_SCAN,
+            HeadUnitCommand.ACTION_CHECK_USB to AapService.ACTION_CHECK_USB,
+            HeadUnitCommand.ACTION_REFRESH_SENSORS to AapService.ACTION_REFRESH_SENSORS,
+            HeadUnitCommand.ACTION_RESTART_AUDIO to AapService.ACTION_RESTART_AUDIO,
+            HeadUnitCommand.ACTION_RAISE_PROJECTION to AapService.ACTION_RAISE_PROJECTION
+        )
+        for ((command, serviceAction) in expected) {
+            assertEquals(
+                command,
+                AutomationCommandPolicy.Effect.StartService(serviceAction),
+                single(command)
+            )
+        }
+    }
+
+    // --- connect --------------------------------------------------------------------------------
+
+    @Test
+    fun `connect without an address checks USB instead`() {
+        assertEquals(
+            AutomationCommandPolicy.Effect.StartService(AapService.ACTION_CHECK_USB),
+            single(HeadUnitCommand.ACTION_CONNECT)
+        )
+        // A blank address is the same as none; a shortcut with an empty field must not try to
+        // open a socket to "".
+        assertEquals(
+            AutomationCommandPolicy.Effect.StartService(AapService.ACTION_CHECK_USB),
+            single(HeadUnitCommand.ACTION_CONNECT, mapOf(HeadUnitCommand.EXTRA_IP to "  "))
+        )
+    }
+
+    @Test
+    fun `connect with an address opens the head unit server socket`() {
+        val effects = effects(HeadUnitCommand.ACTION_CONNECT, mapOf(HeadUnitCommand.EXTRA_IP to "192.168.1.25"))
+        assertEquals(
+            AutomationCommandPolicy.Effect.ConnectSocket("192.168.1.25", AutomationCommandPolicy.HEADUNIT_SERVER_PORT),
+            effects.last()
+        )
+        assertEquals(5277, AutomationCommandPolicy.HEADUNIT_SERVER_PORT)
+    }
+
+    /** #310: connect in the background without taking the screen. */
+    @Test
+    fun `no_ui rides along on the service intent`() {
+        val start = effects(
+            HeadUnitCommand.ACTION_CONNECT,
+            mapOf(HeadUnitCommand.EXTRA_IP to "10.0.0.1", HeadUnitCommand.EXTRA_NO_UI to "true")
+        ).first() as AutomationCommandPolicy.Effect.StartService
+        assertEquals(true, start.flagExtras[AapService.EXTRA_NO_UI])
+
+        val selfMode = single(
+            HeadUnitCommand.ACTION_START_SELF_MODE,
+            mapOf(HeadUnitCommand.EXTRA_NO_UI to "true")
+        ) as AutomationCommandPolicy.Effect.StartService
+        assertEquals(true, selfMode.flagExtras[AapService.EXTRA_NO_UI])
+    }
+
+    @Test
+    fun `self mode defaults to raising the screen`() {
+        val selfMode = single(HeadUnitCommand.ACTION_START_SELF_MODE)
+            as AutomationCommandPolicy.Effect.StartService
+        assertEquals(false, selfMode.flagExtras[AapService.EXTRA_NO_UI])
+    }
+
+    // --- required extras ------------------------------------------------------------------------
+
+    @Test
+    fun `a poke without a MAC is refused rather than sent`() {
+        assertTrue(single(HeadUnitCommand.ACTION_NATIVE_AA_POKE) is AutomationCommandPolicy.Effect.Refuse)
+        assertEquals(
+            AutomationCommandPolicy.Effect.StartService(
+                AapService.ACTION_NATIVE_AA_POKE,
+                stringExtras = mapOf(AapService.EXTRA_MAC to "AA:BB:CC:DD:EE:FF")
+            ),
+            single(HeadUnitCommand.ACTION_NATIVE_AA_POKE, mapOf(HeadUnitCommand.EXTRA_MAC to "AA:BB:CC:DD:EE:FF"))
+        )
+    }
+
+    @Test
+    fun `a cancel poke is relayed with no extras required`() {
+        assertEquals(
+            AutomationCommandPolicy.Effect.StartService(
+                HeadUnitCommand.ACTION_NATIVE_AA_CANCEL_POKE
+            ),
+            single(HeadUnitCommand.ACTION_NATIVE_AA_CANCEL_POKE)
+        )
+    }
+
+    @Test
+    fun `the cancel poke action is the one the service answers to`() {
+        assertEquals(
+            "com.andrerinas.openheadunit.ACTION_NATIVE_AA_CANCEL_POKE",
+            HeadUnitCommand.ACTION_NATIVE_AA_CANCEL_POKE
+        )
+    }
+
+    @Test
+    fun `nearby connect needs an endpoint`() {
+        assertTrue(single(HeadUnitCommand.ACTION_NEARBY_CONNECT) is AutomationCommandPolicy.Effect.Refuse)
+        assertEquals(
+            AutomationCommandPolicy.Effect.StartService(
+                AapService.ACTION_NEARBY_CONNECT,
+                stringExtras = mapOf(AapService.EXTRA_ENDPOINT_ID to "ABCD")
+            ),
+            single(HeadUnitCommand.ACTION_NEARBY_CONNECT, mapOf(HeadUnitCommand.EXTRA_ENDPOINT_ID to "ABCD"))
+        )
+    }
+
+    @Test
+    fun `settings import needs json or a path`() {
+        assertTrue(
+            single(HeadUnitCommand.ACTION_SET_SETTINGS, state = open) is AutomationCommandPolicy.Effect.Refuse
+        )
+        assertEquals(
+            AutomationCommandPolicy.Effect.ImportSettings("{}", null),
+            single(HeadUnitCommand.ACTION_SET_SETTINGS, mapOf(HeadUnitCommand.EXTRA_JSON to "{}"), open)
+        )
+        assertEquals(
+            AutomationCommandPolicy.Effect.ImportSettings(null, "/sdcard/a.json"),
+            single(HeadUnitCommand.ACTION_SET_SETTINGS, mapOf(HeadUnitCommand.EXTRA_PATH to "/sdcard/a.json"), open)
+        )
+    }
+
+    // --- validated values -----------------------------------------------------------------------
+
+    @Test
+    fun `night mode accepts only the three modes, in any case`() {
+        assertEquals(
+            AutomationCommandPolicy.Effect.SetNightMode("night"),
+            single(HeadUnitCommand.ACTION_SET_NIGHT_MODE, mapOf(HeadUnitCommand.EXTRA_STATE to "NIGHT"))
+        )
+        assertTrue(
+            single(HeadUnitCommand.ACTION_SET_NIGHT_MODE, mapOf(HeadUnitCommand.EXTRA_STATE to "dusk"))
+                is AutomationCommandPolicy.Effect.Refuse
+        )
+        assertTrue(
+            single(HeadUnitCommand.ACTION_SET_NIGHT_MODE) is AutomationCommandPolicy.Effect.Refuse
+        )
+    }
+
+    @Test
+    fun `log level accepts only real levels`() {
+        assertEquals(
+            AutomationCommandPolicy.Effect.SetLogLevel("verbose"),
+            single(HeadUnitCommand.ACTION_SET_LOG_LEVEL, mapOf(HeadUnitCommand.EXTRA_LEVEL to "Verbose"), open)
+        )
+        assertTrue(
+            single(HeadUnitCommand.ACTION_SET_LOG_LEVEL, mapOf(HeadUnitCommand.EXTRA_LEVEL to "loud"), open)
+                is AutomationCommandPolicy.Effect.Refuse
+        )
+    }
+
+    // --- unknown --------------------------------------------------------------------------------
+
+    @Test
+    fun `an unknown or absent action is refused, not ignored`() {
+        assertTrue(single(null) is AutomationCommandPolicy.Effect.Refuse)
+        assertTrue(single("com.example.NOPE") is AutomationCommandPolicy.Effect.Refuse)
+    }
+
+    @Test
+    fun `a log marker needs no configuration switch`() {
+        val e = effects(HeadUnitCommand.ACTION_LOG_MARKER, mapOf(HeadUnitCommand.EXTRA_TEXT to "x"), closed)
+        assertTrue(e.none { it is AutomationCommandPolicy.Effect.Refuse })
+    }
+
+    /**
+     * Three verbs kept the internal action strings they had before this surface existed. Both
+     * spellings answer, or a script written from the documented names silently does nothing.
+     */
+    @Test
+    fun `the documented and the original spellings both answer`() {
+        for (pair in listOf(
+            HeadUnitCommand.ACTION_RAISE_PROJECTION to HeadUnitCommand.LEGACY_ACTION_RAISE_PROJECTION,
+            HeadUnitCommand.ACTION_REFRESH_SENSORS to HeadUnitCommand.LEGACY_ACTION_REFRESH_SENSORS,
+            HeadUnitCommand.ACTION_RESTART_AUDIO to HeadUnitCommand.LEGACY_ACTION_RESTART_AUDIO
+        )) {
+            assertEquals(
+                "the two spellings of ${pair.first} must do the same thing",
+                effects(pair.first, emptyMap(), open),
+                effects(pair.second, emptyMap(), open)
+            )
+        }
+    }
+
+    /**
+     * The manifest cannot reference a Kotlin constant, so its action list is a hand-copy. Anything
+     * spelled differently there is unreachable and silently does nothing.
+     */
+    @Test
+    fun `every command the manifest advertises is one the policy answers`() {
+        val manifest = java.io.File("src/main/AndroidManifest.xml").readText()
+        val advertised = Regex("""<action android:name="(com\.andrerinas\.openheadunit\.[^"]+)"""")
+            .findAll(manifest.substringAfter("AutomationReceiver").substringBefore("</receiver>"))
+            .map { it.groupValues[1] }
+            .toList()
+
+        assertTrue("no actions found for the receiver", advertised.isNotEmpty())
+        for (action in advertised) {
+            assertTrue(
+                "$action is advertised in the manifest but the policy does not answer it",
+                effects(action, mapOf(HeadUnitCommand.EXTRA_TEXT to "x"), open).none {
+                    it is AutomationCommandPolicy.Effect.Refuse &&
+                        it.reason.startsWith("unknown action")
+                }
+            )
+        }
+
+        // The other direction: an action the policy answers but the manifest never advertises is
+        // unreachable by an implicit broadcast, which is how every automation app sends.
+        for (action in ALL_COMMANDS) {
+            assertTrue(
+                "$action is answered by the policy but missing from the manifest",
+                advertised.contains(action)
+            )
+        }
+    }
+
+    private val ALL_COMMANDS = listOf(
+        HeadUnitCommand.ACTION_CONNECT, HeadUnitCommand.ACTION_DISCONNECT,
+        HeadUnitCommand.ACTION_START_SELF_MODE, HeadUnitCommand.ACTION_STOP_SERVICE,
+        HeadUnitCommand.ACTION_EXIT, HeadUnitCommand.ACTION_SET_NIGHT_MODE,
+        HeadUnitCommand.ACTION_START_WIRELESS, HeadUnitCommand.ACTION_STOP_WIRELESS,
+        HeadUnitCommand.ACTION_START_WIRELESS_SCAN, HeadUnitCommand.ACTION_NATIVE_AA_POKE,
+        HeadUnitCommand.ACTION_NATIVE_AA_CANCEL_POKE,
+        HeadUnitCommand.ACTION_NEARBY_CONNECT, HeadUnitCommand.ACTION_CHECK_USB,
+        HeadUnitCommand.ACTION_REFRESH_SENSORS, HeadUnitCommand.ACTION_RESTART_AUDIO,
+        HeadUnitCommand.ACTION_RAISE_PROJECTION, HeadUnitCommand.LEGACY_ACTION_REFRESH_SENSORS,
+        HeadUnitCommand.LEGACY_ACTION_RESTART_AUDIO, HeadUnitCommand.LEGACY_ACTION_RAISE_PROJECTION,
+        HeadUnitCommand.ACTION_QUERY_STATE, HeadUnitCommand.ACTION_SET_SETTINGS,
+        HeadUnitCommand.ACTION_GET_SETTINGS, HeadUnitCommand.ACTION_RESET_SETTINGS,
+        HeadUnitCommand.ACTION_SET_LOG_LEVEL, HeadUnitCommand.ACTION_START_LOG_CAPTURE,
+        HeadUnitCommand.ACTION_STOP_LOG_CAPTURE, HeadUnitCommand.ACTION_EXPORT_LOG,
+        HeadUnitCommand.ACTION_LOG_MARKER
+    )
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/automation/AutomationOutputPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/automation/AutomationOutputPolicyTest.kt
@@ -1,0 +1,108 @@
+package com.andrerinas.openheadunit.automation
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutomationOutputPolicyTest {
+
+    private val roots = listOf("/storage/emulated/0/Android/data/pkg/files", "/storage/emulated/0/Download")
+
+    @Test
+    fun `a file inside an allowed root may be written`() {
+        assertTrue(AutomationOutputPolicy.mayWriteTo("/storage/emulated/0/Download/x.json", roots))
+        assertTrue(AutomationOutputPolicy.mayWriteTo("/storage/emulated/0/Download/OpenHeadunitLogs/a.txt", roots))
+    }
+
+    /**
+     * The write runs with the app's own privileges, so an unconstrained path lets a caller put
+     * chosen bytes into the app's private storage. settings.xml is the one that would matter.
+     */
+    @Test
+    fun `app private storage is refused`() {
+        assertFalse(
+            AutomationOutputPolicy.mayWriteTo(
+                "/data/data/com.andrerinas.headunitrevived/shared_prefs/settings.xml",
+                roots
+            )
+        )
+        assertFalse(AutomationOutputPolicy.mayWriteTo("/data/local/tmp/x.json", roots))
+        assertFalse(AutomationOutputPolicy.mayWriteTo("/sdcard/elsewhere/x.json", roots))
+    }
+
+    /** Starting inside an allowed root is not enough if the path then climbs out of it. */
+    @Test
+    fun `traversal out of an allowed root is refused`() {
+        assertFalse(
+            AutomationOutputPolicy.mayWriteTo(
+                "/storage/emulated/0/Download/../../../data/data/pkg/shared_prefs/settings.xml",
+                roots
+            )
+        )
+        assertFalse(AutomationOutputPolicy.mayWriteTo("/storage/emulated/0/Download/..", roots))
+    }
+
+    @Test
+    fun `a relative or empty path is refused rather than resolved`() {
+        assertFalse(AutomationOutputPolicy.mayWriteTo("x.json", roots))
+        assertFalse(AutomationOutputPolicy.mayWriteTo("", roots))
+        assertFalse(AutomationOutputPolicy.mayWriteTo("   ", roots))
+    }
+
+    /** The root itself is a directory, not a file to overwrite. */
+    @Test
+    fun `the root itself is not a writable target`() {
+        assertFalse(AutomationOutputPolicy.mayWriteTo("/storage/emulated/0/Download", roots))
+    }
+
+    @Test
+    fun `a duplicated separator does not slip past the prefix check`() {
+        assertTrue(AutomationOutputPolicy.mayWriteTo("/storage/emulated/0//Download//x.json", roots))
+    }
+
+    @Test
+    fun `with no roots nothing is writable`() {
+        assertFalse(AutomationOutputPolicy.mayWriteTo("/storage/emulated/0/Download/x.json", emptyList()))
+        assertFalse(AutomationOutputPolicy.mayWriteTo("/storage/emulated/0/Download/x.json", listOf("", "  ")))
+    }
+
+    /**
+     * The passphrase is the head unit's own AP credential in clear text, and an export goes either
+     * to a caller we cannot identify or to a path that caller chose.
+     */
+    @Test
+    fun `the credential bearing settings are withheld from an export`() {
+        assertTrue("hotspot-password" in AutomationOutputPolicy.WITHHELD_KEYS)
+        assertTrue("auto-start-bt-macs" in AutomationOutputPolicy.WITHHELD_KEYS)
+        assertTrue("auto-disconnect-bt-macs" in AutomationOutputPolicy.WITHHELD_KEYS)
+        assertTrue("native-poke-bt-macs" in AutomationOutputPolicy.WITHHELD_KEYS)
+        assertTrue("static-bssid" in AutomationOutputPolicy.WITHHELD_KEYS)
+    }
+
+    @Test
+    fun `a primary external storage symlink resolves onto the real root`() {
+        val roots = listOf("/storage/emulated/0/Download")
+        val real = "/storage/emulated/0"
+        assertTrue(AutomationOutputPolicy.mayWriteTo("/sdcard/Download/x.json", roots, real))
+        assertTrue(AutomationOutputPolicy.mayWriteTo("/mnt/sdcard/Download/x.json", roots, real))
+        assertTrue(AutomationOutputPolicy.mayWriteTo("/storage/self/primary/Download/x.json", roots, real))
+        assertTrue(AutomationOutputPolicy.mayWriteTo("/storage/emulated/0/Download/x.json", roots, real))
+    }
+
+    @Test
+    fun `an alias cannot reach anywhere the real path could not`() {
+        val roots = listOf("/storage/emulated/0/Download")
+        val real = "/storage/emulated/0"
+        assertFalse(AutomationOutputPolicy.mayWriteTo("/sdcard/Android/data/x", roots, real))
+        assertFalse(AutomationOutputPolicy.mayWriteTo("/sdcard/Download/../../../data/data/x", roots, real))
+        // A name that merely starts with an alias is not the alias.
+        assertFalse(AutomationOutputPolicy.mayWriteTo("/sdcardish/Download/x", roots, real))
+    }
+
+    @Test
+    fun `with no external root known the alias is refused rather than guessed`() {
+        assertFalse(
+            AutomationOutputPolicy.mayWriteTo("/sdcard/Download/x.json", listOf("/storage/emulated/0/Download"), null)
+        )
+    }
+}

--- a/contract/README.md
+++ b/contract/README.md
@@ -1,0 +1,148 @@
+# Automating Open Headunit
+
+Open Headunit can be driven from Tasker, MacroDroid, a launcher shortcut or `adb`, and it reports
+what the projection session is doing so a macro can react to it.
+
+## The one thing that trips everybody up
+
+The **package** and the **action prefix** are different, on purpose:
+
+| | |
+|---|---|
+| package (applicationId) | `com.andrerinas.headunitrevived` |
+| action prefix (namespace) | `com.andrerinas.openheadunit` |
+
+The app kept its original Play Store listing when it was renamed, so the two never matched. Using
+the wrong one silently does nothing — there is no error. Copy the lines below rather than typing
+them.
+
+## Sending a command
+
+Everything goes to one receiver:
+
+```
+com.andrerinas.headunitrevived/com.andrerinas.openheadunit.automation.AutomationReceiver
+```
+
+**Tasker**: Action → Misc → Send Intent. Set *Target* to **Broadcast Receiver**, *Action* to the
+action you want, *Package* to `com.andrerinas.headunitrevived`, *Class* to the receiver above.
+Targeting a broadcast receiver is what lets this work without granting Tasker "Display over other
+apps" — an activity target needs it on Android 10 and up.
+
+**MacroDroid**: Action → Send Intent, target Broadcast, same package and class. It allows six
+extras with explicit types; Tasker allows two.
+
+**adb**:
+
+```bash
+PKG=com.andrerinas.headunitrevived
+RX=$PKG/com.andrerinas.openheadunit.automation.AutomationReceiver
+
+adb shell am broadcast -n $RX -a com.andrerinas.openheadunit.ACTION_QUERY_STATE
+```
+
+`am` sends ordered, so the reply comes back as JSON on the `data=` field. Tasker's Send Intent is
+not ordered and cannot read a reply — a Tasker task watches the session broadcast below instead.
+
+## Control
+
+Open to any caller, like the steering-wheel key receivers already are.
+
+| Action (prefix `com.andrerinas.openheadunit.`) | Extras | Does |
+|---|---|---|
+| `ACTION_CONNECT` | `ip` (optional), `no_ui` | With `ip`, opens a session to Android Auto's head unit server on 5277. Without, checks USB. |
+| `ACTION_DISCONNECT` | | Ends the session. |
+| `ACTION_START_SELF_MODE` | `no_ui` | Projects this device onto itself. |
+| `ACTION_STOP_SERVICE` | | Ends the session and stops the service. `ACTION_EXIT` is an accepted alias. |
+| `ACTION_SET_NIGHT_MODE` | `state` = `day`/`night`/`auto` | Day/night theme. |
+| `ACTION_START_WIRELESS` | | Arms the stored wireless mode. |
+| `ACTION_STOP_WIRELESS` | | Stops it. |
+| `ACTION_START_WIRELESS_SCAN` | | One discovery pass. |
+| `ACTION_NATIVE_AA_POKE` | `extra_mac` | Wakes a phone over Bluetooth. Native AA mode only. |
+| `ACTION_NATIVE_AA_CANCEL_POKE` | | Cancels a wake in progress, as the driver selector's Cancel does. Native AA mode only, and only on a build carrying driver selection. |
+| `ACTION_NEARBY_CONNECT` | `extra_endpoint_id` | Connects a Google Nearby endpoint. |
+| `ACTION_CHECK_USB` | | Re-checks the USB port. |
+| `ACTION_REFRESH_SENSORS` | | Re-reads sensors. Also answers to `aap.action.REFRESH_SENSORS`. |
+| `ACTION_RESTART_AUDIO` | | Restarts the audio pipeline. Also answers to `aap.action.RESTART_AUDIO`. |
+| `ACTION_RAISE_PROJECTION` | | Brings the projection to the front. Also answers to `aap.action.RAISE_PROJECTION`. |
+| `ACTION_QUERY_STATE` | | Replies with build and session state. |
+| `ACTION_LOG_MARKER` | `text` | Writes `AutomationMarker: <text>` into the log at WARN, so two runs can share one capture. |
+
+`no_ui` asks for the session without taking the screen, for a macro that connects in the background.
+It applies to the next raise only, so an ordinary reconnect still comes to the front.
+
+## Configuration
+
+**Off by default.** Turn on *Allow external configuration* in Settings first, next to the log
+options; without it these are refused and the reply says so. Connecting and disconnecting are
+unaffected.
+
+| Action (prefix `com.andrerinas.openheadunit.`) | Extras | Does |
+|---|---|---|
+| `ACTION_SET_SETTINGS` | `json` or `path` | Applies a settings backup. Same format the in-app export writes. |
+| `ACTION_GET_SETTINGS` | `path` (optional) | Replies with the settings, or writes them to `path`. Credential-bearing keys are withheld; see below. |
+| `ACTION_RESET_SETTINGS` | | Back to defaults. |
+| `ACTION_SET_LOG_LEVEL` | `level` = `verbose`/`debug`/`info`/`warn`/`error`/`silent` | |
+| `ACTION_START_LOG_CAPTURE` | | |
+| `ACTION_STOP_LOG_CAPTURE` | | |
+| `ACTION_EXPORT_LOG` | `path` (optional) | Writes the retained log out. |
+
+### What a configuration command will not do
+
+Two limits apply even with the switch on, because it is one switch that stays on after the round
+that needed it, and any app on the device can send these:
+
+- **An export withholds credentials.** `hotspot-password`, `hotspot-ssid`, `auto-start-wifi-ssid`,
+  `auto-start-bt-macs`, `auto-start-bt-name` and `static-bssid` are removed, and the reply carries
+  `withheld` with the count so a partial export is not mistaken for unset values. Reading those
+  needs a shell and `settings.xml`.
+- **`path` must be somewhere collectable.** Writes are allowed into the app's external files
+  directory and the public Downloads directory only. The write runs with the app's own privileges,
+  so an unconstrained path would let a caller put chosen bytes into the app's private storage.
+  Anything else is refused with a reason. `/sdcard`, `/mnt/sdcard` and `/storage/self/primary` are
+  accepted as the usual spellings of primary external storage.
+
+## Reacting to the session
+
+The app broadcasts `com.andrerinas.headunitrevived.SESSION_STATE` whenever the session changes.
+It is implicit and needs no permission, so **Tasker's *Intent Received* event works directly** —
+this is the answer to "how do I tell whether Android Auto is actually running on the head unit",
+which nothing else on the device reports (`%UIMODE` does not change for a head unit).
+
+| Extra | Values |
+|---|---|
+| `state` | `connecting`, `connected`, `projecting`, `disconnected`, `failed` |
+| `transport` | `usb`, `wifi`, `self`, `unknown` |
+| `reason` | `user_exit`, `link_lost`, `phone_left`, `handshake_failed`, `peer_silent`, `connect_failed`, or empty |
+| `uptime_ms` | How long the session had been up, or 0 |
+
+`projecting` is the one that means "Android Auto is on screen and carrying video". Treat `reason`
+as an open string: new values get added, and an unrecognised one means "some other reason", not an
+error.
+
+Because any app on the device can read this, it deliberately carries no network credentials and
+does not name the phone.
+
+Watch it from a shell with:
+
+```bash
+adb shell am broadcast -a com.andrerinas.headunitrevived.SESSION_STATE --receiver-foreground
+```
+
+or just read the log — every event also prints as `AapService: session state <state>`.
+
+## Deep links and shortcuts
+
+Still supported and unchanged:
+
+```bash
+adb shell am start -a android.intent.action.VIEW -d "headunit://connect?ip=192.168.1.25"
+adb shell am start -a android.intent.action.VIEW -d "headunit://exit"
+```
+
+`headunit://connect`, `disconnect`, `exit`, `nightmode?state=day|night|auto`, and
+`headunit://selfmode`. The app also publishes seven launcher shortcuts, which is what Samsung
+Modes and Routines picks up.
+
+Deep links and shortcuts go through an activity, so an automation app sending them needs "Display
+over other apps". The receiver above does not — prefer it.

--- a/contract/src/main/java/com/andrerinas/openheadunit/contract/HeadUnitIntent.kt
+++ b/contract/src/main/java/com/andrerinas/openheadunit/contract/HeadUnitIntent.kt
@@ -15,24 +15,6 @@ object HeadUnit {
     const val packageName = "com.andrerinas.headunitrevived"
 }
 
-class ConnectedIntent: Intent(action) {
-    companion object {
-        const val action = "${HeadUnit.packageName}.ACTION_CONNECTED"
-    }
-}
-
-class DisconnectIntent(isClean: Boolean = false) : Intent(action) {
-    init {
-        setPackage(HeadUnit.packageName)
-        putExtra(EXTRA_CLEAN, isClean)
-    }
-
-    companion object {
-        const val action = "${HeadUnit.packageName}.ACTION_DISCONNECT"
-        const val EXTRA_CLEAN = "is_clean"
-    }
-}
-
 class KeyIntent(event: KeyEvent): Intent(action) {
     init {
         putExtra(extraEvent, event)
@@ -176,5 +158,149 @@ class NavigationUpdateIntent(
          * Receivers must request this permission using <uses-permission> and should enforce it in their manifest declaration.
          */
         const val BROADCAST_PERMISSION = "${HeadUnit.packageName}.permission.NAVIGATION_UPDATE"
+    }
+}
+
+/**
+ * The commands [HeadUnitCommand.RECEIVER_CLASS] accepts. The component is in [HeadUnit.packageName]
+ * but actions are prefixed `com.andrerinas.openheadunit`: applicationId and namespace deliberately
+ * differ, and the wrong one silently does nothing. Worked examples are in `contract/README.md`.
+ */
+object HeadUnitCommand {
+    const val RECEIVER_CLASS = "com.andrerinas.openheadunit.automation.AutomationReceiver"
+
+    private const val PREFIX = "com.andrerinas.openheadunit"
+
+    // Control. Open to any caller, like the OEM key receivers already are.
+    const val ACTION_CONNECT = "$PREFIX.ACTION_CONNECT"
+    const val ACTION_DISCONNECT = "$PREFIX.ACTION_DISCONNECT"
+    const val ACTION_START_SELF_MODE = "$PREFIX.ACTION_START_SELF_MODE"
+    /**
+     * Ends the session and stops the service. The public name, which the shortcuts and existing
+     * automations already send; the service uses a different string internally.
+     */
+    const val ACTION_STOP_SERVICE = "$PREFIX.ACTION_STOP_SERVICE"
+
+    /** Older alias for [ACTION_STOP_SERVICE], still accepted. */
+    const val ACTION_EXIT = "$PREFIX.ACTION_EXIT"
+    const val ACTION_SET_NIGHT_MODE = "$PREFIX.ACTION_SET_NIGHT_MODE"
+    const val ACTION_START_WIRELESS = "$PREFIX.ACTION_START_WIRELESS"
+    const val ACTION_STOP_WIRELESS = "$PREFIX.ACTION_STOP_WIRELESS"
+    const val ACTION_START_WIRELESS_SCAN = "$PREFIX.ACTION_START_WIRELESS_SCAN"
+    const val ACTION_NATIVE_AA_POKE = "$PREFIX.ACTION_NATIVE_AA_POKE"
+
+    /**
+     * Cancels a Native AA wake in progress, as the driver selector's own Cancel does. Inert on a
+     * build without the driver-selection feature, which is where the service handler lives.
+     */
+    const val ACTION_NATIVE_AA_CANCEL_POKE = "$PREFIX.ACTION_NATIVE_AA_CANCEL_POKE"
+    const val ACTION_NEARBY_CONNECT = "$PREFIX.ACTION_NEARBY_CONNECT"
+    const val ACTION_CHECK_USB = "$PREFIX.ACTION_CHECK_USB"
+    const val ACTION_REFRESH_SENSORS = "$PREFIX.ACTION_REFRESH_SENSORS"
+    const val ACTION_RESTART_AUDIO = "$PREFIX.ACTION_RESTART_AUDIO"
+    const val ACTION_RAISE_PROJECTION = "$PREFIX.ACTION_RAISE_PROJECTION"
+
+    /**
+     * The original spellings of the three above, still accepted. They were the internal service
+     * actions before this surface existed, so anything already scripted against them keeps working.
+     */
+    const val LEGACY_ACTION_REFRESH_SENSORS = "$PREFIX.aap.action.REFRESH_SENSORS"
+    const val LEGACY_ACTION_RESTART_AUDIO = "$PREFIX.aap.action.RESTART_AUDIO"
+    const val LEGACY_ACTION_RAISE_PROJECTION = "$PREFIX.aap.action.RAISE_PROJECTION"
+    const val ACTION_QUERY_STATE = "$PREFIX.ACTION_QUERY_STATE"
+
+    // Configuration. Refused unless the user has turned on "Allow external configuration",
+    // because these rewrite the unit's setup and drive the log capture.
+    const val ACTION_SET_SETTINGS = "$PREFIX.ACTION_SET_SETTINGS"
+    const val ACTION_GET_SETTINGS = "$PREFIX.ACTION_GET_SETTINGS"
+    const val ACTION_RESET_SETTINGS = "$PREFIX.ACTION_RESET_SETTINGS"
+    const val ACTION_SET_LOG_LEVEL = "$PREFIX.ACTION_SET_LOG_LEVEL"
+    const val ACTION_START_LOG_CAPTURE = "$PREFIX.ACTION_START_LOG_CAPTURE"
+    const val ACTION_STOP_LOG_CAPTURE = "$PREFIX.ACTION_STOP_LOG_CAPTURE"
+    const val ACTION_EXPORT_LOG = "$PREFIX.ACTION_EXPORT_LOG"
+    const val ACTION_LOG_MARKER = "$PREFIX.ACTION_LOG_MARKER"
+
+    /** Target address for [ACTION_CONNECT]; without it the USB path is checked instead. */
+    const val EXTRA_IP = "ip"
+
+    /** [ACTION_CONNECT] and [ACTION_START_SELF_MODE]: connect without raising the projection. */
+    const val EXTRA_NO_UI = "no_ui"
+
+    /** `day`, `night` or `auto` for [ACTION_SET_NIGHT_MODE]. */
+    const val EXTRA_STATE = "state"
+
+    /** Bluetooth MAC for [ACTION_NATIVE_AA_POKE]. */
+    const val EXTRA_MAC = "extra_mac"
+
+    /** Google Nearby endpoint for [ACTION_NEARBY_CONNECT]. */
+    const val EXTRA_ENDPOINT_ID = "extra_endpoint_id"
+
+    /** Inline settings JSON for [ACTION_SET_SETTINGS], in the settings-backup format. */
+    const val EXTRA_JSON = "json"
+
+    /** File to read or write, for [ACTION_SET_SETTINGS], [ACTION_GET_SETTINGS], [ACTION_EXPORT_LOG]. */
+    const val EXTRA_PATH = "path"
+
+    /** `verbose`, `debug`, `info`, `warn`, `error` or `silent` for [ACTION_SET_LOG_LEVEL]. */
+    const val EXTRA_LEVEL = "level"
+
+    /** The text [ACTION_LOG_MARKER] writes into the log. */
+    const val EXTRA_TEXT = "text"
+}
+
+/**
+ * Broadcast when the session changes state, so automation can react without polling. Sent implicitly
+ * and unguarded, because an automation app cannot hold an app-declared permission; everything here is
+ * readable by any app, which is why it carries no credentials and never names the phone.
+ * Receive with `registerReceiver(r, IntentFilter(SessionStateIntent.action), RECEIVER_EXPORTED)`.
+ */
+class SessionStateIntent(
+    state: String,
+    transport: String,
+    reason: String,
+    uptimeMs: Long
+) : Intent(action) {
+    init {
+        putExtra(EXTRA_STATE, state)
+        putExtra(EXTRA_TRANSPORT, transport)
+        putExtra(EXTRA_REASON, reason)
+        putExtra(EXTRA_UPTIME_MS, uptimeMs)
+    }
+
+    companion object {
+        const val action = "${HeadUnit.packageName}.SESSION_STATE"
+
+        /** One of [STATE_CONNECTING], [STATE_CONNECTED], [STATE_PROJECTING], [STATE_DISCONNECTED], [STATE_FAILED]. */
+        const val EXTRA_STATE = "state"
+
+        /** `usb`, `wifi`, `self` or `unknown`. */
+        const val EXTRA_TRANSPORT = "transport"
+
+        /**
+         * Why the state changed. An open string, not a closed set: treat an unrecognised value as
+         * "some other reason" rather than failing.
+         */
+        const val EXTRA_REASON = "reason"
+
+        /** Milliseconds the session had been up, or 0 outside a session. */
+        const val EXTRA_UPTIME_MS = "uptime_ms"
+
+        const val STATE_CONNECTING = "connecting"
+        const val STATE_CONNECTED = "connected"
+
+        /** The session is live and carrying video; this is what "Android Auto is running" means. */
+        const val STATE_PROJECTING = "projecting"
+        const val STATE_DISCONNECTED = "disconnected"
+
+        /** The session never started. [EXTRA_REASON] says what failed. */
+        const val STATE_FAILED = "failed"
+
+        const val REASON_USER_EXIT = "user_exit"
+        const val REASON_LINK_LOST = "link_lost"
+        const val REASON_PHONE_LEFT = "phone_left"
+        const val REASON_HANDSHAKE_FAILED = "handshake_failed"
+        const val REASON_PEER_SILENT = "peer_silent"
+        const val REASON_CONNECT_FAILED = "connect_failed"
+        const val REASON_NONE = ""
     }
 }


### PR DESCRIPTION
## What

- One exported `AutomationReceiver` answers every automation verb: connect, disconnect, Self Mode, night mode, wireless arm/stop/scan, USB check, sensors, audio restart, raise projection, Native AA wake and wake cancel, Nearby connect, and a state query.
- The deep-link `AutomationActivity` runs the same `AutomationCommandPolicy`, so both doors answer a command identically instead of drifting.
- Configuring verbs (settings import/export/reset, log level, log capture, log export) are refused unless the user turns on the new "Allow external configuration" setting, off by default.
- A `SessionStateIntent` broadcast reports connecting, connected, projecting, disconnected and failed, with transport, reason and uptime, so a macro reacts instead of polling.
- Replies come back as JSON on the ordered-broadcast result, so `adb shell am broadcast` prints them on `data=`.
- `contract/README.md` documents the whole surface with copy-pasteable Tasker, MacroDroid and `adb` recipes.
- Every APK records the commit it was built from in `BuildConfig.GIT_SHA`, and the log export's session line carries it as `commit=`.

## Why

- The old surface was an activity, which Tasker and MacroDroid can only reach if the user grants "Display over other apps" on Android 10 and up. A broadcast receiver needs no such grant.
- The internal service actions were already reachable and undocumented, so scripts were built on strings that were never a contract. The three in use are kept as accepted aliases.
- Reading and rewriting a unit's settings is not the same risk as pressing a button, so the configuring half gets its own switch rather than riding on the control half being open.
- `versionName` and `versionCode` do not move between two candidates of the same fix, so a reporter's log could not be tied to a build and a fix looked identical to the report of it failing.


## Safety

- `AutomationOutputPolicy.WITHHELD_KEYS` keeps the hotspot passphrase and SSID, the car's WiFi name, the paired-phone MAC lists and the static BSSID out of an exported settings copy.
- `AutomationOutputPolicy.mayWriteTo` confines an export to the app's own collectable directories, resolves `/sdcard` and the other primary-storage aliases, and refuses any path that climbs out with `..`.
- Writing a log marker is deliberately not a configuring verb: it reads and changes nothing, and gating it made it useless for separating two runs inside one capture.
