### PR TITLE
USB: connect non-Pixel phones without fighting a fast-reverting dongle

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -109,11 +109,20 @@
 
         </activity>
 
+        <!--
+            excludeFromRecents/noHistory/taskAffinity: this is a translucent trampoline the system
+            launches on every USB attach once it is the default handler. Without them it lands in
+            the app's own task and lingers there, so a later attach can be delivered to a stale
+            instance instead of starting a fresh one.
+        -->
         <activity
             android:name=".app.UsbAttachedActivity"
             android:directBootAware="true"
+            android:excludeFromRecents="true"
             android:exported="true"
             android:launchMode="singleTop"
+            android:noHistory="true"
+            android:taskAffinity=""
             android:theme="@style/AppTheme.Translucent">
             <intent-filter>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />

--- a/app/src/main/java/com/andrerinas/openheadunit/app/UsbAttachedActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/app/UsbAttachedActivity.kt
@@ -15,6 +15,7 @@ import com.andrerinas.openheadunit.R
 import com.andrerinas.openheadunit.aap.AapService
 import com.andrerinas.openheadunit.connection.CommManager
 import com.andrerinas.openheadunit.connection.usb.UsbAccessoryMode
+import com.andrerinas.openheadunit.connection.usb.UsbAttachPolicy
 import com.andrerinas.openheadunit.connection.usb.UsbDeviceCompat
 import com.andrerinas.openheadunit.connection.usb.UsbDeviceDiagnostics
 import com.andrerinas.openheadunit.connection.usb.UsbReceiver
@@ -148,9 +149,25 @@ class UsbAttachedActivity : Activity() {
         // Google VID (0x18D1) devices are almost certainly Android Auto phones or AA dongles
         // (e.g. AAWireless). Always attempt the AOA switch for these — skipping them would
         // break dongle users who haven't explicitly configured allowlists.
+        //
+        // [BUG_FIX] Every other make used to be refused here, because the vendor id was the only
+        // escape from the allow list. The device has already passed isAndroidDevice() above, so
+        // an unconfigured allow list is no reason to drop the attach — it means the user never
+        // set one, not that nothing is permitted. UsbAttachPolicy carries the reasoning.
         val isGoogleDevice = device.vendorId == 0x18D1
-        if (!isGoogleDevice && settings != null && !autoStartOnUsb && !settings.isConnectingDevice(deviceCompat)) {
-            AppLog.i("Skipping device ${deviceCompat.uniqueName} (not allowed and USB auto-start disabled)")
+        val allowList = settings?.allowedDevices ?: emptySet()
+        val mayAttempt = settings == null || UsbAttachPolicy.shouldAttemptAoaSwitch(
+            isGoogleVendor = isGoogleDevice,
+            autoStartOnUsb = autoStartOnUsb,
+            allowListConfigured = allowList.isNotEmpty(),
+            deviceAllowed = settings.isConnectingDevice(deviceCompat),
+        )
+        if (!mayAttempt) {
+            // Hand the attach to the service rather than swallowing it. This activity is what the
+            // system launches once it is the default handler, so a bare finish() here is the end
+            // of the road for that plug-in: no chooser is shown and nothing else is told.
+            AppLog.i("Not switching ${deviceCompat.uniqueName} here (not on the allow list); letting the service decide")
+            handOffToService()
             finish()
             return
         }
@@ -179,6 +196,20 @@ class UsbAttachedActivity : Activity() {
         }.start()
     }
 
+    /**
+     * Ask [AapService] to look at what is plugged in. Used wherever this activity declines to act
+     * itself: the system delivered the attach to us and nobody else will hear about it otherwise.
+     */
+    private fun handOffToService() {
+        try {
+            ContextCompat.startForegroundService(this, Intent(this, AapService::class.java).apply {
+                action = AapService.ACTION_CHECK_USB
+            })
+        } catch (e: Exception) {
+            AppLog.w("Could not hand the USB attach to the service: ${e.message}")
+        }
+    }
+
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
 
@@ -203,12 +234,15 @@ class UsbAttachedActivity : Activity() {
         }
 
         if (!isLocked && App.provide(this).commManager.connectionState.value !is CommManager.ConnectionState.TransportStarted) {
+            // A normal-mode re-attach used to be dropped here. noHistory means most re-attaches
+            // arrive as a fresh onCreate instead, but one that does reach this instance is the
+            // same dead end as declining in onCreate: nobody else is told.
             if (UsbDeviceCompat.isInAccessoryMode(device)) {
-                AppLog.e("Usb in accessory mode")
-                ContextCompat.startForegroundService(this, Intent(this, AapService::class.java).apply {
-                    action = AapService.ACTION_CHECK_USB
-                })
+                AppLog.i("Usb in accessory mode")
+            } else {
+                AppLog.i("Usb re-attached in normal mode; asking the service to check it")
             }
+            handOffToService()
         } else {
             AppLog.e("Thread already running")
         }

--- a/app/src/main/java/com/andrerinas/openheadunit/app/UsbAttachedActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/app/UsbAttachedActivity.kt
@@ -19,6 +19,7 @@ import com.andrerinas.openheadunit.connection.usb.UsbAttachPolicy
 import com.andrerinas.openheadunit.connection.usb.UsbDeviceCompat
 import com.andrerinas.openheadunit.connection.usb.UsbDeviceDiagnostics
 import com.andrerinas.openheadunit.connection.usb.UsbReceiver
+import com.andrerinas.openheadunit.connection.usb.UsbSwitchClaim
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.DeviceIntent
 import com.andrerinas.openheadunit.utils.LocaleHelper
@@ -178,13 +179,32 @@ class UsbAttachedActivity : Activity() {
             return
         }
 
+        if (UsbSwitchClaim.isLive()) {
+            // Each attach lands in a fresh instance (noHistory, no task affinity), so without this
+            // the 0x2D00 re-enumeration would start a second switch on the same device.
+            AppLog.i("A USB accessory switch is already in flight; leaving ${deviceCompat.uniqueName} to it")
+            finish()
+            return
+        }
+
         val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
         val usbMode = UsbAccessoryMode(usbManager)
         AppLog.i("Switching USB device to accessory mode " + deviceCompat.uniqueName)
         ToastUtils.showToast(this, getString(R.string.switching_usb_accessory_mode, deviceCompat.uniqueName), Toast.LENGTH_SHORT)
         val useLibusb = settings?.useLibusb ?: false
+        // The claim keeps the service's 2 s attach fallback off a device we are already switching.
+        // noHistory means this activity can be finished out from under the thread, so the release
+        // is in a finally and the claim expires on its own if even that is missed.
+        UsbSwitchClaim.stake()
         Thread {
-            val result = usbMode.connectAndSwitch(device, useLibusb)
+            val result = try {
+                usbMode.connectAndSwitch(device, useLibusb)
+            } catch (e: Exception) {
+                AppLog.e("AOA switch threw for ${deviceCompat.uniqueName}", e)
+                false
+            } finally {
+                UsbSwitchClaim.release()
+            }
             runOnUiThread {
                 if (result) {
                     ToastUtils.showToast(this, getString(R.string.success), Toast.LENGTH_SHORT)

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/projection/LibusbProjectionConnection.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/projection/LibusbProjectionConnection.kt
@@ -1,6 +1,5 @@
 package com.andrerinas.openheadunit.connection.projection
 
-import android.hardware.usb.UsbConstants
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbDeviceConnection
 import android.hardware.usb.UsbEndpoint
@@ -121,17 +120,8 @@ class LibusbProjectionConnection(usbMgr: UsbManager,
                 return@withContext false
             }
 
-            // Find endpoints
-            var epIn: UsbEndpoint? = null
-            var epOut: UsbEndpoint? = null
-            for (i in 0 until iface.endpointCount) {
-                val ep = iface.getEndpoint(i)
-                if (ep.direction == UsbConstants.USB_DIR_IN) {
-                    if (epIn == null) epIn = ep
-                } else {
-                    if (epOut == null) epOut = ep
-                }
-            }
+            // Find endpoints, bulk preferred; the standard transport asks the same helper.
+            val (epIn, epOut) = UsbDeviceCompat.selectEndpoints(iface)
             if (epIn == null || epOut == null) {
                 AppLog.e("LibusbAccessoryConnection: Unable to find endpoints")
                 synchronized(stateLock) {

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/projection/StandardUsbProjectionConnection.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/projection/StandardUsbProjectionConnection.kt
@@ -1,6 +1,5 @@
 package com.andrerinas.openheadunit.connection.projection
 
-import android.hardware.usb.UsbConstants
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbDeviceConnection
 import android.hardware.usb.UsbEndpoint
@@ -115,19 +114,11 @@ class StandardUsbProjectionConnection(usbMgr: UsbManager, device: UsbDevice) :
 
     private fun initEndpoint(): Int {
         AppLog.i("Check accessory endpoints")
-        endpointIn = null
-        endpointOut = null
-
-        for (i in 0 until usbInterface!!.endpointCount) {
-            val ep = usbInterface!!.getEndpoint(i)
-            if (ep.direction == UsbConstants.USB_DIR_IN) {
-                if (endpointIn == null) endpointIn = ep
-            } else {
-                if (endpointOut == null) endpointOut = ep
-            }
-        }
+        val (selectedIn, selectedOut) = UsbDeviceCompat.selectEndpoints(usbInterface!!)
+        endpointIn = selectedIn
+        endpointOut = selectedOut
         if (endpointIn == null || endpointOut == null) {
-            AppLog.e("Unable to find bulk endpoints")
+            AppLog.e("Unable to find an endpoint pair on the accessory interface")
             return -1
         }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbAccessoryHandoffPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbAccessoryHandoffPolicy.kt
@@ -1,0 +1,37 @@
+package com.andrerinas.openheadunit.connection.usb
+
+/**
+ * Budgets for the window between `ACC_REQ_START` and the accessory interface being claimed.
+ *
+ * The permission wait exists because `UsbProfileGroupSettingsManager.deviceAttached()` broadcasts
+ * the attach before `resolveActivity()` grants the device, so our own receiver can reach the
+ * re-enumerated 0x2D00 first. Polling is a local workaround for that ordering, not a blessed
+ * pattern: after the budget we fall back to the ordinary permission dialog.
+ */
+object UsbAccessoryHandoffPolicy {
+
+    /** Re-check `hasPermission` on this cadence rather than raising a dialog straight away. */
+    const val PERMISSION_POLL_INTERVAL_MS = 200L
+
+    /**
+     * Give up and ask the user after this long. Must stay under
+     * [UsbLauncherManager.ATTACH_FALLBACK_DELAY_MS] so the retry resolves before the fallback that
+     * would start a competing switch.
+     */
+    const val PERMISSION_POLL_BUDGET_MS = 1_000L
+
+    /**
+     * How long a switch claim stays live without being released. Sized to outlast a worst-case
+     * switch (eight control transfers at [UsbAccessoryMode] timeout, plus the settle), because the
+     * activity that stakes it is `noHistory` and can be finished before its release runs.
+     */
+    const val SWITCH_CLAIM_TTL_MS = 10_000L
+
+    fun shouldKeepPollingForPermission(elapsedMs: Long): Boolean =
+        elapsedMs < PERMISSION_POLL_BUDGET_MS
+
+    /** A claim staked at [claimUntilMs] is honoured until it expires, so a dead claimer frees it. */
+    fun switchClaimIsLive(nowMs: Long, claimUntilMs: Long): Boolean = nowMs < claimUntilMs
+
+    fun claimExpiryFrom(nowMs: Long): Long = nowMs + SWITCH_CLAIM_TTL_MS
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbAccessoryMode.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbAccessoryMode.kt
@@ -107,7 +107,12 @@ class UsbAccessoryMode(private val usbMgr: UsbManager) {
     }
 
     companion object {
-        private const val USB_TIMEOUT_IN_MS = 100
+        /**
+         * 100 ms was under USB 2.0's own 500 ms allowance for the first data packet, so a slow
+         * phone read as "not an AOA device". 1000 is what the native path (`usbhelper.c`) and the
+         * other AOAP implementations use, and the timeout only bounds a device that is not replying.
+         */
+        private const val USB_TIMEOUT_IN_MS = 1000
         private const val MANUFACTURER = "Android"
         private const val MODEL = "Android Auto"
         private const val DESCRIPTION = "Android Auto"//"Android Open Automotive Protocol"

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbAttachPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbAttachPolicy.kt
@@ -1,0 +1,29 @@
+package com.andrerinas.openheadunit.connection.usb
+
+/**
+ * Decides whether an attached Android phone should be switched into accessory mode.
+ *
+ * The gate this replaces asked only whether the vendor id was Google's, so a Pixel connected and
+ * every other make fell through to the manual USB button. An empty allow list means "never
+ * configured", not "nothing is permitted" - the same fallback single-USB auto-connect makes.
+ */
+object UsbAttachPolicy {
+
+    /**
+     * @param isGoogleVendor        vendor id is 0x18D1; a Pixel, or an Android Auto dongle
+     * @param autoStartOnUsb        the user asked us to start on any USB attach
+     * @param allowListConfigured   the user has marked at least one device as allowed
+     * @param deviceAllowed         this device is on that list
+     */
+    fun shouldAttemptAoaSwitch(
+        isGoogleVendor: Boolean,
+        autoStartOnUsb: Boolean,
+        allowListConfigured: Boolean,
+        deviceAllowed: Boolean,
+    ): Boolean = when {
+        isGoogleVendor -> true
+        autoStartOnUsb -> true
+        !allowListConfigured -> true
+        else -> deviceAllowed
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbDeviceCompat.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbDeviceCompat.kt
@@ -3,6 +3,7 @@ package com.andrerinas.openheadunit.connection.usb
 import android.content.Context
 import android.hardware.usb.UsbConstants
 import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbEndpoint
 import android.hardware.usb.UsbInterface
 import android.os.Build
 import com.andrerinas.openheadunit.utils.Settings
@@ -50,6 +51,26 @@ class UsbDeviceCompat(val wrappedDevice: UsbDevice) {
             }
 
             return vidPid
+        }
+
+        /**
+         * The IN/OUT pair to run AAP over, bulk preferred. Both transports ask here so they cannot
+         * drift apart again; the rule itself is [UsbEndpointSelectionPolicy].
+         */
+        fun selectEndpoints(iface: UsbInterface): Pair<UsbEndpoint?, UsbEndpoint?> {
+            val endpoints = (0 until iface.endpointCount).map { iface.getEndpoint(it) }
+            val selection = UsbEndpointSelectionPolicy.select(
+                endpoints.map {
+                    UsbEndpointSelectionPolicy.Endpoint(
+                        isInbound = it.direction == UsbConstants.USB_DIR_IN,
+                        isBulk = it.type == UsbConstants.USB_ENDPOINT_XFER_BULK,
+                    )
+                }
+            )
+            return Pair(
+                selection.inIndex?.let { endpoints[it] },
+                selection.outIndex?.let { endpoints[it] },
+            )
         }
 
         fun isInAccessoryMode(device: UsbDevice): Boolean =

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbEndpointSelectionPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbEndpointSelectionPolicy.kt
@@ -1,0 +1,36 @@
+package com.andrerinas.openheadunit.connection.usb
+
+/**
+ * Picks the endpoint pair to run AAP over. AOAP gives 0x2D00 one interface with exactly two bulk
+ * endpoints, so bulk is what we want; a device that also exposes an interrupt endpoint would
+ * otherwise hand us that one and every transfer would fail. Falls back to any type rather than
+ * refusing, which is what both transports did before.
+ */
+object UsbEndpointSelectionPolicy {
+
+    /** One endpoint, reduced to what the choice turns on. */
+    data class Endpoint(val isInbound: Boolean, val isBulk: Boolean)
+
+    /** Indices into the interface's endpoint list; null means that direction has none. */
+    data class Selection(val inIndex: Int?, val outIndex: Int?) {
+        val isComplete: Boolean get() = inIndex != null && outIndex != null
+    }
+
+    fun select(endpoints: List<Endpoint>): Selection {
+        var inIndex: Int? = null
+        var outIndex: Int? = null
+        for (bulkOnly in listOf(true, false)) {
+            for (index in endpoints.indices) {
+                val endpoint = endpoints[index]
+                if (bulkOnly && !endpoint.isBulk) continue
+                if (endpoint.isInbound) {
+                    if (inIndex == null) inIndex = index
+                } else {
+                    if (outIndex == null) outIndex = index
+                }
+            }
+            if (inIndex != null && outIndex != null) break
+        }
+        return Selection(inIndex, outIndex)
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbLauncherListener.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbLauncherListener.kt
@@ -48,7 +48,8 @@ class UsbLauncherListener(private val manager: UsbLauncherManager) : UsbReceiver
             service.launchMainActivityIfNeeded("USB normal attach ($deviceName)")
             service.serviceScope.launch {
                 delay(ATTACH_FALLBACK_DELAY_MS)
-                if (!commManager.isConnected && !manager.isSwitchingToProjection()) {
+                if (!commManager.isConnected && !manager.isSwitchingToProjection() &&
+                    !manager.isActivitySwitchInFlight()) {
                     AppLog.i("UsbAttachedActivity didn't handle $deviceName. Trying from service...")
                     manager.checkAlreadyConnected(force = true)
                 }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbLauncherManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbLauncherManager.kt
@@ -226,14 +226,28 @@ class UsbLauncherManager(val service: AapService) {
             }
         }
 
-        // Fallback: if force=true and we have a single Google VID device in normal mode,
+        // Fallback: if force=true and exactly one Android phone is attached in normal mode,
         // switch it to accessory mode. This handles cases where UsbAttachedActivity didn't fire.
+        //
+        // [BUG_FIX] This used to require vendor id 0x18D1, so it fired for a Pixel and for nothing
+        // else; every other make reached the end of this function having done nothing and could
+        // only be connected by hand. deviceList is already isAndroidDevice()-filtered.
         if (force) {
             val nonAccessoryDevices = deviceList.filter { !UsbDeviceCompat.isInAccessoryMode(it) }
-            val googleDevices = nonAccessoryDevices.filter { it.vendorId == 0x18D1 }
-            if (googleDevices.size == 1) {
-                AppLog.i("Fallback: force=true and found single Google normal-mode device ${UsbDeviceCompat(googleDevices[0]).uniqueName}. Switching to accessory mode.")
-                performSingleConnect(googleDevices[0])
+            val allowList = settings.allowedDevices
+            val candidates = nonAccessoryDevices.filter {
+                UsbAttachPolicy.shouldAttemptAoaSwitch(
+                    isGoogleVendor = it.vendorId == 0x18D1,
+                    autoStartOnUsb = usbAutoStart,
+                    allowListConfigured = allowList.isNotEmpty(),
+                    deviceAllowed = settings.isConnectingDevice(UsbDeviceCompat(it)),
+                )
+            }
+            if (candidates.size == 1) {
+                AppLog.i("Fallback: force=true and found single normal-mode Android device ${UsbDeviceCompat(candidates[0]).uniqueName}. Switching to accessory mode.")
+                performSingleConnect(candidates[0])
+            } else if (candidates.isNotEmpty()) {
+                AppLog.i("Fallback: force=true but ${candidates.size} candidate USB devices are attached; not guessing which is the phone")
             }
         }
     }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbLauncherManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbLauncherManager.kt
@@ -38,6 +38,14 @@ class UsbLauncherManager(val service: AapService) {
 
     fun isSwitchingToProjection() = this.isSwitchingToProjection.get()
 
+    /**
+     * True while `UsbAttachedActivity` is running its own AOA switch, so the attach fallback does
+     * not start a second one. Deliberately not folded into [isSwitchingToProjection]: that would
+     * also silence the accessory-attach connect and the detach re-sync, which are this path's
+     * recovery rather than its competition.
+     */
+    fun isActivitySwitchInFlight() = UsbSwitchClaim.isLive()
+
     fun setSwitchingToProjection(value: Boolean) = this.isSwitchingToProjection.set(value)
 
     fun register() {
@@ -148,15 +156,12 @@ class UsbLauncherManager(val service: AapService) {
             if (UsbDeviceCompat.isInAccessoryMode(device)) {
                 val deviceName = UsbDeviceCompat(device).uniqueName
                 AppLog.i("Found device already in accessory mode: $deviceName")
-                if (!usbManager.hasPermission(device)) {
-                    AppLog.i("Accessory-mode device has no permission (re-enumerated); requesting permission: $deviceName")
-                    requestPermission(device)
-                    return
-                }
                 isSwitchingToProjection.set(true)
                 service.serviceScope.launch {
                     try {
-                        connectWithRetry(device)
+                        if (awaitAccessoryPermission(usbManager, device, deviceName)) {
+                            connectWithRetry(device)
+                        }
                     } finally {
                         isSwitchingToProjection.set(false)
                     }
@@ -276,6 +281,33 @@ class UsbLauncherManager(val service: AapService) {
             AppLog.i("Single USB auto-connect: device found but no permission, requesting...")
             requestPermission(device)
         }
+    }
+
+    /**
+     * Wait briefly for the manifest auto-grant on a freshly re-enumerated 0x2D00 before falling
+     * back to a dialog. The grant arrives with the activity the system launches for the attach, so
+     * the service's own receiver reaches this a few hundred ms early and used to raise a prompt the
+     * dongle did not stay in accessory mode long enough to answer.
+     */
+    private suspend fun awaitAccessoryPermission(
+        usbManager: UsbManager,
+        device: UsbDevice,
+        deviceName: String,
+    ): Boolean {
+        if (usbManager.hasPermission(device)) return true
+
+        val startedAt = System.currentTimeMillis()
+        while (UsbAccessoryHandoffPolicy.shouldKeepPollingForPermission(System.currentTimeMillis() - startedAt)) {
+            delay(UsbAccessoryHandoffPolicy.PERMISSION_POLL_INTERVAL_MS)
+            if (usbManager.hasPermission(device)) {
+                AppLog.i("Accessory-mode permission arrived after ${System.currentTimeMillis() - startedAt}ms: $deviceName")
+                return true
+            }
+        }
+
+        AppLog.i("Accessory-mode device has no permission (re-enumerated); requesting permission: $deviceName")
+        requestPermission(device)
+        return false
     }
 
     /**

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbSwitchClaim.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/usb/UsbSwitchClaim.kt
@@ -1,0 +1,25 @@
+package com.andrerinas.openheadunit.connection.usb
+
+/**
+ * A process-wide "an AOA switch is running" flag, staked by `UsbAttachedActivity`.
+ *
+ * The activity switches on its own thread and cannot reach [UsbLauncherManager], which may not
+ * exist yet on a cold start; both live in the same process, so a static is what is visible early
+ * enough. Only the attach fallback reads it - see [UsbLauncherManager.isActivitySwitchInFlight].
+ */
+object UsbSwitchClaim {
+
+    @Volatile
+    private var claimUntilMs = 0L
+
+    fun stake() {
+        claimUntilMs = UsbAccessoryHandoffPolicy.claimExpiryFrom(System.currentTimeMillis())
+    }
+
+    fun release() {
+        claimUntilMs = 0L
+    }
+
+    fun isLive(): Boolean =
+        UsbAccessoryHandoffPolicy.switchClaimIsLive(System.currentTimeMillis(), claimUntilMs)
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/usb/UsbAccessoryHandoffPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/usb/UsbAccessoryHandoffPolicyTest.kt
@@ -1,0 +1,66 @@
+package com.andrerinas.openheadunit.connection.usb
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** The budgets that decide whether we win the accessory-mode window. */
+class UsbAccessoryHandoffPolicyTest {
+
+    @Test
+    fun `permission is re-checked while the budget lasts`() {
+        assertTrue(UsbAccessoryHandoffPolicy.shouldKeepPollingForPermission(elapsedMs = 0L))
+        assertTrue(UsbAccessoryHandoffPolicy.shouldKeepPollingForPermission(elapsedMs = 999L))
+    }
+
+    @Test
+    fun `permission polling stops at the budget, so the dialog is still reachable`() {
+        assertFalse(UsbAccessoryHandoffPolicy.shouldKeepPollingForPermission(elapsedMs = 1_000L))
+        assertFalse(UsbAccessoryHandoffPolicy.shouldKeepPollingForPermission(elapsedMs = 5_000L))
+    }
+
+    /**
+     * The retry has to resolve before the attach fallback would fire, or the fallback starts a
+     * second AOA switch on a device we are already waiting on.
+     */
+    @Test
+    fun `the permission budget fits inside the attach fallback delay`() {
+        assertTrue(
+            UsbAccessoryHandoffPolicy.PERMISSION_POLL_BUDGET_MS <
+                UsbLauncherManager.ATTACH_FALLBACK_DELAY_MS
+        )
+    }
+
+    @Test
+    fun `a fresh claim is live and an expired one is not`() {
+        val now = 10_000L
+        val until = UsbAccessoryHandoffPolicy.claimExpiryFrom(now)
+
+        assertTrue(UsbAccessoryHandoffPolicy.switchClaimIsLive(nowMs = now, claimUntilMs = until))
+        assertTrue(UsbAccessoryHandoffPolicy.switchClaimIsLive(nowMs = until - 1, claimUntilMs = until))
+        assertFalse(UsbAccessoryHandoffPolicy.switchClaimIsLive(nowMs = until, claimUntilMs = until))
+    }
+
+    /** A released claim is stored as 0, which must never read as live. */
+    @Test
+    fun `a released claim is not live`() {
+        assertFalse(UsbAccessoryHandoffPolicy.switchClaimIsLive(nowMs = 0L, claimUntilMs = 0L))
+        assertFalse(UsbAccessoryHandoffPolicy.switchClaimIsLive(nowMs = 1_000L, claimUntilMs = 0L))
+    }
+
+    /**
+     * The claim has to outlive the switch it guards, or an activity finished by `noHistory` before
+     * it could release leaves the attach fallback free to start a second switch mid-flight.
+     */
+    @Test
+    fun `the claim TTL outlasts the switch it covers`() {
+        assertTrue(
+            UsbAccessoryHandoffPolicy.SWITCH_CLAIM_TTL_MS >
+                UsbAccessoryHandoffPolicy.PERMISSION_POLL_BUDGET_MS
+        )
+        assertTrue(
+            UsbAccessoryHandoffPolicy.SWITCH_CLAIM_TTL_MS >
+                UsbLauncherManager.ATTACH_FALLBACK_DELAY_MS
+        )
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/usb/UsbAttachPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/usb/UsbAttachPolicyTest.kt
@@ -1,0 +1,94 @@
+package com.andrerinas.openheadunit.connection.usb
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UsbAttachPolicyTest {
+
+    @Test
+    fun `google vendor is always attempted`() {
+        assertTrue(
+            UsbAttachPolicy.shouldAttemptAoaSwitch(
+                isGoogleVendor = true,
+                autoStartOnUsb = false,
+                allowListConfigured = true,
+                deviceAllowed = false,
+            )
+        )
+    }
+
+    @Test
+    fun `auto start on usb overrides the allow list`() {
+        assertTrue(
+            UsbAttachPolicy.shouldAttemptAoaSwitch(
+                isGoogleVendor = false,
+                autoStartOnUsb = true,
+                allowListConfigured = true,
+                deviceAllowed = false,
+            )
+        )
+    }
+
+    /**
+     * The reporter's case. A Samsung phone (0x04E8), auto-start off, and a fresh install whose
+     * allow list has never been written. This returned false before and was the whole defect.
+     */
+    @Test
+    fun `unconfigured allow list lets an android phone through`() {
+        assertTrue(
+            UsbAttachPolicy.shouldAttemptAoaSwitch(
+                isGoogleVendor = false,
+                autoStartOnUsb = false,
+                allowListConfigured = false,
+                deviceAllowed = false,
+            )
+        )
+    }
+
+    @Test
+    fun `a configured allow list still excludes a device that is not on it`() {
+        assertFalse(
+            UsbAttachPolicy.shouldAttemptAoaSwitch(
+                isGoogleVendor = false,
+                autoStartOnUsb = false,
+                allowListConfigured = true,
+                deviceAllowed = false,
+            )
+        )
+    }
+
+    @Test
+    fun `a configured allow list admits a device that is on it`() {
+        assertTrue(
+            UsbAttachPolicy.shouldAttemptAoaSwitch(
+                isGoogleVendor = false,
+                autoStartOnUsb = false,
+                allowListConfigured = true,
+                deviceAllowed = true,
+            )
+        )
+    }
+
+    /** The only combination that may refuse: a list exists and this device is absent from it. */
+    @Test
+    fun `refusal requires a configured list that excludes the device`() {
+        for (google in listOf(true, false)) {
+            for (autoStart in listOf(true, false)) {
+                for (configured in listOf(true, false)) {
+                    for (allowed in listOf(true, false)) {
+                        val attempt = UsbAttachPolicy.shouldAttemptAoaSwitch(
+                            google, autoStart, configured, allowed
+                        )
+                        if (!attempt) {
+                            assertFalse(google)
+                            assertFalse(autoStart)
+                            assertTrue(configured)
+                            assertFalse(allowed)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/usb/UsbEndpointSelectionPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/usb/UsbEndpointSelectionPolicyTest.kt
@@ -1,0 +1,83 @@
+package com.andrerinas.openheadunit.connection.usb
+
+import com.andrerinas.openheadunit.connection.usb.UsbEndpointSelectionPolicy.Endpoint
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Which endpoint pair AAP runs over. Both USB transports ask this. */
+class UsbEndpointSelectionPolicyTest {
+
+    private fun bulkIn() = Endpoint(isInbound = true, isBulk = true)
+    private fun bulkOut() = Endpoint(isInbound = false, isBulk = true)
+    private fun interruptIn() = Endpoint(isInbound = true, isBulk = false)
+    private fun interruptOut() = Endpoint(isInbound = false, isBulk = false)
+
+    /** What AOAP actually gives us on 0x2D00: one interface, one bulk pair. */
+    @Test
+    fun `the plain accessory interface picks its only pair`() {
+        val selection = UsbEndpointSelectionPolicy.select(listOf(bulkIn(), bulkOut()))
+
+        assertEquals(0, selection.inIndex)
+        assertEquals(1, selection.outIndex)
+        assertTrue(selection.isComplete)
+    }
+
+    /** The bug: an interrupt endpoint listed first used to win, and every transfer then failed. */
+    @Test
+    fun `an interrupt endpoint never beats a bulk one in the same direction`() {
+        val selection = UsbEndpointSelectionPolicy.select(
+            listOf(interruptIn(), bulkOut(), bulkIn())
+        )
+
+        assertEquals(2, selection.inIndex)
+        assertEquals(1, selection.outIndex)
+    }
+
+    @Test
+    fun `order within the bulk endpoints does not matter`() {
+        val selection = UsbEndpointSelectionPolicy.select(listOf(bulkOut(), bulkIn()))
+
+        assertEquals(1, selection.inIndex)
+        assertEquals(0, selection.outIndex)
+    }
+
+    /** Falling back to any type keeps the behaviour both transports had before. */
+    @Test
+    fun `a device with no bulk endpoints still yields a pair`() {
+        val selection = UsbEndpointSelectionPolicy.select(listOf(interruptIn(), interruptOut()))
+
+        assertEquals(0, selection.inIndex)
+        assertEquals(1, selection.outIndex)
+        assertTrue(selection.isComplete)
+    }
+
+    /** A half-bulk interface takes the bulk side and falls back only for the direction that lacks one. */
+    @Test
+    fun `the fallback fills only the direction that has no bulk endpoint`() {
+        val selection = UsbEndpointSelectionPolicy.select(listOf(interruptOut(), bulkIn()))
+
+        assertEquals(1, selection.inIndex)
+        assertEquals(0, selection.outIndex)
+    }
+
+    @Test
+    fun `a one-directional interface is refused rather than half claimed`() {
+        val selection = UsbEndpointSelectionPolicy.select(listOf(bulkIn(), interruptIn()))
+
+        assertEquals(0, selection.inIndex)
+        assertNull(selection.outIndex)
+        assertFalse(selection.isComplete)
+    }
+
+    @Test
+    fun `an interface with no endpoints is refused`() {
+        val selection = UsbEndpointSelectionPolicy.select(emptyList())
+
+        assertNull(selection.inIndex)
+        assertNull(selection.outIndex)
+        assertFalse(selection.isComplete)
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/usb/UsbSwitchClaimTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/usb/UsbSwitchClaimTest.kt
@@ -1,0 +1,50 @@
+package com.andrerinas.openheadunit.connection.usb
+
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/** The flag the attach fallback reads to tell our own switch from a device nobody is handling. */
+class UsbSwitchClaimTest {
+
+    @Before
+    @After
+    fun clearClaim() {
+        UsbSwitchClaim.release()
+    }
+
+    @Test
+    fun `nothing is claimed until something stakes one`() {
+        assertFalse(UsbSwitchClaim.isLive())
+    }
+
+    @Test
+    fun `a staked claim is live and a released one is not`() {
+        UsbSwitchClaim.stake()
+        assertTrue(UsbSwitchClaim.isLive())
+
+        UsbSwitchClaim.release()
+        assertFalse(UsbSwitchClaim.isLive())
+    }
+
+    /** Releasing a claim nobody staked must not resurrect one. */
+    @Test
+    fun `release is idempotent`() {
+        UsbSwitchClaim.release()
+        UsbSwitchClaim.release()
+
+        assertFalse(UsbSwitchClaim.isLive())
+    }
+
+    /** Re-staking pushes the expiry out rather than stacking claims that need matching releases. */
+    @Test
+    fun `a second stake still needs only one release`() {
+        UsbSwitchClaim.stake()
+        UsbSwitchClaim.stake()
+        UsbSwitchClaim.release()
+
+        assertFalse(UsbSwitchClaim.isLive())
+    }
+}


### PR DESCRIPTION
WHY

- The AOA switch gate only passed vendor id 0x18D1, so a Pixel or an AA dongle
  worked and every other make fell through to the manual USB button. An empty
  allow list was read as "nothing permitted" when it means "never configured".
- UsbAttachedActivity is the system's default handler once registered, so
  declining with a bare finish() was the end of the road for that plug-in: no
  chooser, nothing else told.
- On a re-enumerated 0x2D00 the service beat the manifest auto-grant and raised a
  permission dialog a fast-reverting dongle never stayed connected long enough to
  answer.
- The 100 ms control-transfer timeout sat under USB 2.0's own first-packet
  allowance, so a slow phone read as "not an AOA device".
- The attach fallback could start a second AOA switch on a device the activity
  was already switching; the two USB transports each carried their own
  endpoint-selection copy that had drifted apart once.

HOW

- New UsbAttachPolicy states the rule once (Google vendor, or auto-start-on-USB,
  or no allow list configured, else honour the list); both the activity gate and
  the force=true service fallback call it.
- When the activity declines it hands the attach to AapService (ACTION_CHECK_USB)
  instead of swallowing it.
- UsbAttachedActivity gets noHistory / excludeFromRecents / empty taskAffinity so
  each attach lands in a fresh instance.
- awaitAccessoryPermission() polls hasPermission for up to 1 s (inside the
  attach-fallback window) before falling back to the dialog, so the auto-grant
  wins.
- UsbSwitchClaim is a process-wide flag the activity stakes around its switch,
  with a 10 s TTL and a finally release; the attach fallback checks it so it does
  not compete.
- UsbEndpointSelectionPolicy gives both transports one bulk-first endpoint
  choice, falling back to any type.
- Control-transfer timeout raised 100 ms to 1000 ms, matching the native path.
- New logic is pure policy objects with unit tests.