### PR TITLE
Video fit and ultrawide touch

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
@@ -894,6 +894,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
 
                             // Lock the resolution so that orientation changes don't cause re-negotiation
                             HeadUnitScreenConfig.lockResolution()
+                            HeadUnitScreenConfig.onMarginsDiverged = ::onMarginsDiverged
                             applyOrientationSettings()
 
                             // Handshake done. If the surface is already ready (e.g. reconnect
@@ -1779,16 +1780,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
                 AppLog.i("[UI_DEBUG_FIX] Skipping surface dimension cache update due to transient orientation mismatch: ${width}x${height}")
             }
 
-            if (commManager.connectionState.value is CommManager.ConnectionState.TransportStarted) {
-                // AA is already running → send corrected per-side margins dynamically
-                commManager.sendUpdateUiConfigRequest(
-                    HeadUnitScreenConfig.getLeftMargin(),
-                    HeadUnitScreenConfig.getTopMargin(),
-                    HeadUnitScreenConfig.getRightMargin(),
-                    HeadUnitScreenConfig.getBottomMargin()
-                )
-                AppLog.i("[UI_DEBUG_FIX] AA is already running, send corrected via sendUpdateUiConfigRequest")
-            }
+            reannounceMargins()
             // If transport not started yet, ServiceDiscoveryResponse will use the corrected values automatically.
         }
 
@@ -1869,6 +1861,42 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
             projectionView.setVideoSize(width, height)
             ProjectionViewScaler.updateScale(projectionView as View, width, height)
         }
+    }
+
+    /**
+     * Send the panel's per-side margins to a running session. False when there is no session to
+     * tell, which leaves the announced margins standing so the next recalculate tries again.
+     * A surface change reaches here twice, through recalculate and then directly; one send.
+     */
+    private fun reannounceMargins(): Boolean {
+        if (commManager.connectionState.value !is CommManager.ConnectionState.TransportStarted) {
+            return false
+        }
+        if (HeadUnitScreenConfig.marginsMatchAnnounced()) return true
+        commManager.sendUpdateUiConfigRequest(
+            HeadUnitScreenConfig.getLeftMargin(),
+            HeadUnitScreenConfig.getTopMargin(),
+            HeadUnitScreenConfig.getRightMargin(),
+            HeadUnitScreenConfig.getBottomMargin()
+        )
+        HeadUnitScreenConfig.recordAnnouncedMargins(
+            HeadUnitScreenConfig.getWidthMargin(), HeadUnitScreenConfig.getHeightMargin()
+        )
+        AppLog.i("[UI_DEBUG_FIX] AA is already running, send corrected via sendUpdateUiConfigRequest")
+        return true
+    }
+
+    /**
+     * The margins moved after they were announced, which on a device whose insets are still
+     * settling also means the scale was computed against the old reading. Re-announce and redraw.
+     */
+    private fun onMarginsDiverged(): Boolean {
+        val reannounced = reannounceMargins()
+        runOnUiThread {
+            val view = projectionView as? View ?: return@runOnUiThread
+            ProjectionViewScaler.updateScale(view, videoDecoder.videoWidth, videoDecoder.videoHeight)
+        }
+        return reannounced
     }
 
     private fun sendTouchEvent(event: MotionEvent) {
@@ -1996,6 +2024,8 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
 
     override fun onDestroy() {
         super.onDestroy()
+        HeadUnitScreenConfig.onMarginsDiverged = null
+        HeadUnitScreenConfig.clearAnnouncedMargins()
         closeCallRaiseEpisode("the projection is going away")
         unregisterAudioModeListener()
         if (isFinishReceiverRegistered) {

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
@@ -1908,77 +1908,35 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         val marginW = HeadUnitScreenConfig.getWidthMargin().toFloat()
         val marginH = HeadUnitScreenConfig.getHeightMargin().toFloat()
 
-        // Logic check: When forcedScale is active, the visual behavior of 'stretchToFill'
-        // is inverted (True = Aspect Ratio Centered, False = Stretched to Screen).
-        // We adjust the touch mapping to match this visual reality.
-        val isStretch = if (HeadUnitScreenConfig.forcedScale) {
-            !settings.stretchToFill
-        } else {
-            settings.stretchToFill
-        }
-
         val pointerData = mutableListOf<Triple<Int, Int, Int>>()
         repeat(event.pointerCount) { pointerIndex ->
             val pointerId = event.getPointerId(pointerIndex)
-            if (measuredTouchSurfaceEnabled) {
-                val corrected = TouchCoordinateMapper.map(
-                    rawX = event.getX(pointerIndex),
-                    rawY = event.getY(pointerIndex),
-                    inputSurfaceWidth = viewW,
-                    inputSurfaceHeight = viewH,
-                    negotiatedWidth = videoW,
-                    negotiatedHeight = videoH,
-                    marginWidth = marginW,
-                    marginHeight = marginH,
-                    stretchToFill = isStretch,
-                    hudMirroring = settings.hudMirroring
-                )
+            // measuredTouchSurfaceEnabled already chose viewW/viewH above; the mapping is the same
+            // either way, so there is one implementation of it now.
+            val corrected = TouchCoordinateMapper.map(
+                rawX = event.getX(pointerIndex),
+                rawY = event.getY(pointerIndex),
+                inputSurfaceWidth = viewW,
+                inputSurfaceHeight = viewH,
+                negotiatedWidth = videoW,
+                negotiatedHeight = videoH,
+                marginWidth = marginW,
+                marginHeight = marginH,
+                fitMode = settings.videoFitMode,
+                hudMirroring = settings.hudMirroring
+            )
+            pointerData.add(Triple(pointerId, corrected.x, corrected.y))
+        }
 
-                pointerData.add(Triple(pointerId, corrected.x, corrected.y))
-            } else {
-                val rawPx = event.getX(pointerIndex)
-                val px = if (settings.hudMirroring) (viewW - rawPx) else rawPx
-                val py = event.getY(pointerIndex)
-
-                val videoX: Float
-                val videoY: Float
-
-                if (HeadUnitScreenConfig.isUltrawideEnabled() && HeadUnitScreenConfig.getUsableWidth() >= 1700) {
-                    // Ultrawide Sidebar-Aware Mapping
-                    videoX = (px / viewW) * videoW
-                    videoY = (py / viewH) * videoH
-                } else if (isStretch) {
-                    videoX = (px / viewW) * (videoW - marginW)
-                    videoY = (py / viewH) * (videoH - marginH)
-                } else {
-                    val uiW = videoW - marginW
-                    val uiH = videoH - marginH
-                    val uiRatio = uiW / uiH
-                    val viewRatio = viewW / viewH
-
-                    var displayedUiW = viewW
-                    var displayedUiH = viewH
-
-                    if (viewRatio > uiRatio) {
-                        displayedUiW = viewH * uiRatio
-                    } else {
-                        displayedUiH = viewW / uiRatio
-                    }
-
-                    val uiLeft = (viewW - displayedUiW) / 2f
-                    val uiTop = (viewH - displayedUiH) / 2f
-
-                    val localX = px - uiLeft
-                    val localY = py - uiTop
-
-                    videoX = (localX / displayedUiW) * uiW
-                    videoY = (localY / displayedUiH) * uiH
-                }
-
-                val correctedX = videoX.toInt().coerceIn(0, videoW)
-                val correctedY = videoY.toInt().coerceIn(0, videoH)
-                pointerData.add(Triple(pointerId, correctedX, correctedY))
-            }
+        // The only instrument that says whether a tap reached the pixel it looked like it hit.
+        // Verbose because it is one line per pointer per motion event.
+        if (AppLog.LOG_VERBOSE) {
+            val first = pointerData.firstOrNull()
+            AppLog.v(
+                "[UI_DEBUG] Touch map: raw=${event.getX(0).toInt()},${event.getY(0).toInt()} " +
+                    "-> video=${first?.second},${first?.third} view=${viewW.toInt()}x${viewH.toInt()} " +
+                    "video=${videoW}x${videoH} margin=${marginW.toInt()}x${marginH.toInt()} fit=${settings.videoFitMode}"
+            )
         }
 
         commManager.send(TouchEvent(ts, action, event.actionIndex, pointerData))

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
@@ -1756,30 +1756,30 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         val prevUsableW = HeadUnitScreenConfig.getUsableWidth()
         val prevUsableH = HeadUnitScreenConfig.getUsableHeight()
 
-        if (HeadUnitScreenConfig.updateSurfaceDimensions(width, height)) {
+        val anchorMoved = HeadUnitScreenConfig.updateSurfaceDimensions(width, height)
+
+        // What is cached is the usable area, which the screen config has already turned the right
+        // way up, so the orientation guard this used to carry could only reject a correct reading.
+        val shouldCache = !App.isPiPActive
+
+        // Cached whether or not the anchor moved: service discovery answers before any surface
+        // exists, so next session's announcement has only this to go on.
+        val canvasW = HeadUnitScreenConfig.getUsableWidth()
+        val canvasH = HeadUnitScreenConfig.getUsableHeight()
+        val canvasHash = HeadUnitScreenConfig.computeSettingsHash(settings)
+        if (shouldCache && (settings.cachedSurfaceWidth != canvasW ||
+                settings.cachedSurfaceHeight != canvasH ||
+                settings.cachedSurfaceSettingsHash != canvasHash)
+        ) {
+            settings.cachedSurfaceWidth = canvasW
+            settings.cachedSurfaceHeight = canvasH
+            settings.cachedSurfaceSettingsHash = canvasHash
+        } else if (!shouldCache) {
+            AppLog.i("[UI_DEBUG_FIX] Skipping surface dimension cache update due to transient orientation mismatch: ${width}x${height}")
+        }
+
+        if (anchorMoved) {
             AppLog.i("[UI_DEBUG_FIX] Surface mismatch! Expected: ${prevUsableW}x${prevUsableH}, Actual: ${width}x${height}")
-
-            // Cache the real surface size for next session only if orientation matches expected setting
-            val isTargetLandscape = settings.screenOrientation == Settings.ScreenOrientation.LANDSCAPE ||
-                settings.screenOrientation == Settings.ScreenOrientation.LANDSCAPE_REVERSE
-            val isTargetPortrait = settings.screenOrientation == Settings.ScreenOrientation.PORTRAIT ||
-                settings.screenOrientation == Settings.ScreenOrientation.PORTRAIT_REVERSE
-            val surfaceIsLandscape = width >= height
-
-            val shouldCache = when {
-                isTargetLandscape -> surfaceIsLandscape
-                isTargetPortrait -> !surfaceIsLandscape
-                else -> true
-            }
-
-            if (shouldCache) {
-                settings.cachedSurfaceWidth = HeadUnitScreenConfig.getUsableWidth()
-                settings.cachedSurfaceHeight = HeadUnitScreenConfig.getUsableHeight()
-                settings.cachedSurfaceSettingsHash = HeadUnitScreenConfig.computeSettingsHash(settings)
-            } else {
-                AppLog.i("[UI_DEBUG_FIX] Skipping surface dimension cache update due to transient orientation mismatch: ${width}x${height}")
-            }
-
             reannounceMargins()
             // If transport not started yet, ServiceDiscoveryResponse will use the corrected values automatically.
         }
@@ -1912,24 +1912,16 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         }
 
         val view = projectionView as View
-        val effectiveFullscreenMode = activityFullscreenOverride ?: settings.fullscreenMode
-        val measuredTouchSurfaceEnabled = settings.useMeasuredTouchSurface &&
-            effectiveFullscreenMode == Settings.FullscreenMode.IMMERSIVE
+        // The coordinates come from the overlay, so only the overlay can be the denominator. The
+        // screen config is the fallback for a touch that beats the first layout, and outside
+        // immersive it describes the display rather than the window this event was measured in.
         val overlay = touchOverlayView
-        val viewW = if (measuredTouchSurfaceEnabled) {
-            (overlay?.width ?: 0).takeIf { it > 0 }?.toFloat()
-                ?: view.width.takeIf { it > 0 }?.toFloat()
-                ?: HeadUnitScreenConfig.getUsableWidth().toFloat()
-        } else {
-            HeadUnitScreenConfig.getUsableWidth().toFloat()
-        }
-        val viewH = if (measuredTouchSurfaceEnabled) {
-            (overlay?.height ?: 0).takeIf { it > 0 }?.toFloat()
-                ?: view.height.takeIf { it > 0 }?.toFloat()
-                ?: HeadUnitScreenConfig.getUsableHeight().toFloat()
-        } else {
-            HeadUnitScreenConfig.getUsableHeight().toFloat()
-        }
+        val viewW = (overlay?.width ?: 0).takeIf { it > 0 }?.toFloat()
+            ?: view.width.takeIf { it > 0 }?.toFloat()
+            ?: HeadUnitScreenConfig.getUsableWidth().toFloat()
+        val viewH = (overlay?.height ?: 0).takeIf { it > 0 }?.toFloat()
+            ?: view.height.takeIf { it > 0 }?.toFloat()
+            ?: HeadUnitScreenConfig.getUsableHeight().toFloat()
 
         if (viewW <= 0 || viewH <= 0) return
 
@@ -1939,8 +1931,6 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         val pointerData = mutableListOf<Triple<Int, Int, Int>>()
         repeat(event.pointerCount) { pointerIndex ->
             val pointerId = event.getPointerId(pointerIndex)
-            // measuredTouchSurfaceEnabled already chose viewW/viewH above; the mapping is the same
-            // either way, so there is one implementation of it now.
             val corrected = TouchCoordinateMapper.map(
                 rawX = event.getX(pointerIndex),
                 rawY = event.getY(pointerIndex),

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/ServiceDiscoveryResponse.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/ServiceDiscoveryResponse.kt
@@ -88,6 +88,8 @@ class ServiceDiscoveryResponse(private val context: Context)
                     val negotiatedResolution = HeadUnitScreenConfig.negotiatedResolutionType
                     val phoneWidthMargin = HeadUnitScreenConfig.getWidthMargin()
                     val phoneHeightMargin = HeadUnitScreenConfig.getHeightMargin()
+                    // What goes on the wire, so a later metrics change can be seen to have left it.
+                    HeadUnitScreenConfig.recordAnnouncedMargins(phoneWidthMargin, phoneHeightMargin)
 
                     // Enforce H.265 for 1440p resolution as required by Android Auto.
                     // Software HEVC is allowed only when the user explicitly selected it.
@@ -112,6 +114,7 @@ class ServiceDiscoveryResponse(private val context: Context)
                     logNegotiatedCodecCapability(effectiveCodec, announcedFps)
                     logNarrowBandProfile(context, settings)
                     AppLog.i("[ServiceDiscovery] Margins are: ${phoneWidthMargin}x${phoneHeightMargin}")
+                    AppLog.i("[ServiceDiscovery] PixelAspectRatioE4 is: ${HeadUnitScreenConfig.getPixelAspectRatioE4()} (10000 = square)")
 
                     mediaSinkServiceBuilder.addVideoConfigs(Control.Service.MediaSinkService.VideoConfiguration.newBuilder().apply {
                         codecResolution = negotiatedResolution

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/ServiceDiscoveryResponse.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/ServiceDiscoveryResponse.kt
@@ -90,6 +90,9 @@ class ServiceDiscoveryResponse(private val context: Context)
                     val phoneHeightMargin = HeadUnitScreenConfig.getHeightMargin()
                     // What goes on the wire, so a later metrics change can be seen to have left it.
                     HeadUnitScreenConfig.recordAnnouncedMargins(phoneWidthMargin, phoneHeightMargin)
+                    // The pixel shape goes out here and nowhere else, so this is the canvas the
+                    // rest of the session is committed to.
+                    HeadUnitScreenConfig.recordAnnouncedCanvas()
 
                     // Enforce H.265 for 1440p resolution as required by Android Auto.
                     // Software HEVC is allowed only when the user explicitly selected it.

--- a/app/src/main/java/com/andrerinas/openheadunit/input/TouchCoordinateMapper.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/input/TouchCoordinateMapper.kt
@@ -1,5 +1,6 @@
 package com.andrerinas.openheadunit.input
 
+import com.andrerinas.openheadunit.utils.Settings
 import kotlin.math.roundToInt
 
 data class TouchCoordinate(
@@ -17,7 +18,7 @@ object TouchCoordinateMapper {
         negotiatedHeight: Int,
         marginWidth: Float,
         marginHeight: Float,
-        stretchToFill: Boolean,
+        fitMode: Settings.VideoFitMode,
         hudMirroring: Boolean
     ): TouchCoordinate {
         val surfaceW = inputSurfaceWidth.coerceAtLeast(1f)
@@ -30,7 +31,7 @@ object TouchCoordinateMapper {
         val videoX: Float
         val videoY: Float
 
-        if (stretchToFill) {
+        if (fitMode == Settings.VideoFitMode.FILL) {
             videoX = (px / surfaceW) * uiW
             videoY = (rawY / surfaceH) * uiH
         } else {
@@ -40,7 +41,12 @@ object TouchCoordinateMapper {
             var displayedUiW = surfaceW
             var displayedUiH = surfaceH
 
-            if (viewRatio > uiRatio) {
+            // CONTAIN picks the smaller fit (letterboxed, <= surface); COVER picks the larger
+            // fit (cropped, >= surface) - same shape of math, opposite branch selection.
+            val screenIsRelativelyWider = viewRatio > uiRatio
+            val matchWidthToHeight = if (fitMode == Settings.VideoFitMode.COVER) !screenIsRelativelyWider else screenIsRelativelyWider
+
+            if (matchWidthToHeight) {
                 displayedUiW = surfaceH * uiRatio
             } else {
                 displayedUiH = surfaceW / uiRatio

--- a/app/src/main/java/com/andrerinas/openheadunit/input/TouchCoordinateMapper.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/input/TouchCoordinateMapper.kt
@@ -27,6 +27,10 @@ object TouchCoordinateMapper {
 
         val uiW = negotiatedWidth - marginWidth
         val uiH = negotiatedHeight - marginHeight
+        // Android Auto draws at the buffer's top-left and leaves the announced margin at the
+        // bottom, measured from the coordinate it logged receiving. Centring the canvas here put
+        // every tap half the margin low, one control down. The renderer's centre pivot and the
+        // symmetric insets both suggest otherwise; neither describes what the phone does.
 
         val videoX: Float
         val videoY: Float

--- a/app/src/main/java/com/andrerinas/openheadunit/main/QuickSettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/QuickSettingsFragment.kt
@@ -39,7 +39,6 @@ class QuickSettingsFragment : DialogFragment() {
     private lateinit var toolbar: MaterialToolbar
     
     private var originalViewMode: Settings.ViewMode? = null
-    private var originalStretch: Boolean? = null
     private var originalScale: Boolean? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -56,7 +55,6 @@ class QuickSettingsFragment : DialogFragment() {
         
         settings = App.provide(requireContext()).settings
         originalViewMode = settings.viewMode
-        originalStretch = settings.stretchToFill
         originalScale = settings.forcedScale
 
         toolbar = view.findViewById<MaterialToolbar>(R.id.toolbar)
@@ -140,17 +138,11 @@ class QuickSettingsFragment : DialogFragment() {
             onClick = { showFullscreenDialog() }
         ))
 
-        items.add(SettingItem.ToggleSettingEntry(
-            stableId = "stretchToFill",
-            nameResId = R.string.pref_stretch_screen_title,
-            descriptionResId = R.string.pref_stretch_screen_summary,
-            isChecked = settings.stretchToFill,
-            onCheckedChanged = { isChecked ->
-                settings.stretchToFill = isChecked
-                settings.commit()
-                notifyChange(needsViewRecreate = true)
-                updateSettingsList()
-            }
+        items.add(SettingItem.SettingEntry(
+            stableId = "videoFitMode",
+            nameResId = R.string.video_fit_mode,
+            value = resources.getStringArray(R.array.video_fit_mode)[settings.videoFitMode.value],
+            onClick = { showVideoFitModeDialog() }
         ))
 
         items.add(SettingItem.ToggleSettingEntry(
@@ -261,6 +253,20 @@ class QuickSettingsFragment : DialogFragment() {
                 requireContext().sendBroadcast(Intent(AapService.ACTION_ORIENTATION_CHANGED).apply {
                     setPackage(requireContext().packageName)
                 })
+                dialog.dismiss()
+                updateSettingsList()
+            }
+            .show()
+    }
+
+    private fun showVideoFitModeDialog() {
+        val options = resources.getStringArray(R.array.video_fit_mode)
+        MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
+            .setTitle(R.string.change_video_fit_mode)
+            .setSingleChoiceItems(options, settings.videoFitMode.value) { dialog, which ->
+                settings.videoFitMode = Settings.VideoFitMode.fromInt(which) ?: Settings.VideoFitMode.FILL
+                settings.commit()
+                notifyChange(needsViewRecreate = true)
                 dialog.dismiss()
                 updateSettingsList()
             }

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsActivity.kt
@@ -65,7 +65,9 @@ class SettingsActivity : BaseActivity() {
         }
 
         val root = findViewById<View>(R.id.settings_nav_host)
-        SystemUI.apply(window, root, appSettings.fullscreenMode)
+        // Never the projection: this window has a search box and its own decor, so its content area
+        // is not the canvas the video is drawn into.
+        SystemUI.apply(window, root, appSettings.fullscreenMode, notesCanvas = false)
     }
 
     override fun onResume() {
@@ -119,7 +121,7 @@ class SettingsActivity : BaseActivity() {
         if (hasFocus) {
             val appSettings = Settings(this)
             val root = findViewById<View>(R.id.settings_nav_host)
-            SystemUI.apply(window, root, appSettings.fullscreenMode)
+            SystemUI.apply(window, root, appSettings.fullscreenMode, notesCanvas = false)
         }
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -192,7 +192,6 @@ class SettingsFragment : Fragment() {
     private var pendingVideoFitMode: Settings.VideoFitMode? = null
     private var pendingForcedScale: Boolean? = null
     private var pendingHudMirroring: Boolean? = null
-    private var pendingUseMeasuredTouchSurface: Boolean? = null
 
     private var pendingKillOnDisconnect: Boolean? = null
     private var pendingRaiseProjectionDuringCall: Boolean? = null
@@ -326,7 +325,6 @@ class SettingsFragment : Fragment() {
         pendingVideoFitMode = settings.videoFitMode
         pendingForcedScale = settings.forcedScale
         pendingHudMirroring = settings.hudMirroring
-        pendingUseMeasuredTouchSurface = settings.useMeasuredTouchSurface
 
         pendingKillOnDisconnect = settings.killOnDisconnect
         pendingRaiseProjectionDuringCall = settings.raiseProjectionDuringCall
@@ -453,7 +451,6 @@ class SettingsFragment : Fragment() {
         pendingVideoFitMode = settings.videoFitMode
         pendingForcedScale = settings.forcedScale
         pendingHudMirroring = settings.hudMirroring
-        pendingUseMeasuredTouchSurface = settings.useMeasuredTouchSurface
         pendingKillOnDisconnect = settings.killOnDisconnect
         pendingRaiseProjectionDuringCall = settings.raiseProjectionDuringCall
         pendingAutoEnableHotspot = settings.autoEnableHotspot
@@ -609,7 +606,6 @@ class SettingsFragment : Fragment() {
         pendingVideoFitMode?.let { settings.videoFitMode = it }
         pendingForcedScale?.let { settings.forcedScale = it }
         pendingHudMirroring?.let { settings.hudMirroring = it }
-        pendingUseMeasuredTouchSurface?.let { settings.useMeasuredTouchSurface = it }
 
         pendingKillOnDisconnect?.let { settings.killOnDisconnect = it }
         pendingRaiseProjectionDuringCall?.let { settings.raiseProjectionDuringCall = it }
@@ -731,7 +727,6 @@ class SettingsFragment : Fragment() {
                         pendingVideoFitMode != settings.videoFitMode ||
                         pendingForcedScale != settings.forcedScale ||
                         pendingHudMirroring != settings.hudMirroring ||
-                        pendingUseMeasuredTouchSurface != settings.useMeasuredTouchSurface ||
                         pendingInsetLeft != settings.insetLeft ||
                         pendingInsetTop != settings.insetTop ||
                         pendingInsetRight != settings.insetRight ||
@@ -1839,18 +1834,6 @@ class SettingsFragment : Fragment() {
             isChecked = pendingHudMirroring ?: false,
             onCheckedChanged = { isChecked ->
                 pendingHudMirroring = isChecked
-                checkChanges()
-                updateSettingsList()
-            }
-        ))
-
-        items.add(SettingItem.ToggleSettingEntry(
-            stableId = "useMeasuredTouchSurface",
-            nameResId = R.string.use_measured_touch_surface,
-            descriptionResId = R.string.use_measured_touch_surface_description,
-            isChecked = pendingUseMeasuredTouchSurface ?: false,
-            onCheckedChanged = { isChecked ->
-                pendingUseMeasuredTouchSurface = isChecked
                 checkChanges()
                 updateSettingsList()
             }

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -184,7 +184,6 @@ class SettingsFragment : Fragment() {
     private var pendingHotspotPassword: String? = null
     private var pendingHotspotInterface: String? = null
 
-    private var pendingOptimizeUltrawide: Boolean? = null
     private var pendingEnableFloatingButton: Boolean? = null
     private var pendingFloatingButtonSizeDp: Int? = null
     private var pendingFloatingButtonOpacityPercent: Int? = null
@@ -319,7 +318,6 @@ class SettingsFragment : Fragment() {
         pendingScreenOrientation = settings.screenOrientation
         pendingAppLanguage = settings.appLanguage
 
-        pendingOptimizeUltrawide = settings.optimizeUltrawide
         pendingEnableFloatingButton = settings.enableFloatingButton
         pendingFloatingButtonSizeDp = settings.floatingButtonSizeDp
         pendingFloatingButtonOpacityPercent = settings.floatingButtonOpacityPercent
@@ -447,7 +445,6 @@ class SettingsFragment : Fragment() {
         pendingShowToastMessages = settings.showToastMessages
         pendingScreenOrientation = settings.screenOrientation
         pendingAppLanguage = settings.appLanguage
-        pendingOptimizeUltrawide = settings.optimizeUltrawide
         pendingEnableFloatingButton = settings.enableFloatingButton
         pendingFloatingButtonSizeDp = settings.floatingButtonSizeDp
         pendingFloatingButtonOpacityPercent = settings.floatingButtonOpacityPercent
@@ -603,7 +600,6 @@ class SettingsFragment : Fragment() {
         val hudMirroringChanged = pendingHudMirroring != null && pendingHudMirroring != settings.hudMirroring
 
         // Save the stretch to fill preference
-        pendingOptimizeUltrawide?.let { settings.optimizeUltrawide = it }
         pendingEnableFloatingButton?.let { settings.enableFloatingButton = it }
         pendingFloatingButtonSizeDp?.let { settings.floatingButtonSizeDp = it }
         pendingFloatingButtonOpacityPercent?.let { settings.floatingButtonOpacityPercent = it }
@@ -727,7 +723,6 @@ class SettingsFragment : Fragment() {
                         pendingShowToastMessages != settings.showToastMessages ||
                         pendingScreenOrientation != settings.screenOrientation ||
                         pendingAppLanguage != settings.appLanguage ||
-                        pendingOptimizeUltrawide != settings.optimizeUltrawide ||
                         pendingEnableFloatingButton != settings.enableFloatingButton ||
                         pendingFloatingButtonSizeDp != settings.floatingButtonSizeDp ||
                         pendingFloatingButtonOpacityPercent != settings.floatingButtonOpacityPercent ||
@@ -1834,20 +1829,6 @@ class SettingsFragment : Fragment() {
                         updateSettingsList()
                     }
                     .show()
-            }
-        ))
-
-        // Add the toggle for Ultrawide Optimization
-        items.add(SettingItem.ToggleSettingEntry(
-            stableId = "optimizeUltrawide",
-            nameResId = R.string.pref_optimize_ultrawide_title,
-            descriptionResId = R.string.pref_optimize_ultrawide_summary,
-            isChecked = pendingOptimizeUltrawide ?: settings.optimizeUltrawide,
-            onCheckedChanged = { isChecked ->
-                pendingOptimizeUltrawide = isChecked
-                requiresRestart = true
-                checkChanges()
-                updateSettingsList()
             }
         ))
 

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -184,14 +184,13 @@ class SettingsFragment : Fragment() {
     private var pendingHotspotPassword: String? = null
     private var pendingHotspotInterface: String? = null
 
-    // Flag to determine if the projection should stretch to fill the screen
-    private var pendingStretchToFill: Boolean? = null
     private var pendingOptimizeUltrawide: Boolean? = null
     private var pendingEnableFloatingButton: Boolean? = null
     private var pendingFloatingButtonSizeDp: Int? = null
     private var pendingFloatingButtonOpacityPercent: Int? = null
     private var pendingFloatingButtonXPercent: Int? = null
     private var pendingFloatingButtonYPercent: Int? = null
+    private var pendingVideoFitMode: Settings.VideoFitMode? = null
     private var pendingForcedScale: Boolean? = null
     private var pendingHudMirroring: Boolean? = null
     private var pendingUseMeasuredTouchSurface: Boolean? = null
@@ -320,14 +319,13 @@ class SettingsFragment : Fragment() {
         pendingScreenOrientation = settings.screenOrientation
         pendingAppLanguage = settings.appLanguage
 
-        // Initialize local state for stretch to fill
-        pendingStretchToFill = settings.stretchToFill
         pendingOptimizeUltrawide = settings.optimizeUltrawide
         pendingEnableFloatingButton = settings.enableFloatingButton
         pendingFloatingButtonSizeDp = settings.floatingButtonSizeDp
         pendingFloatingButtonOpacityPercent = settings.floatingButtonOpacityPercent
         pendingFloatingButtonXPercent = settings.floatingButtonXPercent
         pendingFloatingButtonYPercent = settings.floatingButtonYPercent
+        pendingVideoFitMode = settings.videoFitMode
         pendingForcedScale = settings.forcedScale
         pendingHudMirroring = settings.hudMirroring
         pendingUseMeasuredTouchSurface = settings.useMeasuredTouchSurface
@@ -449,13 +447,13 @@ class SettingsFragment : Fragment() {
         pendingShowToastMessages = settings.showToastMessages
         pendingScreenOrientation = settings.screenOrientation
         pendingAppLanguage = settings.appLanguage
-        pendingStretchToFill = settings.stretchToFill
         pendingOptimizeUltrawide = settings.optimizeUltrawide
         pendingEnableFloatingButton = settings.enableFloatingButton
         pendingFloatingButtonSizeDp = settings.floatingButtonSizeDp
         pendingFloatingButtonOpacityPercent = settings.floatingButtonOpacityPercent
         pendingFloatingButtonXPercent = settings.floatingButtonXPercent
         pendingFloatingButtonYPercent = settings.floatingButtonYPercent
+        pendingVideoFitMode = settings.videoFitMode
         pendingForcedScale = settings.forcedScale
         pendingHudMirroring = settings.hudMirroring
         pendingUseMeasuredTouchSurface = settings.useMeasuredTouchSurface
@@ -605,7 +603,6 @@ class SettingsFragment : Fragment() {
         val hudMirroringChanged = pendingHudMirroring != null && pendingHudMirroring != settings.hudMirroring
 
         // Save the stretch to fill preference
-        pendingStretchToFill?.let { settings.stretchToFill = it }
         pendingOptimizeUltrawide?.let { settings.optimizeUltrawide = it }
         pendingEnableFloatingButton?.let { settings.enableFloatingButton = it }
         pendingFloatingButtonSizeDp?.let { settings.floatingButtonSizeDp = it }
@@ -613,6 +610,7 @@ class SettingsFragment : Fragment() {
         pendingFloatingButtonXPercent?.let { settings.floatingButtonXPercent = it }
         pendingFloatingButtonYPercent?.let { settings.floatingButtonYPercent = it }
         FloatingButtonManager.update(requireContext())
+        pendingVideoFitMode?.let { settings.videoFitMode = it }
         pendingForcedScale?.let { settings.forcedScale = it }
         pendingHudMirroring?.let { settings.hudMirroring = it }
         pendingUseMeasuredTouchSurface?.let { settings.useMeasuredTouchSurface = it }
@@ -729,13 +727,13 @@ class SettingsFragment : Fragment() {
                         pendingShowToastMessages != settings.showToastMessages ||
                         pendingScreenOrientation != settings.screenOrientation ||
                         pendingAppLanguage != settings.appLanguage ||
-                        pendingStretchToFill != settings.stretchToFill ||
                         pendingOptimizeUltrawide != settings.optimizeUltrawide ||
                         pendingEnableFloatingButton != settings.enableFloatingButton ||
                         pendingFloatingButtonSizeDp != settings.floatingButtonSizeDp ||
                         pendingFloatingButtonOpacityPercent != settings.floatingButtonOpacityPercent ||
                         pendingFloatingButtonXPercent != settings.floatingButtonXPercent ||
                         pendingFloatingButtonYPercent != settings.floatingButtonYPercent ||
+                        pendingVideoFitMode != settings.videoFitMode ||
                         pendingForcedScale != settings.forcedScale ||
                         pendingHudMirroring != settings.hudMirroring ||
                         pendingUseMeasuredTouchSurface != settings.useMeasuredTouchSurface ||
@@ -777,6 +775,7 @@ class SettingsFragment : Fragment() {
 
         // Check for restart requirement
         requiresRestart = pendingResolution != settings.resolutionId ||
+                          pendingVideoFitMode != settings.videoFitMode ||
                           pendingVideoCodec != settings.videoCodec ||
                           pendingFpsLimit != settings.fpsLimit ||
                           pendingDpi != settings.dpiPixelDensity ||
@@ -1817,17 +1816,24 @@ class SettingsFragment : Fragment() {
             }
         ))
 
-        // Add the toggle for Stretch to Fill
-        items.add(SettingItem.ToggleSettingEntry(
-            stableId = "stretchToFill",
-            nameResId = R.string.pref_stretch_screen_title,
-            descriptionResId = R.string.pref_stretch_screen_summary,
-            isChecked = pendingStretchToFill ?: settings.stretchToFill,
-            onCheckedChanged = { isChecked ->
-                pendingStretchToFill = isChecked
-                requiresRestart = true // Requires a reconnect to apply the new rendering bounds
-                checkChanges()
-                updateSettingsList()
+        // Video fit: how a mismatched-aspect video is fitted into the panel (object-fit style).
+        items.add(SettingItem.SettingEntry(
+            stableId = "videoFitMode",
+            nameResId = R.string.video_fit_mode,
+            value = resources.getStringArray(R.array.video_fit_mode)[(pendingVideoFitMode ?: settings.videoFitMode).value],
+            searchKeywords = resources.getStringArray(R.array.video_fit_mode).joinToString(" "),
+            onClick = { _ ->
+                val fitOptions = resources.getStringArray(R.array.video_fit_mode)
+                val currentIdx = (pendingVideoFitMode ?: settings.videoFitMode).value
+                MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
+                    .setTitle(R.string.change_video_fit_mode)
+                    .setSingleChoiceItems(fitOptions, currentIdx) { dialog, which ->
+                        pendingVideoFitMode = Settings.VideoFitMode.fromInt(which) ?: Settings.VideoFitMode.FILL
+                        checkChanges()
+                        dialog.dismiss()
+                        updateSettingsList()
+                    }
+                    .show()
             }
         ))
 

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/HeadUnitScreenConfig.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/HeadUnitScreenConfig.kt
@@ -52,8 +52,9 @@ object HeadUnitScreenConfig {
     private var realScreenWidthPx: Int = 0
     private var realScreenHeightPx: Int = 0
 
-    // The panel itself, orientation-normalised. Stable unless the display rotates, which is what
-    // makes it safe to fold into the settings hash the surface cache is keyed on.
+    // The panel itself, orientation-normalised. A ROM that counts a decoration on the wrong axis
+    // moves this reading by tens of px between two init() calls, so it is a sanity bound on a
+    // stored canvas and never an identity the cache is keyed on.
     private var physicalWidthPx: Int = 0
     private var physicalHeightPx: Int = 0
 
@@ -706,26 +707,24 @@ object HeadUnitScreenConfig {
      * Computes a hash of all settings that affect screen dimensions.
      * Used to invalidate the cached surface dimensions when settings change.
      */
-    fun computeSettingsHash(settings: Settings): Int {
-        var hash = 17
-        hash = 31 * hash + settings.resolutionId
-        hash = 31 * hash + settings.dpiPixelDensity
-        hash = 31 * hash + settings.pixelAspectRatioE4
-        hash = 31 * hash + settings.insetLeft
-        hash = 31 * hash + settings.insetTop
-        hash = 31 * hash + settings.insetRight
-        hash = 31 * hash + settings.insetBottom
-        hash = 31 * hash + settings.viewMode.ordinal
-        hash = 31 * hash + settings.screenOrientation.ordinal
-        hash = 31 * hash + settings.fullscreenMode.value
-        hash = 31 * hash + settings.videoFitMode.value
-        hash = 31 * hash + (if (settings.forcedScale) 1 else 0)
-        // The panel, not the anchor: folding the anchor in made the hash depend on state this call
-        // is about to replace, so a cached canvas could never match it after a cold start.
-        hash = 31 * hash + physicalWidthPx
-        hash = 31 * hash + physicalHeightPx
-        return hash
-    }
+    fun computeSettingsHash(settings: Settings): Int = ScreenSettingsHash.of(
+        resolutionId = settings.resolutionId,
+        dpiPixelDensity = settings.dpiPixelDensity,
+        pixelAspectRatioE4 = settings.pixelAspectRatioE4,
+        insetLeft = settings.insetLeft,
+        insetTop = settings.insetTop,
+        insetRight = settings.insetRight,
+        insetBottom = settings.insetBottom,
+        viewMode = settings.viewMode.ordinal,
+        screenOrientation = settings.screenOrientation.ordinal,
+        fullscreenMode = settings.fullscreenMode.value,
+        videoFitMode = settings.videoFitMode.value,
+        forcedScale = settings.forcedScale,
+        // The effective orientation, not the panel. A ROM that counts a decoration on the wrong
+        // axis moves the panel reading mid-connect, which discarded a good window measurement and
+        // then fell back to that same reading; rotation is what has to invalidate, and this is it.
+        normalisation = normalisation,
+    )
 
     fun lockResolution() {
         if (!isResolutionLocked) {

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/HeadUnitScreenConfig.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/HeadUnitScreenConfig.kt
@@ -21,9 +21,9 @@ object HeadUnitScreenConfig {
     private var isPortraitScaled: Boolean = false
     private var isInitialized: Boolean = false
     private var lastSettingsHash: Int = 0
-
-    // Flag to determine if the projection should stretch and ignore aspect ratio
-    private var stretchToFill: Boolean = false
+    
+    // How the negotiated video is fitted into the panel (FILL/CONTAIN/COVER, see Settings.VideoFitMode).
+    private var videoFitMode: Settings.VideoFitMode = Settings.VideoFitMode.FILL
 
     // Forced scale for older devices (Legacy fix)
     var forcedScale: Boolean = false
@@ -54,7 +54,7 @@ object HeadUnitScreenConfig {
 
 
     fun init(context: Context, displayMetrics: DisplayMetrics, settings: Settings) {
-        stretchToFill = settings.stretchToFill
+        videoFitMode = settings.videoFitMode
         forcedScale = settings.forcedScale && settings.viewMode == Settings.ViewMode.SURFACE
 
         val realW: Int
@@ -313,7 +313,7 @@ object HeadUnitScreenConfig {
             if (isUltrawideEnabled() && (screenWidthPx >= 1700 || realScreenWidthPx >= 1700)) {
                 // Force 720p (1280x720) for 2.4GHz compatibility, but use PAR to fill the 1780+ width
                 negotiatedResolutionType = Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._1280x720
-                stretchToFill = true // Must be true for Ultrawide stretch
+                videoFitMode = Settings.VideoFitMode.FILL // the ultra-wide stretch needs FILL
                 AppLog.i("[ULTRAWIDE] Forcing 720p and Stretch for window width: $screenWidthPx")
             } else if (isPortraitDisplay) {
                 negotiatedResolutionType = if (screenWidthPx > 720 || screenHeightPx > 1280) {
@@ -366,46 +366,28 @@ object HeadUnitScreenConfig {
         // 2. Perform scaling calculations (now safe because negotiatedResolutionType is set)
         AppLog.i("[UI_DEBUG] CarScreen: usable area ${screenWidthPx}x${screenHeightPx}, using $negotiatedResolutionType")
 
-        if (screenHeightPx > screenWidthPx) {
-            isSmallScreen = screenWidthPx <= 1080 && screenHeightPx <= 1920
-        } else {
-            isSmallScreen = screenWidthPx <= 1920 && screenHeightPx <= 1080
-        }
-
-        scaleFactor = 1.0f
-        if (isUltrawideEnabled() && (screenWidthPx >= 1700 || realScreenWidthPx >= 1700)) {
-            // Force usable dimensions to match the physical window for 1:1 mapping
-            screenHeightPx = 720
-            scaleFactor = 1.0f
-            AppLog.i("[ULTRAWIDE] Forcing 1.0 Scale and Usable area: ${screenWidthPx}x${screenHeightPx}")
-        } else if (!isSmallScreen) {
-            val sWidth = screenWidthPx.toFloat()
-            val sHeight = screenHeightPx.toFloat()
-            if (getNegotiatedWidth() > 0 && getNegotiatedHeight() > 0) {
-                 if (sWidth / sHeight < getAspectRatio()) {
-                    isPortraitScaled = true
-                    scaleFactor = sHeight / getNegotiatedHeight().toFloat()
-                } else {
-                    isPortraitScaled = false
-                    scaleFactor = sWidth / getNegotiatedWidth().toFloat()
-                }
-            }
-        }
-
-        AppLog.i("[UI_DEBUG] CarScreen isSmallScreen: $isSmallScreen, scaleFactor: $scaleFactor, margins: w=${getWidthMargin()}, h=${getHeightMargin()}")
+        val fit = ProjectionGeometryPolicy.fit(
+            screenWidthPx, screenHeightPx, getNegotiatedWidth(), getNegotiatedHeight()
+        )
+        isSmallScreen = fit.isSmallScreen
+        scaleFactor = fit.scaleFactor
+        // Null on a small screen, where the previous value deliberately stands.
+        fit.isPortraitScaled?.let { isPortraitScaled = it }
+        
+        AppLog.i("[UI_DEBUG] CarScreen isSmallScreen: $isSmallScreen, scaleFactor: $scaleFactor, portraitScaled: $isPortraitScaled, margins: w=${getWidthMargin()}, h=${getHeightMargin()}")
     }
 
-    fun getAdjustedHeight(): Int {
-        return (getNegotiatedHeight() * scaleFactor).roundToInt()
-    }
+    fun getAdjustedHeight(): Int = ProjectionGeometryPolicy.adjustedHeight(getNegotiatedHeight(), scaleFactor)
 
-    fun getAdjustedWidth(): Int {
-        return (getNegotiatedWidth() * scaleFactor).roundToInt()
-    }
+    fun getAdjustedWidth(): Int = ProjectionGeometryPolicy.adjustedWidth(getNegotiatedWidth(), scaleFactor)
 
-    private fun getAspectRatio(): Float {
-        return getNegotiatedWidth().toFloat() / getNegotiatedHeight().toFloat()
-    }
+    // COVER target size for the legacy forcedScale/SurfaceView path, which sizes the view through
+    // LayoutParams rather than a View.scale transform.
+    fun getCoverWidth(): Int =
+        ProjectionGeometryPolicy.coverWidth(screenWidthPx, screenHeightPx, getNegotiatedWidth(), getNegotiatedHeight())
+
+    fun getCoverHeight(): Int =
+        ProjectionGeometryPolicy.coverHeight(screenWidthPx, screenHeightPx, getNegotiatedWidth(), getNegotiatedHeight())
 
     fun getNegotiatedHeight(): Int {
         val resString = negotiatedResolutionType.toString().replace("_", "")
@@ -434,65 +416,23 @@ object HeadUnitScreenConfig {
         }
     }
 
-    fun getHeightMargin(): Int {
-        if (isUltrawideEnabled() && screenWidthPx >= 1920) return 0
-        val margin = ((getAdjustedHeight() - screenHeightPx) / scaleFactor).roundToInt()
-        return margin.coerceAtLeast(0)
-    }
+    fun getHeightMargin(): Int =
+        ProjectionGeometryPolicy.heightMargin(getNegotiatedHeight(), screenHeightPx, scaleFactor)
 
-    fun getWidthMargin(): Int {
-        if (isUltrawideEnabled() && screenWidthPx >= 1920) return 0
-        val margin = ((getAdjustedWidth() - screenWidthPx) / scaleFactor).roundToInt()
-        return margin.coerceAtLeast(0)
-    }
+    fun getWidthMargin(): Int =
+        ProjectionGeometryPolicy.widthMargin(getNegotiatedWidth(), screenWidthPx, scaleFactor)
 
-    private fun divideOrOne(numerator: Float, denominator: Float): Float {
-        return if (denominator == 0.0f) 1.0f else numerator / denominator
-    }
+    fun getScaleX(): Float = ProjectionGeometryPolicy.scaleX(
+        videoFitMode, forcedScale,
+        screenWidthPx, screenHeightPx, getNegotiatedWidth(), getNegotiatedHeight(),
+        getWidthMargin(), getHeightMargin()
+    )
 
-    fun getScaleX(): Float {
-        if (isUltrawideEnabled() && (screenWidthPx >= 1700 || realScreenWidthPx >= 1700)) {
-            return 1.0f
-        }
-
-        if (forcedScale) {
-            return 1.0f
-        }
-
-        if (getNegotiatedWidth() > screenWidthPx) {
-            return divideOrOne(getNegotiatedWidth().toFloat(), screenWidthPx.toFloat())
-        }
-        if (isPortraitScaled) {
-            return divideOrOne(getAspectRatio(), (screenWidthPx.toFloat() / screenHeightPx.toFloat()))
-        }
-        return 1.0f
-    }
-        // Stretch option PR #259
-    fun getScaleY(): Float {
-        if (isUltrawideEnabled() && (screenWidthPx >= 1700 || realScreenWidthPx >= 1700)) {
-            return 1.0f
-        }
-
-        if (forcedScale) {
-            return 1.0f
-        }
-
-        if (getNegotiatedHeight() > screenHeightPx) {
-            return if (stretchToFill) {
-                // Before PR #233 Fix scaler Y
-                divideOrOne(getNegotiatedHeight().toFloat(), screenHeightPx.toFloat())
-            } else {
-                // After PR #233 Fix scaler Y
-                divideOrOne((screenWidthPx.toFloat() / screenHeightPx.toFloat()), getAspectRatio())
-            }
-        }
-
-        if (isPortraitScaled) {
-            return 1.0f
-        }
-
-        return divideOrOne((screenWidthPx.toFloat() / screenHeightPx.toFloat()), getAspectRatio())
-    }
+    fun getScaleY(): Float = ProjectionGeometryPolicy.scaleY(
+        videoFitMode, forcedScale,
+        screenWidthPx, screenHeightPx, getNegotiatedWidth(), getNegotiatedHeight(),
+        getWidthMargin(), getHeightMargin()
+    )
 
     fun getDensityDpi(): Int {
         return if (this::currentSettings.isInitialized && currentSettings.dpiPixelDensity != 0) {
@@ -596,7 +536,7 @@ object HeadUnitScreenConfig {
         hash = 31 * hash + settings.viewMode.ordinal
         hash = 31 * hash + settings.screenOrientation.ordinal
         hash = 31 * hash + settings.fullscreenMode.value
-        hash = 31 * hash + (if (settings.stretchToFill) 1 else 0)
+        hash = 31 * hash + settings.videoFitMode.value
         hash = 31 * hash + (if (settings.forcedScale) 1 else 0)
         // Include physical dimensions in the hash. If the screen rotates or a foldable is unfolded,
         // the hash will change, triggering a clean unlock and recalculation.

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/HeadUnitScreenConfig.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/HeadUnitScreenConfig.kt
@@ -52,6 +52,30 @@ object HeadUnitScreenConfig {
     private var realScreenWidthPx: Int = 0
     private var realScreenHeightPx: Int = 0
 
+    // The panel itself, orientation-normalised. Stable unless the display rotates, which is what
+    // makes it safe to fold into the settings hash the surface cache is keyed on.
+    private var physicalWidthPx: Int = 0
+    private var physicalHeightPx: Int = 0
+
+    // Which way up every reading is turned. Held rather than re-derived, so the four call sites
+    // that take one cannot disagree about the orientation a canvas was measured in.
+    private var normalisation: ScreenOrientationPolicy.Normalisation =
+        ScreenOrientationPolicy.Normalisation.AS_READ
+
+    // The canvas the anchor was derived from, so the anchor can follow the insets when they move
+    // under it. A bar subtracted from a rectangle measured before it appeared shrinks it twice.
+    private var anchorCanvasW: Int = 0
+    private var anchorCanvasH: Int = 0
+    private var anchorSource: String = ""
+
+    // Canvases somebody actually measured, each tagged with the settings they were measured under.
+    private var surfaceCanvas: ProjectionCanvasPolicy.Measurement? = null
+    private var windowCanvas: ProjectionCanvasPolicy.Measurement? = null
+
+    // A window measured before the first init(), which has no hash to tag it with yet.
+    private var pendingWindowCanvasW: Int = 0
+    private var pendingWindowCanvasH: Int = 0
+
     // What ServiceDiscoveryResponse actually put on the wire. init() re-reads the display metrics
     // on every scale update, so the live margins can move under a session that already announced
     // its own; this is what the drift is measured against.
@@ -72,6 +96,20 @@ object HeadUnitScreenConfig {
         announcedHeightMargin = heightMargin
     }
 
+    // The canvas the announced pixel shape was derived from. Only service discovery carries a pixel
+    // shape, so this is what a later canvas change can no longer be told to the phone.
+    private var announcedCanvasW: Int = 0
+    private var announcedCanvasH: Int = 0
+    private var loggedCanvasDrift: Boolean = false
+    private var canvasDriftLines: Int = 0
+
+    fun recordAnnouncedCanvas() {
+        announcedCanvasW = screenWidthPx
+        announcedCanvasH = screenHeightPx
+        loggedCanvasDrift = false
+        canvasDriftLines = 0
+    }
+
     /** True when the live margins are already on the wire, so sending them again would only repeat it. */
     fun marginsMatchAnnounced(): Boolean =
         announcedWidthMargin != MarginAnnouncementPolicy.NOT_ANNOUNCED &&
@@ -83,6 +121,10 @@ object HeadUnitScreenConfig {
     fun clearAnnouncedMargins() {
         announcedWidthMargin = MarginAnnouncementPolicy.NOT_ANNOUNCED
         announcedHeightMargin = MarginAnnouncementPolicy.NOT_ANNOUNCED
+        announcedCanvasW = 0
+        announcedCanvasH = 0
+        loggedCanvasDrift = false
+        canvasDriftLines = 0
     }
 
 
@@ -120,43 +162,76 @@ object HeadUnitScreenConfig {
             usableH = size.y
         }
 
-        val finalRealW: Int
-        val finalRealH: Int
-        val finalUsableW: Int
-        val finalUsableH: Int
-
         val screenOrientation = settings.screenOrientation
         val configOrientation = context.resources.configuration.orientation
         val isConfigLandscape = configOrientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
         val isConfigPortrait = configOrientation == android.content.res.Configuration.ORIENTATION_PORTRAIT
 
-        if (screenOrientation == Settings.ScreenOrientation.LANDSCAPE ||
-            screenOrientation == Settings.ScreenOrientation.LANDSCAPE_REVERSE ||
-            ((screenOrientation == Settings.ScreenOrientation.AUTO || screenOrientation == Settings.ScreenOrientation.SYSTEM) && isConfigLandscape)) {
-            finalRealW = Math.max(realW, realH)
-            finalRealH = Math.min(realW, realH)
-            finalUsableW = Math.max(usableW, usableH)
-            finalUsableH = Math.min(usableW, usableH)
-        } else if (screenOrientation == Settings.ScreenOrientation.PORTRAIT ||
-                   screenOrientation == Settings.ScreenOrientation.PORTRAIT_REVERSE ||
-                   ((screenOrientation == Settings.ScreenOrientation.AUTO || screenOrientation == Settings.ScreenOrientation.SYSTEM) && isConfigPortrait)) {
-            finalRealW = Math.min(realW, realH)
-            finalRealH = Math.max(realW, realH)
-            finalUsableW = Math.min(usableW, usableH)
-            finalUsableH = Math.max(usableW, usableH)
-        } else {
-            finalRealW = realW
-            finalRealH = realH
-            finalUsableW = usableW
-            finalUsableH = usableH
-        }
+        normalisation = ScreenOrientationPolicy.normalisation(screenOrientation, isConfigLandscape, isConfigPortrait)
+        val real = ScreenOrientationPolicy.normalise(realW, realH, normalisation)
+        val usable = ScreenOrientationPolicy.normalise(usableW, usableH, normalisation)
+        val finalRealW = real.width
+        val finalRealH = real.height
+        val finalUsableW = usable.width
+        val finalUsableH = usable.height
 
         AppLog.i("[UI_DEBUG] HeadUnitScreenConfig: Raw size: ${realW}x${realH}, usable: ${usableW}x${usableH}, orientation setting: $screenOrientation, configOrientation: $configOrientation")
         AppLog.i("[UI_DEBUG] HeadUnitScreenConfig: Final normalized size: ${finalRealW}x${finalRealH}, usable: ${finalUsableW}x${finalUsableH}")
 
-        // Only update if dimensions or settings changed
+        physicalWidthPx = finalRealW
+        physicalHeightPx = finalRealH
+
         val currentHash = computeSettingsHash(settings)
-        if (isInitialized && realScreenWidthPx == finalRealW && realScreenHeightPx == finalRealH && lastSettingsHash == currentHash) {
+
+        val settingsChanged = !isInitialized || lastSettingsHash != currentHash
+
+        // A window laid out before the first init() was measured under these very settings, but in
+        // whatever orientation the view happened to report; this is the first call that knows which.
+        if (windowCanvas == null && pendingWindowCanvasW > 0 && pendingWindowCanvasH > 0) {
+            val pending = ScreenOrientationPolicy.normalise(pendingWindowCanvasW, pendingWindowCanvasH, normalisation)
+            windowCanvas = ProjectionCanvasPolicy.Measurement(pending.width, pending.height, currentHash)
+            pendingWindowCanvasW = 0
+            pendingWindowCanvasH = 0
+        }
+
+        val immersive = settings.fullscreenMode == Settings.FullscreenMode.IMMERSIVE ||
+                        settings.fullscreenMode == Settings.FullscreenMode.IMMERSIVE_WITH_NOTCH
+
+        // THE ANCHOR: whatever last measured the canvas the video is drawn into, and the display
+        // only while nothing has. Outside immersive the display APIs describe neither a window a
+        // ROM sidebar narrowed nor a decoration reported on the wrong axis.
+        val choice = ProjectionCanvasPolicy.choose(
+            immersive = immersive,
+            realW = finalRealW,
+            realH = finalRealH,
+            usableW = finalUsableW,
+            usableH = finalUsableH,
+            surface = surfaceCanvas,
+            window = windowCanvas,
+            cached = cachedMeasurement(settings, screenOrientation, isConfigLandscape, isConfigPortrait),
+            hash = currentHash,
+        )
+
+        // A measured canvas is the area inside the insets, so the anchor carries them. Only the
+        // immersive display reading is the whole panel already; outside it the fallback is the
+        // window metrics, which are bar-reduced like any other canvas. The insets in force are the
+        // right ones unless the settings moved, in which case the manual ones are re-seeded below.
+        val insetW = if (settingsChanged) settings.insetLeft + settings.insetRight else systemInsetLeft + systemInsetRight
+        val insetH = if (settingsChanged) settings.insetTop + settings.insetBottom else systemInsetTop + systemInsetBottom
+        val panelIsTheAnchor = choice.source == ProjectionCanvasPolicy.Source.DISPLAY && immersive
+        val anchor = if (panelIsTheAnchor) {
+            ProjectionCanvasPolicy.Rect(choice.width, choice.height)
+        } else {
+            ProjectionCanvasPolicy.anchor(choice.width, choice.height, insetW, insetH)
+        }
+        val anchorW = anchor.width
+        val anchorH = anchor.height
+
+        // Nothing the anchor depends on has moved, so a repeat call must not undo a measurement
+        // taken since. This used to compare the anchor with the raw display, which outside an
+        // immersive mode can never match, so every scale update reset it.
+        if (isInitialized && realScreenWidthPx == anchorW && realScreenHeightPx == anchorH &&
+            lastSettingsHash == currentHash) {
             return
         }
 
@@ -171,66 +246,109 @@ object HeadUnitScreenConfig {
         currentSettings = settings
         appContext = context.applicationContext
 
-        // Determine if we are planning to hide the bars (Immersive)
-        val immersive = settings.fullscreenMode == Settings.FullscreenMode.IMMERSIVE ||
-                        settings.fullscreenMode == Settings.FullscreenMode.IMMERSIVE_WITH_NOTCH
-
-        // THE ANCHOR:
-        // If we are immersive, our "World" is the physical screen.
-        // If we are NOT, our "World" is limited to the usable window area (no lying to AA).
-        val defaultAnchorW = if (immersive) finalRealW else finalUsableW
-        val defaultAnchorH = if (immersive) finalRealH else finalUsableH
-
         density = displayMetrics.density
         densityDpi = displayMetrics.densityDpi
 
-        // Initial Insets: For non-immersive, the bars are already baked into the anchor (realSize = 736),
-        // so we start with 0 system insets and just add manual settings.
-        systemInsetLeft = settings.insetLeft
-        systemInsetTop = settings.insetTop
-        systemInsetRight = settings.insetRight
-        systemInsetBottom = settings.insetBottom
-
-        // Check if we have cached surface dimensions from a previous session.
-        // If the settings haven't changed (same hash), use the cached values
-        // to avoid a mid-session UpdateUiConfigRequest and potential flicker.
-        val cachedW = settings.cachedSurfaceWidth
-        val cachedH = settings.cachedSurfaceHeight
-        val cachedHash = settings.cachedSurfaceSettingsHash
-
-        if (cachedW > 0 && cachedH > 0 && cachedHash == currentHash) {
-            val normalizedCachedW: Int
-            val normalizedCachedH: Int
-            if (screenOrientation == Settings.ScreenOrientation.LANDSCAPE ||
-                screenOrientation == Settings.ScreenOrientation.LANDSCAPE_REVERSE ||
-                ((screenOrientation == Settings.ScreenOrientation.AUTO || screenOrientation == Settings.ScreenOrientation.SYSTEM) && isConfigLandscape)) {
-                normalizedCachedW = Math.max(cachedW, cachedH)
-                normalizedCachedH = Math.min(cachedW, cachedH)
-            } else if (screenOrientation == Settings.ScreenOrientation.PORTRAIT ||
-                       screenOrientation == Settings.ScreenOrientation.PORTRAIT_REVERSE ||
-                       ((screenOrientation == Settings.ScreenOrientation.AUTO || screenOrientation == Settings.ScreenOrientation.SYSTEM) && isConfigPortrait)) {
-                normalizedCachedW = Math.min(cachedW, cachedH)
-                normalizedCachedH = Math.max(cachedW, cachedH)
-            } else {
-                normalizedCachedW = cachedW
-                normalizedCachedH = cachedH
-            }
-
-            // Cached surface dimensions are the usable area. The anchor includes insets.
-            realScreenWidthPx = normalizedCachedW + systemInsetLeft + systemInsetRight
-            realScreenHeightPx = normalizedCachedH + systemInsetTop + systemInsetBottom
-            AppLog.i("[UI_DEBUG_FIX] HeadUnitScreenConfig: Using cached surface dimensions: ${normalizedCachedW}x${normalizedCachedH} (raw: ${cachedW}x${cachedH}, anchor: ${realScreenWidthPx}x${realScreenHeightPx})")
-        } else {
-            realScreenWidthPx = defaultAnchorW
-            realScreenHeightPx = defaultAnchorH
-            if (cachedW > 0) {
-                AppLog.i("[UI_DEBUG_FIX] HeadUnitScreenConfig: Cache invalidated (hash mismatch: stored=$cachedHash, current=$currentHash)")
-            }
+        // Manual insets only; the bars are re-read by the insets listener right after this. Left
+        // alone otherwise, or a bar already in force would be subtracted from the canvas twice.
+        if (settingsChanged) {
+            systemInsetLeft = settings.insetLeft
+            systemInsetTop = settings.insetTop
+            systemInsetRight = settings.insetRight
+            systemInsetBottom = settings.insetBottom
         }
 
-        AppLog.i("[UI_DEBUG] HeadUnitScreenConfig: Honest Init | Mode: ${settings.fullscreenMode} | Anchor: ${realScreenWidthPx}x${realScreenHeightPx} | Seeded Insets: L$systemInsetLeft T$systemInsetTop R$systemInsetRight B$systemInsetBottom")
+        realScreenWidthPx = anchorW
+        realScreenHeightPx = anchorH
+
+        // The panel reading is the one rectangle that already contains the bars, so it has no
+        // canvas to re-derive from; everything else does, and the insets can still move under it.
+        anchorCanvasW = if (panelIsTheAnchor) 0 else choice.width
+        anchorCanvasH = if (panelIsTheAnchor) 0 else choice.height
+        anchorSource = sourceNoun(choice.source)
+
+        AppLog.i("[UI_DEBUG] HeadUnitScreenConfig: Honest Init | Mode: ${settings.fullscreenMode} | Anchor: ${realScreenWidthPx}x${realScreenHeightPx} (from ${choice.source}) | Seeded Insets: L$systemInsetLeft T$systemInsetTop R$systemInsetRight B$systemInsetBottom")
 
         recalculate()
+    }
+
+    /** The canvas an earlier session measured, normalised to the orientation now in force. */
+    private fun cachedMeasurement(
+        settings: Settings,
+        screenOrientation: Settings.ScreenOrientation,
+        isConfigLandscape: Boolean,
+        isConfigPortrait: Boolean
+    ): ProjectionCanvasPolicy.Measurement? {
+        val cachedW = settings.cachedSurfaceWidth
+        val cachedH = settings.cachedSurfaceHeight
+        if (cachedW <= 0 || cachedH <= 0) return null
+
+        val turned = ScreenOrientationPolicy.normalise(
+            cachedW,
+            cachedH,
+            ScreenOrientationPolicy.normalisation(screenOrientation, isConfigLandscape, isConfigPortrait),
+        )
+        // Another session wrote this, so it can describe another panel. The live readings above are
+        // this process's own and outrank the panel, which is why only the cache is bounded by it.
+        if (!ProjectionCanvasPolicy.fitsPanel(turned.width, turned.height, physicalWidthPx, physicalHeightPx)) {
+            return null
+        }
+        return ProjectionCanvasPolicy.Measurement(turned.width, turned.height, settings.cachedSurfaceSettingsHash)
+    }
+
+    /**
+     * A laid-out activity window's content area, which is the canvas the projection will get in
+     * this screen mode plus whatever insets are in force. Recorded so the first session in a mode
+     * announces the shape it will actually draw into, rather than learning it from a surface that
+     * only arrives after the answer went out.
+     */
+    fun noteWindowContent(contentW: Int, contentH: Int) {
+        if (contentW <= 0 || contentH <= 0 || App.isPiPActive) return
+        val content = ScreenOrientationPolicy.normalise(contentW, contentH, normalisation)
+        val canvas = ProjectionCanvasPolicy.canvas(
+            content.width, content.height,
+            systemInsetLeft + systemInsetRight, systemInsetTop + systemInsetBottom,
+        )
+
+        if (!isInitialized) {
+            pendingWindowCanvasW = canvas.width
+            pendingWindowCanvasH = canvas.height
+            return
+        }
+        val hash = liveHash()
+        val known = windowCanvas
+        if (known != null && known.width == canvas.width && known.height == canvas.height && known.hash == hash) {
+            return
+        }
+        windowCanvas = ProjectionCanvasPolicy.Measurement(canvas.width, canvas.height, hash)
+        adoptCanvas(canvas.width, canvas.height, "the activity window")
+    }
+
+    /**
+     * The hash a measurement taken right now belongs to. Settings can move between an init() and
+     * the layout that answers it, and a reading tagged with the previous hash is thrown away.
+     */
+    private fun liveHash(): Int =
+        if (this::currentSettings.isInitialized) computeSettingsHash(currentSettings) else lastSettingsHash
+
+    /** Move the anchor onto a canvas somebody measured. True when it moved. */
+    private fun adoptCanvas(canvasW: Int, canvasH: Int, source: String, note: String = ""): Boolean {
+        val anchor = ProjectionCanvasPolicy.anchor(
+            canvasW, canvasH,
+            systemInsetLeft + systemInsetRight, systemInsetTop + systemInsetBottom,
+        )
+        // Recorded whether or not the anchor moved, so the provenance can never describe an older
+        // rectangle than the numbers beside it.
+        anchorCanvasW = canvasW
+        anchorCanvasH = canvasH
+        anchorSource = source
+        if (anchor.width == realScreenWidthPx && anchor.height == realScreenHeightPx) return false
+
+        AppLog.i("[UI_DEBUG] HeadUnitScreenConfig: anchor ${realScreenWidthPx}x${realScreenHeightPx} -> ${anchor.width}x${anchor.height}, measured on $source$note")
+        realScreenWidthPx = anchor.width
+        realScreenHeightPx = anchor.height
+        recalculate()
+        return true
     }
 
     fun updateInsets(left: Int, top: Int, right: Int, bottom: Int) {
@@ -243,9 +361,27 @@ object HeadUnitScreenConfig {
         systemInsetRight = right
         systemInsetBottom = bottom
 
-        if (isInitialized) {
+        if (!isInitialized) return
+
+        // A bar arriving after the canvas was measured has to grow the anchor, not shrink the
+        // canvas: subtracting it from a rectangle that never contained it counts it twice.
+        if (anchorCanvasW > 0 && anchorCanvasH > 0) {
+            if (!adoptCanvas(anchorCanvasW, anchorCanvasH, anchorSource, ", against the insets now in force")) {
+                recalculate()
+            }
+        } else {
             recalculate()
         }
+    }
+
+    /** What the anchor's rectangle is called in a log line. */
+    private fun sourceNoun(source: ProjectionCanvasPolicy.Source): String = when (source) {
+        ProjectionCanvasPolicy.Source.SURFACE -> "the projection surface"
+        ProjectionCanvasPolicy.Source.WINDOW -> "the activity window"
+        ProjectionCanvasPolicy.Source.CACHE -> "a canvas an earlier session measured"
+        // Never "the display": outside immersive this reading is the window metrics, and calling it
+        // the display is what hid a bar-reduced rectangle being treated as the whole panel.
+        ProjectionCanvasPolicy.Source.DISPLAY -> "the window metrics"
     }
 
     // Native standard resolution for a given panel size, mirroring the AUTO selection so the
@@ -318,13 +454,12 @@ object HeadUnitScreenConfig {
 
     private fun recalculate() {
         // Calculate USABLE area
-        screenWidthPx = realScreenWidthPx - systemInsetLeft - systemInsetRight
-        screenHeightPx = realScreenHeightPx - systemInsetTop - systemInsetBottom
-
-        if (screenWidthPx <= 0 || screenHeightPx <= 0) {
-            screenWidthPx = realScreenWidthPx
-            screenHeightPx = realScreenHeightPx
-        }
+        val canvas = ProjectionCanvasPolicy.canvas(
+            realScreenWidthPx, realScreenHeightPx,
+            systemInsetLeft + systemInsetRight, systemInsetTop + systemInsetBottom,
+        )
+        screenWidthPx = canvas.width
+        screenHeightPx = canvas.height
 
         val selectedResolution = Settings.Resolution.fromId(currentSettings.resolutionId)
         val isPortraitDisplay = screenHeightPx > screenWidthPx
@@ -406,6 +541,33 @@ object HeadUnitScreenConfig {
                 onMarginsDiverged?.invoke()
             } finally {
                 notifyingMarginDivergence = false
+            }
+        }
+
+        // Only service discovery carries a pixel shape, so a canvas that moves under a session
+        // announced by shape cannot be corrected on the wire. Say so once.
+        if (announcedCanvasW > 0 && marginStrategy() == MarginStrategyPolicy.Strategy.PAR &&
+            canvasDriftLines <= MAX_CANVAS_DRIFT_LINES
+        ) {
+            val moved = announcedCanvasW != screenWidthPx || announcedCanvasH != screenHeightPx
+            if (moved && !loggedCanvasDrift) {
+                loggedCanvasDrift = true
+                canvasDriftLines++
+                AppLog.i(
+                    "[UI_DEBUG] CarScreen: canvas moved from the announced " +
+                        "${announcedCanvasW}x${announcedCanvasH} to ${screenWidthPx}x${screenHeightPx}; " +
+                        "the pixel shape cannot be re-sent" +
+                        if (canvasDriftLines > MAX_CANVAS_DRIFT_LINES) " — and is still moving; no longer reporting" else ""
+                )
+            } else if (!moved && loggedCanvasDrift) {
+                // The move can be a settling transient, and a latch that cannot retract turns one
+                // into a permanent claim in somebody's bug report.
+                loggedCanvasDrift = false
+                canvasDriftLines++
+                AppLog.i(
+                    "[UI_DEBUG] CarScreen: canvas returned to the announced " +
+                        "${announcedCanvasW}x${announcedCanvasH}"
+                )
             }
         }
     }
@@ -509,27 +671,19 @@ object HeadUnitScreenConfig {
      * @return true if the dimensions changed and margins need to be re-sent to AA.
      */
     fun updateSurfaceDimensions(surfaceW: Int, surfaceH: Int): Boolean {
-        val finalSurfaceW: Int
-        val finalSurfaceH: Int
+        // A picture-in-picture window is a few hundred px of somebody else's screen, not the canvas.
+        if (App.isPiPActive) return false
 
-        val screenOrientation = if (this::currentSettings.isInitialized) currentSettings.screenOrientation else Settings.ScreenOrientation.SYSTEM
-        if (screenOrientation == Settings.ScreenOrientation.LANDSCAPE ||
-            screenOrientation == Settings.ScreenOrientation.LANDSCAPE_REVERSE) {
-            finalSurfaceW = Math.max(surfaceW, surfaceH)
-            finalSurfaceH = Math.min(surfaceW, surfaceH)
-        } else if (screenOrientation == Settings.ScreenOrientation.PORTRAIT ||
-                   screenOrientation == Settings.ScreenOrientation.PORTRAIT_REVERSE) {
-            finalSurfaceW = Math.min(surfaceW, surfaceH)
-            finalSurfaceH = Math.max(surfaceW, surfaceH)
-        } else {
-            finalSurfaceW = surfaceW
-            finalSurfaceH = surfaceH
-        }
+        val surface = ScreenOrientationPolicy.normalise(surfaceW, surfaceH, normalisation)
+        val finalSurfaceW = surface.width
+        val finalSurfaceH = surface.height
 
         val diffW = kotlin.math.abs(finalSurfaceW - screenWidthPx)
         val diffH = kotlin.math.abs(finalSurfaceH - screenHeightPx)
 
         if (diffW <= SURFACE_MISMATCH_TOLERANCE && diffH <= SURFACE_MISMATCH_TOLERANCE) {
+            // Already the canvas in force, but still the reading that outranks the display metrics.
+            surfaceCanvas = ProjectionCanvasPolicy.Measurement(screenWidthPx, screenHeightPx, liveHash())
             return false
         }
 
@@ -540,12 +694,9 @@ object HeadUnitScreenConfig {
 
         AppLog.i("[UI_DEBUG_FIX] Surface mismatch detected! Usable: ${screenWidthPx}x${screenHeightPx}, Actual surface: ${finalSurfaceW}x${finalSurfaceH} (diff: ${diffW}x${diffH})")
 
-        // Update anchor: the surface dimensions ARE the real usable area,
-        // so the anchor is the usable area plus insets.
-        realScreenWidthPx = finalSurfaceW + systemInsetLeft + systemInsetRight
-        realScreenHeightPx = finalSurfaceH + systemInsetTop + systemInsetBottom
-
-        recalculate()
+        // The surface is the canvas, so it outranks every other reading until the settings change.
+        surfaceCanvas = ProjectionCanvasPolicy.Measurement(finalSurfaceW, finalSurfaceH, liveHash())
+        adoptCanvas(finalSurfaceW, finalSurfaceH, "the projection surface")
 
         AppLog.i("[UI_DEBUG_FIX] Recalculated: usable=${screenWidthPx}x${screenHeightPx}, margins: w=${getWidthMargin()}, h=${getHeightMargin()}, per-side: L=${getLeftMargin()} T=${getTopMargin()} R=${getRightMargin()} B=${getBottomMargin()}")
         return true
@@ -569,10 +720,10 @@ object HeadUnitScreenConfig {
         hash = 31 * hash + settings.fullscreenMode.value
         hash = 31 * hash + settings.videoFitMode.value
         hash = 31 * hash + (if (settings.forcedScale) 1 else 0)
-        // Include physical dimensions in the hash. If the screen rotates or a foldable is unfolded,
-        // the hash will change, triggering a clean unlock and recalculation.
-        hash = 31 * hash + realScreenWidthPx
-        hash = 31 * hash + realScreenHeightPx
+        // The panel, not the anchor: folding the anchor in made the hash depend on state this call
+        // is about to replace, so a cached canvas could never match it after a cold start.
+        hash = 31 * hash + physicalWidthPx
+        hash = 31 * hash + physicalHeightPx
         return hash
     }
 
@@ -591,4 +742,8 @@ object HeadUnitScreenConfig {
     }
 
     private const val SURFACE_MISMATCH_TOLERANCE = 4
+
+    // A canvas that leaves and returns more than twice is itself the finding, and repeating the
+    // pair for every settle would drown the line that matters.
+    private const val MAX_CANVAS_DRIFT_LINES = 4
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/HeadUnitScreenConfig.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/HeadUnitScreenConfig.kt
@@ -52,6 +52,39 @@ object HeadUnitScreenConfig {
     private var realScreenWidthPx: Int = 0
     private var realScreenHeightPx: Int = 0
 
+    // What ServiceDiscoveryResponse actually put on the wire. init() re-reads the display metrics
+    // on every scale update, so the live margins can move under a session that already announced
+    // its own; this is what the drift is measured against.
+    private var announcedWidthMargin: Int = MarginAnnouncementPolicy.NOT_ANNOUNCED
+    private var announcedHeightMargin: Int = MarginAnnouncementPolicy.NOT_ANNOUNCED
+
+    /**
+     * Raised when the live margins leave the announced ones. The listener records what it sends;
+     * a false keeps the old announcement standing so the next recalculate retries.
+     */
+    var onMarginsDiverged: (() -> Boolean)? = null
+
+    // The listener redraws, which re-enters init() and can land back here. One notification at a time.
+    private var notifyingMarginDivergence: Boolean = false
+
+    fun recordAnnouncedMargins(widthMargin: Int, heightMargin: Int) {
+        announcedWidthMargin = widthMargin
+        announcedHeightMargin = heightMargin
+    }
+
+    /** True when the live margins are already on the wire, so sending them again would only repeat it. */
+    fun marginsMatchAnnounced(): Boolean =
+        announcedWidthMargin != MarginAnnouncementPolicy.NOT_ANNOUNCED &&
+            announcedHeightMargin != MarginAnnouncementPolicy.NOT_ANNOUNCED &&
+            !MarginAnnouncementPolicy.shouldReannounce(
+                announcedWidthMargin, announcedHeightMargin, getWidthMargin(), getHeightMargin()
+            )
+
+    fun clearAnnouncedMargins() {
+        announcedWidthMargin = MarginAnnouncementPolicy.NOT_ANNOUNCED
+        announcedHeightMargin = MarginAnnouncementPolicy.NOT_ANNOUNCED
+    }
+
 
     fun init(context: Context, displayMetrics: DisplayMetrics, settings: Settings) {
         videoFitMode = settings.videoFitMode
@@ -237,17 +270,18 @@ object HeadUnitScreenConfig {
     }
 
     /**
-     * The proto resolution the physical panel warrants, in the display's orientation. Delegates to
-     * SystemOptimizer.panelCeiling (the shared source of truth) so the runtime cap agrees with the
-     * settings "too high" warning and the DPI calculation (issue #767).
+     * The largest proto resolution the panel can use, in the display's orientation. Deliberately
+     * SystemOptimizer.hardCeiling and not panelCeiling: the latter is the recommendation, and
+     * capping to it silently overrode the "Use anyway" the settings dialog offers, costing an
+     * ultra-wide panel its native width on a resolution the user had picked on purpose.
      */
-    private fun autoResolutionForPanel(
+    private fun hardCeilingForPanel(
         w: Int,
         h: Int,
         portrait: Boolean,
         canHevc: Boolean
     ): Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType {
-        return protoForResolution(SystemOptimizer.panelCeiling(w, h, canHevc), portrait)
+        return protoForResolution(SystemOptimizer.hardCeiling(w, h, canHevc), portrait)
     }
 
     /**
@@ -308,46 +342,28 @@ object HeadUnitScreenConfig {
                 AppLog.i("[UI_DEBUG] CarScreen: RESOLUTION LOCKED to $negotiatedResolutionType. Usable area is ${screenWidthPx}x${screenHeightPx}. Skipping re-negotiation.")
             }
         }
+        
+        // A locked session keeps what it already negotiated. This used to fall through to the
+        // manual branch, where AUTO carries no codec and the fallback landed on 480p.
+        NegotiatedResolutionPolicy.select(
+            isLocked = isResolutionLocked,
+            selected = selectedResolution,
+            panelW = screenWidthPx,
+            panelH = screenHeightPx,
+            fitMode = videoFitMode,
+            hevcSupported = VideoDecoder.isHevcSupported(),
+            canHevcHighRes = canNegotiateHevc,
+            sdkInt = Build.VERSION.SDK_INT
+        )?.let { negotiatedResolutionType = protoForResolution(it, isPortraitDisplay) }
 
-        if (!isResolutionLocked && selectedResolution == Settings.Resolution.AUTO) {
-            if (isUltrawideEnabled() && (screenWidthPx >= 1700 || realScreenWidthPx >= 1700)) {
-                // Force 720p (1280x720) for 2.4GHz compatibility, but use PAR to fill the 1780+ width
-                negotiatedResolutionType = Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._1280x720
-                videoFitMode = Settings.VideoFitMode.FILL // the ultra-wide stretch needs FILL
-                AppLog.i("[ULTRAWIDE] Forcing 720p and Stretch for window width: $screenWidthPx")
-            } else if (isPortraitDisplay) {
-                negotiatedResolutionType = if (screenWidthPx > 720 || screenHeightPx > 1280) {
-                    Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._1080x1920
-                } else {
-                    Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._720x1280
-                }
-            } else {
-                negotiatedResolutionType = when {
-                    screenWidthPx <= 800 && screenHeightPx <= 480 -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._800x480
-                    (screenWidthPx >= 3840 || screenHeightPx >= 2160) && VideoDecoder.isHevcSupported() && Build.VERSION.SDK_INT >= 24 ->
-                        Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._3840x2160
-                    (screenWidthPx >= 2560 || screenHeightPx >= 1440) && canNegotiateHevc && Build.VERSION.SDK_INT >= 24 ->
-                        Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._2560x1440
-                    screenWidthPx > 1280 || screenHeightPx > 720 -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._1920x1080
-                    else -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._1280x720
-                }
-            }
-        } else {
-            // Manual selection: map to the correct orientation via the shared helper.
-            negotiatedResolutionType = protoForResolution(
-                selectedResolution ?: Settings.Resolution._800x480, isPortraitDisplay
-            )
-        }
-
-        // Cap the negotiated resolution to what the physical panel warrants, so we never ask the
-        // phone for more pixels than the screen can show. Downscaling e.g. 1080p to a 600p panel
-        // every frame overloads the display scaler (MediaTek MDP) and stalls video (issue #650).
-        // min(current, panelCeiling): only ever lowers, so explicit lower choices and HEVC-gated
-        // 1440p/4K are never raised.
+        // Cap to the largest buffer the panel can use, so a small panel never decodes a frame it
+        // has to downscale every time, which overloads the MediaTek MDP scaler (issue #650). This
+        // is the hard ceiling, not the recommendation: a wide panel uses a 1920-wide buffer in full
+        // and only hides rows. min(current, ceiling), so a lower choice is never raised.
         val preCapResolution = negotiatedResolutionType
-        val panelCeiling = autoResolutionForPanel(realScreenWidthPx, realScreenHeightPx, isPortraitDisplay, canNegotiateHevc)
-        if (pixelsOf(negotiatedResolutionType) > pixelsOf(panelCeiling)) {
-            negotiatedResolutionType = panelCeiling
+        val hardCeiling = hardCeilingForPanel(realScreenWidthPx, realScreenHeightPx, isPortraitDisplay, canNegotiateHevc)
+        if (pixelsOf(negotiatedResolutionType) > pixelsOf(hardCeiling)) {
+            negotiatedResolutionType = hardCeiling
         }
         // And to what the link can carry. Same min(current, ceiling) shape as the panel cap above,
         // so a user already asking for less is never raised to meet it.
@@ -375,6 +391,23 @@ object HeadUnitScreenConfig {
         fit.isPortraitScaled?.let { isPortraitScaled = it }
         
         AppLog.i("[UI_DEBUG] CarScreen isSmallScreen: $isSmallScreen, scaleFactor: $scaleFactor, portraitScaled: $isPortraitScaled, margins: w=${getWidthMargin()}, h=${getHeightMargin()}")
+
+        if (!notifyingMarginDivergence &&
+            MarginAnnouncementPolicy.shouldReannounce(
+                announcedWidthMargin, announcedHeightMargin, getWidthMargin(), getHeightMargin()
+            )
+        ) {
+            AppLog.i(
+                "[UI_DEBUG] CarScreen: margins drifted from the announced " +
+                    "${announcedWidthMargin}x${announcedHeightMargin} to ${getWidthMargin()}x${getHeightMargin()}"
+            )
+            notifyingMarginDivergence = true
+            try {
+                onMarginsDiverged?.invoke()
+            } finally {
+                notifyingMarginDivergence = false
+            }
+        }
     }
 
     fun getAdjustedHeight(): Int = ProjectionGeometryPolicy.adjustedHeight(getNegotiatedHeight(), scaleFactor)
@@ -443,24 +476,14 @@ object HeadUnitScreenConfig {
     }
 
     fun getPixelAspectRatioE4(): Int {
-        if (isUltrawideEnabled() && screenWidthPx >= 1700) {
-            // Force dynamic Pixel Aspect Ratio for 1780+ width window using a 1280 buffer
-            val ratio = (screenWidthPx.toFloat() / 1280f) * 10000
-            return ratio.roundToInt()
-        }
-        return if (this::currentSettings.isInitialized && currentSettings.pixelAspectRatioE4 > 0) {
-            currentSettings.pixelAspectRatioE4
-        } else {
-            10000 // 1.0 = square pixels
-        }
-    }
-
-    fun isUltrawideEnabled(): Boolean {
-        return if (this::currentSettings.isInitialized) {
-            currentSettings.optimizeUltrawide
-        } else {
-            false
-        }
+        // The settings row normalises anything <= 0 to 10000, so 10000 is also "unset" and is what
+        // lets the derived value through. An explicit non-square choice always wins.
+        val manual = if (this::currentSettings.isInitialized) currentSettings.pixelAspectRatioE4 else 0
+        if (manual > 0 && manual != ProjectionGeometryPolicy.SQUARE_PIXELS_E4) return manual
+        return ProjectionGeometryPolicy.pixelAspectRatioE4(
+            videoFitMode, screenWidthPx, screenHeightPx, getNegotiatedWidth(), getNegotiatedHeight(),
+            getWidthMargin(), getHeightMargin()
+        )
     }
 
     fun getUsableWidth(): Int = screenWidthPx

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/HeadUnitScreenConfig.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/HeadUnitScreenConfig.kt
@@ -390,7 +390,7 @@ object HeadUnitScreenConfig {
         // Null on a small screen, where the previous value deliberately stands.
         fit.isPortraitScaled?.let { isPortraitScaled = it }
         
-        AppLog.i("[UI_DEBUG] CarScreen isSmallScreen: $isSmallScreen, scaleFactor: $scaleFactor, portraitScaled: $isPortraitScaled, margins: w=${getWidthMargin()}, h=${getHeightMargin()}")
+        AppLog.i("[UI_DEBUG] CarScreen isSmallScreen: $isSmallScreen, scaleFactor: $scaleFactor, portraitScaled: $isPortraitScaled, shape=${marginStrategy()}, margins: w=${getWidthMargin()}, h=${getHeightMargin()}")
 
         if (!notifyingMarginDivergence &&
             MarginAnnouncementPolicy.shouldReannounce(
@@ -449,11 +449,19 @@ object HeadUnitScreenConfig {
         }
     }
 
+    // A stored resolution above the panel's rows used to hide a third of the frame behind a margin
+    // the touch mapper never saw. In FILL a wider panel describes itself by pixel shape instead.
+    private fun marginStrategy(): MarginStrategyPolicy.Strategy = MarginStrategyPolicy.select(
+        videoFitMode, screenWidthPx, screenHeightPx, getNegotiatedWidth(), getNegotiatedHeight()
+    )
+
     fun getHeightMargin(): Int =
-        ProjectionGeometryPolicy.heightMargin(getNegotiatedHeight(), screenHeightPx, scaleFactor)
+        if (marginStrategy() == MarginStrategyPolicy.Strategy.PAR) 0
+        else ProjectionGeometryPolicy.heightMargin(getNegotiatedHeight(), screenHeightPx, scaleFactor)
 
     fun getWidthMargin(): Int =
-        ProjectionGeometryPolicy.widthMargin(getNegotiatedWidth(), screenWidthPx, scaleFactor)
+        if (marginStrategy() == MarginStrategyPolicy.Strategy.PAR) 0
+        else ProjectionGeometryPolicy.widthMargin(getNegotiatedWidth(), screenWidthPx, scaleFactor)
 
     fun getScaleX(): Float = ProjectionGeometryPolicy.scaleX(
         videoFitMode, forcedScale,

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/MarginAnnouncementPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/MarginAnnouncementPolicy.kt
@@ -1,0 +1,22 @@
+package com.andrerinas.openheadunit.utils
+
+/**
+ * Whether the margins the phone was told about still describe the panel. init() re-reads the
+ * display metrics on every scale update, so a device whose window insets are still settling can
+ * leave one margin on the wire and a different one in use, with nothing to reconcile them.
+ */
+object MarginAnnouncementPolicy {
+
+    /** Nothing has been announced yet, so there is nothing to have drifted from. */
+    const val NOT_ANNOUNCED = -1
+
+    fun shouldReannounce(
+        announcedWidthMargin: Int,
+        announcedHeightMargin: Int,
+        liveWidthMargin: Int,
+        liveHeightMargin: Int
+    ): Boolean {
+        if (announcedWidthMargin == NOT_ANNOUNCED || announcedHeightMargin == NOT_ANNOUNCED) return false
+        return announcedWidthMargin != liveWidthMargin || announcedHeightMargin != liveHeightMargin
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/MarginStrategyPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/MarginStrategyPolicy.kt
@@ -1,0 +1,33 @@
+package com.andrerinas.openheadunit.utils
+
+import kotlin.math.roundToInt
+
+/**
+ * Which of the two encodings of a non-16:9 panel goes on the wire: a margin (rows or columns the
+ * panel cannot show) or the pixel aspect ratio (the panel's real pixel shape). They are
+ * alternatives, never layers: wherever a margin is announced the derived ratio cancels to square.
+ */
+object MarginStrategyPolicy {
+
+    enum class Strategy { PAR, MARGIN }
+
+    /**
+     * FILL on a panel wider than its buffer rides on the pixel ratio, so the stored resolution no
+     * longer decides whether a third of the frame hides behind a margin the touch mapper never saw.
+     * Taller-than-buffer panels and shapes past the clamp keep the margin, which is what is measured.
+     */
+    fun select(
+        mode: Settings.VideoFitMode,
+        panelW: Int,
+        panelH: Int,
+        videoW: Int,
+        videoH: Int
+    ): Strategy {
+        if (mode != Settings.VideoFitMode.FILL) return Strategy.MARGIN
+        if (panelW <= 0 || panelH <= 0 || videoW <= 0 || videoH <= 0) return Strategy.MARGIN
+        val derived = ((panelW.toFloat() * videoH) / (panelH.toFloat() * videoW) * 10000f).roundToInt()
+        if (derived <= ProjectionGeometryPolicy.SQUARE_PIXELS_E4) return Strategy.MARGIN
+        if (derived > ProjectionGeometryPolicy.MAX_PIXEL_ASPECT_E4) return Strategy.MARGIN
+        return Strategy.PAR
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/NegotiatedResolutionPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/NegotiatedResolutionPolicy.kt
@@ -1,0 +1,61 @@
+package com.andrerinas.openheadunit.utils
+
+/**
+ * Which resolution the AUTO ladder asks the phone for. Speaks Settings.Resolution so it stays
+ * testable without the generated proto; HeadUnitScreenConfig maps the answer to the wire type and
+ * applies the panel and link ceilings on top.
+ */
+object NegotiatedResolutionPolicy {
+
+    /**
+     * The AUTO choice for a panel. Every proto resolution is 16:9 bar 480p, so the rows are the
+     * only dimension a panel can match exactly. In FILL a wider panel is a pixel shape question,
+     * answered by ProjectionGeometryPolicy.pixelAspectRatioE4, so the short side alone decides.
+     * CONTAIN and COVER announce square pixels, so there the buffer's columns are the only width.
+     */
+    fun autoLadder(
+        panelW: Int,
+        panelH: Int,
+        fitMode: Settings.VideoFitMode,
+        hevcSupported: Boolean,
+        canHevcHighRes: Boolean,
+        sdkInt: Int
+    ): Settings.Resolution {
+        val longSide = maxOf(panelW, panelH)
+        val shortSide = minOf(panelW, panelH)
+        // Without the pixel aspect ratio, a 720-row wide panel on 720p is a 1280-wide picture
+        // between pillars, where 1080p with a height margin fills the width at 1:1.
+        val wide = if (fitMode == Settings.VideoFitMode.FILL) 0 else longSide
+        return when {
+            longSide <= 800 && shortSide <= 480 -> Settings.Resolution._800x480
+            (shortSide >= 2160 || wide >= 3840) && hevcSupported && sdkInt >= 24 -> Settings.Resolution._3840x2160
+            (shortSide >= 1440 || wide >= 2560) && canHevcHighRes && sdkInt >= 24 -> Settings.Resolution._2560x1440
+            shortSide > 720 || wide > 1280 -> Settings.Resolution._1920x1080
+            else -> Settings.Resolution._1280x720
+        }
+    }
+
+    /**
+     * What a session should renegotiate to, or null to keep what is already negotiated.
+     *
+     * A locked session keeps its resolution. It used to fall through to the manual branch, where
+     * AUTO carries no codec and the fallback landed on 480p, so a locked AUTO session downgraded
+     * itself mid-drive.
+     */
+    fun select(
+        isLocked: Boolean,
+        selected: Settings.Resolution?,
+        panelW: Int,
+        panelH: Int,
+        fitMode: Settings.VideoFitMode,
+        hevcSupported: Boolean,
+        canHevcHighRes: Boolean,
+        sdkInt: Int
+    ): Settings.Resolution? {
+        if (isLocked) return null
+        if (selected == null || selected == Settings.Resolution.AUTO) {
+            return autoLadder(panelW, panelH, fitMode, hevcSupported, canHevcHighRes, sdkInt)
+        }
+        return selected
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/ProjectionCanvasPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/ProjectionCanvasPolicy.kt
@@ -1,0 +1,80 @@
+package com.andrerinas.openheadunit.utils
+
+/**
+ * Which rectangle the projection is measured against. The phone is told about this canvas once, at
+ * service discovery, so it has to be the one the video is really drawn into: a display-level API
+ * can describe neither a window a ROM sidebar has narrowed nor a decoration it reports on the wrong
+ * axis.
+ */
+object ProjectionCanvasPolicy {
+
+    enum class Source {
+        /** The projection surface itself, this process. */
+        SURFACE,
+        /** A laid-out activity window in the current screen mode. */
+        WINDOW,
+        /** A surface measured by an earlier session under the same settings. */
+        CACHE,
+        /** Nothing has been measured yet: the display metrics. */
+        DISPLAY,
+    }
+
+    /** A canvas someone measured, and the settings hash it was measured under. */
+    data class Measurement(val width: Int, val height: Int, val hash: Int)
+
+    data class Choice(val width: Int, val height: Int, val source: Source)
+
+    data class Rect(val width: Int, val height: Int)
+
+    /** A cached canvas may exceed the panel it is checked against by this much and still be it. */
+    private const val PANEL_SLACK = 1.25f
+
+    /**
+     * The rectangle a measured canvas sits in. A measurement is the area inside the insets, so the
+     * anchor carries them; freezing an anchor while the insets move subtracts a bar from a
+     * rectangle that never contained it, and the canvas is announced short by a bar's width.
+     */
+    fun anchor(canvasW: Int, canvasH: Int, insetW: Int, insetH: Int): Rect =
+        Rect(canvasW + insetW, canvasH + insetH)
+
+    /** The canvas inside an anchor. Insets that would empty it are ignored rather than obeyed. */
+    fun canvas(anchorW: Int, anchorH: Int, insetW: Int, insetH: Int): Rect {
+        val w = anchorW - insetW
+        val h = anchorH - insetH
+        return if (w <= 0 || h <= 0) Rect(anchorW, anchorH) else Rect(w, h)
+    }
+
+    /**
+     * Whether a stored canvas can still belong to this panel. A decoration counted on the wrong
+     * axis moves a display reading by tens of px, so the test is a ratio: it has to reject another
+     * panel without rejecting a metric that wobbled.
+     */
+    fun fitsPanel(canvasW: Int, canvasH: Int, panelW: Int, panelH: Int): Boolean {
+        if (panelW <= 0 || panelH <= 0) return true
+        return canvasW <= panelW * PANEL_SLACK && canvasH <= panelH * PANEL_SLACK
+    }
+
+    private fun usable(m: Measurement?, hash: Int): Boolean =
+        m != null && m.width > 0 && m.height > 0 && m.hash == hash
+
+    /**
+     * The canvas to anchor on. A measurement only counts for the settings it was taken under, so a
+     * screen-mode change drops every reading that described the old window.
+     */
+    fun choose(
+        immersive: Boolean,
+        realW: Int,
+        realH: Int,
+        usableW: Int,
+        usableH: Int,
+        surface: Measurement?,
+        window: Measurement?,
+        cached: Measurement?,
+        hash: Int,
+    ): Choice {
+        if (usable(surface, hash)) return Choice(surface!!.width, surface.height, Source.SURFACE)
+        if (usable(window, hash)) return Choice(window!!.width, window.height, Source.WINDOW)
+        if (usable(cached, hash)) return Choice(cached!!.width, cached.height, Source.CACHE)
+        return if (immersive) Choice(realW, realH, Source.DISPLAY) else Choice(usableW, usableH, Source.DISPLAY)
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/ProjectionGeometryPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/ProjectionGeometryPolicy.kt
@@ -1,5 +1,6 @@
 package com.andrerinas.openheadunit.utils
 
+import kotlin.math.abs
 import kotlin.math.roundToInt
 
 /**
@@ -138,5 +139,43 @@ object ProjectionGeometryPolicy {
         val uiH = uiHeight(videoH, marginH)
         if (mode == Settings.VideoFitMode.FILL) return divideOrOne(videoH.toFloat(), uiH.toFloat())
         return fitFactor(mode, panelW, panelH, uiW, uiH) * divideOrOne(videoH.toFloat(), panelH.toFloat())
+    }
+
+    /** 10000 means square pixels, and doubles as "the user has not set one". */
+    const val SQUARE_PIXELS_E4 = 10000
+
+    /** Half as wide as tall, and twice as wide as tall. No real panel is outside this. */
+    const val MIN_PIXEL_ASPECT_E4 = 5000
+    const val MAX_PIXEL_ASPECT_E4 = 20000
+
+    /**
+     * The pixel shape to advertise so the phone lays its UI out for the real panel while still
+     * encoding a 16:9 buffer. Measured against the margin-reduced canvas, because the margins
+     * already describe a correctly shaped canvas inside a bigger buffer. The phone pre-compensates
+     * by 10000/this and the panel's own stretch cancels it, so sending the reciprocal doubles it.
+     */
+    fun pixelAspectRatioE4(
+        mode: Settings.VideoFitMode,
+        panelW: Int,
+        panelH: Int,
+        videoW: Int,
+        videoH: Int,
+        marginW: Int,
+        marginH: Int
+    ): Int {
+        // Only FILL stretches the canvas to the panel. CONTAIN and COVER keep the aspect themselves,
+        // so asking the phone to pre-compensate would squeeze its UI by the correction.
+        if (mode != Settings.VideoFitMode.FILL) return SQUARE_PIXELS_E4
+        val canvasW = uiWidth(videoW, marginW)
+        val canvasH = uiHeight(videoH, marginH)
+        if (panelW <= 0 || panelH <= 0 || canvasW <= 0 || canvasH <= 0) return SQUARE_PIXELS_E4
+        val derived = ((panelW.toFloat() * canvasH) / (panelH.toFloat() * canvasW) * 10000f).roundToInt()
+        // A panel reading this far from square is a bad measurement, not a panel; say square rather
+        // than put it on the wire.
+        if (derived < MIN_PIXEL_ASPECT_E4 || derived > MAX_PIXEL_ASPECT_E4) return SQUARE_PIXELS_E4
+        // Within a few percent of square, say square: the phone gains nothing from the correction.
+        // This is the dial to widen if a panel class turns out not to want the correction.
+        val deviation = abs(derived - SQUARE_PIXELS_E4) / SQUARE_PIXELS_E4.toFloat()
+        return if (deviation > 0.03f) derived else SQUARE_PIXELS_E4
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/ProjectionGeometryPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/ProjectionGeometryPolicy.kt
@@ -1,0 +1,142 @@
+package com.andrerinas.openheadunit.utils
+
+import kotlin.math.roundToInt
+
+/**
+ * The panel geometry decisions: how far the negotiated video is scaled, what margin that leaves,
+ * and what pixel shape the phone should author for. Pure so the ultra-wide cases can be asserted
+ * without a device; HeadUnitScreenConfig keeps the Context and DisplayMetrics reading.
+ */
+object ProjectionGeometryPolicy {
+
+    /** isPortraitScaled is null on a small screen, where recalculate() leaves the previous value standing. */
+    data class Fit(
+        val scaleFactor: Float,
+        val isSmallScreen: Boolean,
+        val isPortraitScaled: Boolean?
+    )
+
+    fun divideOrOne(numerator: Float, denominator: Float): Float {
+        return if (denominator == 0.0f) 1.0f else numerator / denominator
+    }
+
+    fun isSmallScreen(panelW: Int, panelH: Int): Boolean {
+        return if (panelH > panelW) {
+            panelW <= 1080 && panelH <= 1920
+        } else {
+            panelW <= 1920 && panelH <= 1080
+        }
+    }
+
+    fun fit(panelW: Int, panelH: Int, videoW: Int, videoH: Int): Fit {
+        val small = isSmallScreen(panelW, panelH)
+        if (small || videoW <= 0 || videoH <= 0) return Fit(1.0f, small, null)
+        val sW = panelW.toFloat()
+        val sH = panelH.toFloat()
+        val aspect = videoW.toFloat() / videoH.toFloat()
+        return if (sW / sH < aspect) {
+            Fit(sH / videoH.toFloat(), small, true)
+        } else {
+            Fit(sW / videoW.toFloat(), small, false)
+        }
+    }
+
+    fun adjustedWidth(videoW: Int, scaleFactor: Float): Int = (videoW * scaleFactor).roundToInt()
+
+    fun adjustedHeight(videoH: Int, scaleFactor: Float): Int = (videoH * scaleFactor).roundToInt()
+
+    fun widthMargin(videoW: Int, panelW: Int, scaleFactor: Float): Int {
+        if (scaleFactor == 0.0f) return 0
+        return ((adjustedWidth(videoW, scaleFactor) - panelW) / scaleFactor).roundToInt().coerceAtLeast(0)
+    }
+
+    fun heightMargin(videoH: Int, panelH: Int, scaleFactor: Float): Int {
+        if (scaleFactor == 0.0f) return 0
+        return ((adjustedHeight(videoH, scaleFactor) - panelH) / scaleFactor).roundToInt().coerceAtLeast(0)
+    }
+
+    /** The largest uniform scale that fits the canvas entirely inside the panel: the letterbox. */
+    fun containScaleFactor(panelW: Int, panelH: Int, videoW: Int, videoH: Int): Float {
+        return minOf(
+            divideOrOne(panelW.toFloat(), videoW.toFloat()),
+            divideOrOne(panelH.toFloat(), videoH.toFloat())
+        )
+    }
+
+    /**
+     * The smallest uniform scale that still covers the panel, cropping the overshoot. Floored at
+     * 1.0f so a video that already has the pixels is cropped at native size rather than downscaled.
+     */
+    fun coverScaleFactor(panelW: Int, panelH: Int, videoW: Int, videoH: Int): Float {
+        return maxOf(
+            1.0f,
+            maxOf(
+                divideOrOne(panelW.toFloat(), videoW.toFloat()),
+                divideOrOne(panelH.toFloat(), videoH.toFloat())
+            )
+        )
+    }
+
+    // These two size the view on the legacy forcedScale SurfaceView path, which lays the whole
+    // buffer out rather than scaling it, so they measure the buffer and not the margin-reduced canvas.
+    fun coverWidth(panelW: Int, panelH: Int, videoW: Int, videoH: Int): Int =
+        (videoW * coverScaleFactor(panelW, panelH, videoW, videoH)).roundToInt()
+
+    fun coverHeight(panelW: Int, panelH: Int, videoW: Int, videoH: Int): Int =
+        (videoH * coverScaleFactor(panelW, panelH, videoW, videoH)).roundToInt()
+
+    /**
+     * The visible canvas: the negotiated buffer minus the margin the phone was told to keep clear.
+     * Every scale below is expressed against it, because it is what the panel actually shows.
+     */
+    fun uiWidth(videoW: Int, marginW: Int): Int = videoW - marginW
+
+    fun uiHeight(videoH: Int, marginH: Int): Int = videoH - marginH
+
+    private fun fitFactor(mode: Settings.VideoFitMode, panelW: Int, panelH: Int, uiW: Int, uiH: Int): Float =
+        when (mode) {
+            Settings.VideoFitMode.COVER -> coverScaleFactor(panelW, panelH, uiW, uiH)
+            else -> containScaleFactor(panelW, panelH, uiW, uiH)
+        }
+
+    /**
+     * FILL asks for the canvas to reach the panel edges, which means scaling the buffer by however
+     * much of it the margin hides. Returning 1.0f unconditionally stretched a 720p picture 1.5x on
+     * a 1920x720 panel; returning panel aspect over video aspect showed margin rows we had promised
+     * the phone were invisible. One expression covers both, and reproduces what the removed
+     * videoW > panelW and isPortraitScaled arms computed.
+     */
+    fun scaleX(
+        mode: Settings.VideoFitMode,
+        forcedScale: Boolean,
+        panelW: Int,
+        panelH: Int,
+        videoW: Int,
+        videoH: Int,
+        marginW: Int,
+        marginH: Int
+    ): Float {
+        if (forcedScale) return 1.0f
+        val uiW = uiWidth(videoW, marginW)
+        val uiH = uiHeight(videoH, marginH)
+        if (mode == Settings.VideoFitMode.FILL) return divideOrOne(videoW.toFloat(), uiW.toFloat())
+        return fitFactor(mode, panelW, panelH, uiW, uiH) * divideOrOne(videoW.toFloat(), panelW.toFloat())
+    }
+
+    fun scaleY(
+        mode: Settings.VideoFitMode,
+        forcedScale: Boolean,
+        panelW: Int,
+        panelH: Int,
+        videoW: Int,
+        videoH: Int,
+        marginW: Int,
+        marginH: Int
+    ): Float {
+        if (forcedScale) return 1.0f
+        val uiW = uiWidth(videoW, marginW)
+        val uiH = uiHeight(videoH, marginH)
+        if (mode == Settings.VideoFitMode.FILL) return divideOrOne(videoH.toFloat(), uiH.toFloat())
+        return fitFactor(mode, panelW, panelH, uiW, uiH) * divideOrOne(videoH.toFloat(), panelH.toFloat())
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/ScreenOrientationPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/ScreenOrientationPolicy.kt
@@ -1,0 +1,45 @@
+package com.andrerinas.openheadunit.utils
+
+/**
+ * Which way up a reading is meant to be. Four call sites each grew their own copy of this swap and
+ * two omitted the AUTO/SYSTEM fallback, so a portrait window reading was adopted as the landscape
+ * canvas and a portrait resolution was announced from it.
+ */
+object ScreenOrientationPolicy {
+
+    /** The shape a reading is turned into before anything compares it with another. */
+    enum class Normalisation {
+        /** Longest side first. */
+        LANDSCAPE,
+        /** Shortest side first. */
+        PORTRAIT,
+        /** Neither is known, so the reading is left as it came. */
+        AS_READ,
+    }
+
+    /** AUTO and SYSTEM take the orientation the configuration is actually in. */
+    fun normalisation(
+        setting: Settings.ScreenOrientation,
+        configLandscape: Boolean,
+        configPortrait: Boolean,
+    ): Normalisation = when (setting) {
+        Settings.ScreenOrientation.LANDSCAPE,
+        Settings.ScreenOrientation.LANDSCAPE_REVERSE -> Normalisation.LANDSCAPE
+        Settings.ScreenOrientation.PORTRAIT,
+        Settings.ScreenOrientation.PORTRAIT_REVERSE -> Normalisation.PORTRAIT
+        Settings.ScreenOrientation.AUTO,
+        Settings.ScreenOrientation.SYSTEM -> when {
+            configLandscape -> Normalisation.LANDSCAPE
+            configPortrait -> Normalisation.PORTRAIT
+            else -> Normalisation.AS_READ
+        }
+    }
+
+    /** A reading turned the way [normalisation] says. */
+    fun normalise(w: Int, h: Int, normalisation: Normalisation): ProjectionCanvasPolicy.Rect =
+        when (normalisation) {
+            Normalisation.LANDSCAPE -> ProjectionCanvasPolicy.Rect(Math.max(w, h), Math.min(w, h))
+            Normalisation.PORTRAIT -> ProjectionCanvasPolicy.Rect(Math.min(w, h), Math.max(w, h))
+            Normalisation.AS_READ -> ProjectionCanvasPolicy.Rect(w, h)
+        }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/ScreenSettingsHash.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/ScreenSettingsHash.kt
@@ -1,0 +1,45 @@
+package com.andrerinas.openheadunit.utils
+
+/**
+ * The identity of the settings a canvas measurement was taken under. A reading only counts for the
+ * settings it describes, and a display metric that moves by a decoration's width is not a setting:
+ * folding one in threw away a good window measurement and then supplied the fallback itself.
+ */
+object ScreenSettingsHash {
+
+    /**
+     * [normalisation] stands in for the panel the hash used to fold. It is what actually invalidates
+     * a measurement, because AUTO and SYSTEM rotate without the orientation setting moving.
+     */
+    fun of(
+        resolutionId: Int,
+        dpiPixelDensity: Int,
+        pixelAspectRatioE4: Int,
+        insetLeft: Int,
+        insetTop: Int,
+        insetRight: Int,
+        insetBottom: Int,
+        viewMode: Int,
+        screenOrientation: Int,
+        fullscreenMode: Int,
+        videoFitMode: Int,
+        forcedScale: Boolean,
+        normalisation: ScreenOrientationPolicy.Normalisation,
+    ): Int {
+        var hash = 17
+        hash = 31 * hash + resolutionId
+        hash = 31 * hash + dpiPixelDensity
+        hash = 31 * hash + pixelAspectRatioE4
+        hash = 31 * hash + insetLeft
+        hash = 31 * hash + insetTop
+        hash = 31 * hash + insetRight
+        hash = 31 * hash + insetBottom
+        hash = 31 * hash + viewMode
+        hash = 31 * hash + screenOrientation
+        hash = 31 * hash + fullscreenMode
+        hash = 31 * hash + videoFitMode
+        hash = 31 * hash + (if (forcedScale) 1 else 0)
+        hash = 31 * hash + normalisation.ordinal
+        return hash
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -84,10 +84,29 @@ class Settings(private val context: Context) {
         get() = prefs.getInt("resolutionId", 0)
         set(value) = prefs.edit().putInt("resolutionId", value).apply()
 
-    // Flag to determine if the projection should stretch and ignore aspect ratio to fill the screen
-    var stretchToFill: Boolean
-        get() = prefs.getBoolean("stretch_to_fill", true)
-        set(value) { prefs.edit().putBoolean("stretch_to_fill", value).apply() }
+    // How the video is fitted into the panel, in CSS object-fit terms: FILL stretches,
+    // CONTAIN letterboxes, COVER crops. Migrated from the old "stretch_to_fill" boolean,
+    // which the legacy forcedScale/SurfaceView path read inverted (true = bars), so the
+    // migration has to branch on forced_scale rather than map the boolean straight across.
+    var videoFitMode: VideoFitMode
+        get() = VideoFitPolicy.resolve(
+            storedFitMode = if (prefs.contains("video-fit-mode")) prefs.getInt("video-fit-mode", VideoFitMode.FILL.value) else null,
+            legacyStretch = if (prefs.contains("stretch_to_fill")) prefs.getBoolean("stretch_to_fill", true) else null,
+            legacyForcedScale = prefs.getBoolean("forced_scale", false),
+            legacyViewMode = prefs.getInt("view-mode", 1)
+        )
+        set(value) { prefs.edit().putInt("video-fit-mode", value.value).apply() }
+
+    enum class VideoFitMode(val value: Int) {
+        FILL(0),
+        CONTAIN(1),
+        COVER(2);
+
+        companion object {
+            private val map = values().associateBy(VideoFitMode::value)
+            fun fromInt(value: Int) = map[value]
+        }
+    }
 
     // Optimization for Ultrawide displays (1920x720 / 1780x720)
     var optimizeUltrawide: Boolean

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -108,14 +108,11 @@ class Settings(private val context: Context) {
         }
     }
 
-    // Optimization for Ultrawide displays (1920x720 / 1780x720)
-    var optimizeUltrawide: Boolean
-        get() = prefs.getBoolean("optimize-ultrawide", false)
-        set(value) { prefs.edit().putBoolean("optimize-ultrawide", value).apply() }
-
     // Floating Launcher Overlay Button Settings
+    // Off by default: on it, MainActivity.checkOverlayPermission() sends a fresh install to the
+    // system overlay screen on first resume, for a feature the user has not asked for yet.
     var enableFloatingButton: Boolean
-        get() = prefs.getBoolean("enable-floating-button", true)
+        get() = prefs.getBoolean("enable-floating-button", false)
         set(value) { prefs.edit().putBoolean("enable-floating-button", value).apply() }
 
     var floatingButtonXPercent: Int

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -141,10 +141,6 @@ class Settings(private val context: Context) {
         get() = prefs.getBoolean("hud_mirroring", false)
         set(value) { prefs.edit().putBoolean("hud_mirroring", value).apply() }
 
-    var useMeasuredTouchSurface: Boolean
-        get() = prefs.getBoolean("use_measured_touch_surface", false)
-        set(value) { prefs.edit().putBoolean("use_measured_touch_surface", value).apply() }
-
     // UI Scale percentage for Home
     var uiScaleHomePercent: Int
         get() = prefs.getInt("ui-scale-home-percent", 100)

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
@@ -56,6 +56,10 @@ object SettingsBackupManager {
         "network-addresses" to ValueType.STRING_SET,
         "bt-address" to ValueType.STRING,
         "resolutionId" to ValueType.INT,
+        "video-fit-mode" to ValueType.INT,
+        // Older backups carry the boolean this replaced. parseImportJson drops keys it does
+        // not know, so without this an old backup loses the setting; Settings.videoFitMode
+        // migrates the restored boolean on first read.
         "stretch_to_fill" to ValueType.BOOLEAN,
         "optimize-ultrawide" to ValueType.BOOLEAN,
         "enable-floating-button" to ValueType.BOOLEAN,
@@ -228,6 +232,7 @@ object SettingsBackupManager {
 
     private val projectionRestartKeys = setOf(
         "resolutionId",
+        "video-fit-mode",
         "video-codec",
         "fps-limit",
         "dpi-pixel-density",

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
@@ -61,7 +61,6 @@ object SettingsBackupManager {
         // not know, so without this an old backup loses the setting; Settings.videoFitMode
         // migrates the restored boolean on first read.
         "stretch_to_fill" to ValueType.BOOLEAN,
-        "optimize-ultrawide" to ValueType.BOOLEAN,
         "enable-floating-button" to ValueType.BOOLEAN,
         "floating-button-x-percent" to ValueType.INT,
         "floating-button-y-percent" to ValueType.INT,

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
@@ -224,7 +224,6 @@ object SettingsBackupManager {
         "wifi-5ghz-channel" to ValueType.INT,
         "static-bssid" to ValueType.STRING,
         // Touch calibration fix and toast visibility.
-        "use_measured_touch_surface" to ValueType.BOOLEAN,
         "show-toast-messages" to ValueType.BOOLEAN,
         "usb-blacklist" to ValueType.STRING_SET
     )

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SystemOptimizer.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SystemOptimizer.kt
@@ -126,16 +126,35 @@ class SystemOptimizer(private val context: Context) {
         private const val LEGIBILITY_FACTOR = 1.1f
 
         /**
-         * The single source of truth for the largest resolution a physical panel warrants, shared
-         * by the recommended resolution, the runtime resolution cap (HeadUnitScreenConfig) and the
-         * DPI calculation, so all three always agree (issue #767). Bucketed by the panel's real
-         * pixels, in landscape terms (long side x short side); 1440p/4K are gated behind hardware
-         * HEVC on a recent enough Android, matching what the phone will actually stream. Mild
-         * downscaling (e.g. 1080p onto a 1024x600 panel) is allowed on purpose; only genuinely
-         * small panels are dropped to 720p/480p, which avoids the heavy per-frame downscale that
-         * overloads the MediaTek MDP scaler (issue #650).
+         * The largest resolution a physical panel warrants: the recommended label, the wizard, AUTO
+         * and the DPI all read this, so they agree (issue #767). Bucketed by the panel's real pixels
+         * in landscape terms; 1440p/4K are gated behind hardware HEVC on a recent enough Android.
+         * A recommendation, not a limit: the runtime cap is [hardCeiling] and it sits at or above.
          */
         fun panelCeiling(realWidthPx: Int, realHeightPx: Int, canHevc: Boolean): Settings.Resolution {
+            val longSide = maxOf(realWidthPx, realHeightPx)
+            val shortSide = minOf(realWidthPx, realHeightPx)
+            val hevcHiRes = canHevc && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+            // Keyed on the short side, matching NegotiatedResolutionPolicy.autoLadder in FILL: the
+            // rows are the only dimension a 16:9 buffer can match, and a wider panel is described
+            // by the pixel aspect ratio instead of by a margin that hides the extra rows.
+            return when {
+                longSide <= 0 -> Settings.Resolution._1280x720
+                longSide <= 800 && shortSide <= 480 -> Settings.Resolution._800x480
+                shortSide >= 2160 && hevcHiRes -> Settings.Resolution._3840x2160
+                shortSide >= 1440 && hevcHiRes -> Settings.Resolution._2560x1440
+                shortSide > 720 -> Settings.Resolution._1920x1080
+                else -> Settings.Resolution._1280x720
+            }
+        }
+
+        /**
+         * The largest buffer the panel can still *use*, as opposed to the one it warrants. A wide
+         * panel uses every column of a 1920-wide buffer and only hides rows behind a margin, which
+         * is not the per-frame downscale issue #650 is about, so refusing it would cost native
+         * width for a saving the user did not ask for. Only the runtime cap reads this.
+         */
+        fun hardCeiling(realWidthPx: Int, realHeightPx: Int, canHevc: Boolean): Settings.Resolution {
             val longSide = maxOf(realWidthPx, realHeightPx)
             val shortSide = minOf(realWidthPx, realHeightPx)
             val hevcHiRes = canHevc && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SystemUI.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SystemUI.kt
@@ -14,7 +14,17 @@ import com.andrerinas.openheadunit.utils.AppLog
 
 object SystemUI {
 
-    fun apply(window: Window, root: View, mode: Settings.FullscreenMode, onInsetsChanged: (() -> Unit)? = null) {
+    /**
+     * [notesCanvas] false for a window that is not the projection, so it cannot describe a canvas
+     * the video will never be drawn into.
+     */
+    fun apply(
+        window: Window,
+        root: View,
+        mode: Settings.FullscreenMode,
+        notesCanvas: Boolean = true,
+        onInsetsChanged: (() -> Unit)? = null,
+    ) {
         // Always keep screen on for Headunit functionality
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 
@@ -116,6 +126,11 @@ object SystemUI {
         val manualR = settings.insetRight
         val manualB = settings.insetBottom
 
+        // Read before the line below re-seeds the insets: until it runs, the content area and the
+        // insets in force describe the same layout, and afterwards one half of the pair is stale.
+        val canvasView = if (notesCanvas) (window.decorView.findViewById<View>(android.R.id.content) ?: root) else null
+        canvasView?.let { noteContentSize(it) }
+
         root.setPadding(manualL, manualT, manualR, manualB)
         HeadUnitScreenConfig.updateInsets(manualL, manualT, manualR, manualB)
 
@@ -197,5 +212,29 @@ object SystemUI {
 
         ViewCompat.requestApplyInsets(root)
         root.requestLayout()
+
+        canvasView?.let { watchCanvas(it) }
     }
+
+    /**
+     * Report this window's content area as the canvas for the current screen mode. Service
+     * discovery answers before any projection surface exists, so without this the first session in
+     * a mode announces a pixel shape measured from the display instead of the window.
+     */
+    private fun watchCanvas(content: View) {
+        // apply() runs again on every focus change, so the watch is installed once per view and
+        // left in place: a one-shot would latch whatever the insets happened to be that frame.
+        if (canvasWatched.put(content, true) != null) return
+        content.addOnLayoutChangeListener { v, _, _, _, _, _, _, _, _ -> noteContentSize(v) }
+    }
+
+    /** A window shrunk by the soft keyboard is not the canvas the projection will get. */
+    private fun noteContentSize(content: View) {
+        if (content.width <= 0 || content.height <= 0) return
+        val ime = ViewCompat.getRootWindowInsets(content)?.getInsets(WindowInsetsCompat.Type.ime())
+        if (ime != null && (ime.bottom > 0 || ime.top > 0)) return
+        HeadUnitScreenConfig.noteWindowContent(content.width, content.height)
+    }
+
+    private val canvasWatched = java.util.WeakHashMap<View, Boolean>()
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/VideoFitPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/VideoFitPolicy.kt
@@ -1,0 +1,25 @@
+package com.andrerinas.openheadunit.utils
+
+/**
+ * Resolves the stored video fit mode, migrating installs that only have the old
+ * "stretch_to_fill" boolean. The legacy forcedScale/SurfaceView path read that boolean
+ * inverted (true meant bars, not stretch), so the migration branches on it.
+ */
+object VideoFitPolicy {
+
+    /** Null arguments mean the preference was never written; the old getter read the boolean as true. */
+    fun resolve(
+        storedFitMode: Int?,
+        legacyStretch: Boolean?,
+        legacyForcedScale: Boolean,
+        legacyViewMode: Int
+    ): Settings.VideoFitMode {
+        if (storedFitMode != null) {
+            return Settings.VideoFitMode.fromInt(storedFitMode) ?: Settings.VideoFitMode.FILL
+        }
+        val legacy = legacyStretch ?: true
+        val forcedScaleActive = legacyForcedScale && legacyViewMode == Settings.ViewMode.SURFACE.value
+        val effectiveStretch = if (forcedScaleActive) !legacy else legacy
+        return if (effectiveStretch) Settings.VideoFitMode.FILL else Settings.VideoFitMode.CONTAIN
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/view/ProjectionView.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/view/ProjectionView.kt
@@ -9,6 +9,7 @@ import com.andrerinas.openheadunit.decoder.video.DecoderStopPolicy
 import com.andrerinas.openheadunit.decoder.video.VideoDecoder
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.HeadUnitScreenConfig
+import com.andrerinas.openheadunit.utils.Settings
 
 class ProjectionView @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
@@ -73,11 +74,14 @@ class ProjectionView @JvmOverloads constructor(
 
         if (HeadUnitScreenConfig.forcedScale) {
             val settings = App.provide(context).settings
-            if (settings.stretchToFill) {
-                holder.setSizeFromLayout()
-            } else {
+            if (settings.videoFitMode == Settings.VideoFitMode.FILL) {
                 AppLog.i("FORCED SCALE: Setting fixed size to ${width}x$height")
                 holder.setFixedSize(width, height)
+            } else {
+                // CONTAIN/COVER: the LayoutParams size set by ProjectionViewScaler (getAdjustedWidth/
+                // Height or getCoverWidth/Height) IS the deliberate final pixel size - adopt it as
+                // the buffer size directly rather than stretching from native.
+                holder.setSizeFromLayout()
             }
         } else {
             holder.setSizeFromLayout()

--- a/app/src/main/java/com/andrerinas/openheadunit/view/ProjectionViewScaler.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/view/ProjectionViewScaler.kt
@@ -7,6 +7,7 @@ import android.view.Gravity
 import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.HeadUnitScreenConfig
+import com.andrerinas.openheadunit.utils.Settings
 
 object ProjectionViewScaler {
 
@@ -26,13 +27,46 @@ object ProjectionViewScaler {
         if (HeadUnitScreenConfig.forcedScale && view is ProjectionView) {
             val lp = view.layoutParams
             var paramsChanged = false
-            
-            // NOTE: For legacy forcedScale (SurfaceView), the 'stretchToFill' setting logic
-            // is historically inverted compared to its name.
-            if (settings.stretchToFill) {
-                // stretchToFill = TRUE results in Aspect Ratio preservation (Centered with bars)
-                val targetW = HeadUnitScreenConfig.getAdjustedWidth()
-                val targetH = HeadUnitScreenConfig.getAdjustedHeight()
+
+            if (settings.videoFitMode == Settings.VideoFitMode.FILL) {
+                // Stretch to fill the usable area exactly (ignores aspect ratio, no bars, no crop)
+                if (lp.width != usableW || lp.height != usableH) {
+                    lp.width = usableW
+                    lp.height = usableH
+                    paramsChanged = true
+                }
+
+                if (lp is FrameLayout.LayoutParams) {
+                    val targetGravity = Gravity.TOP or Gravity.START
+                    if (lp.gravity != targetGravity) {
+                        lp.gravity = targetGravity
+                        paramsChanged = true
+                    }
+                }
+
+                if (paramsChanged) {
+                    view.layoutParams = lp
+                }
+
+                view.scaleX = 1.0f * mirrorFactor
+                view.scaleY = 1.0f
+                view.translationX = 0f
+                view.translationY = 0f
+
+                AppLog.i("[UI_DEBUG] FORCED FILL: Resized view to match screen exactly: ${usableW}x${usableH}")
+            } else {
+                // CONTAIN: size down to fit within the usable area, centered, letterboxed.
+                // COVER: size up past the usable area, centered, the parent clips the overflow.
+                // Both preserve aspect ratio (no distortion) - only the target size differs.
+                val targetW: Int
+                val targetH: Int
+                if (settings.videoFitMode == Settings.VideoFitMode.COVER) {
+                    targetW = HeadUnitScreenConfig.getCoverWidth()
+                    targetH = HeadUnitScreenConfig.getCoverHeight()
+                } else {
+                    targetW = HeadUnitScreenConfig.getAdjustedWidth()
+                    targetH = HeadUnitScreenConfig.getAdjustedHeight()
+                }
 
                 if (lp.width != targetW || lp.height != targetH) {
                     lp.width = targetW
@@ -47,7 +81,7 @@ object ProjectionViewScaler {
                         paramsChanged = true
                     }
                 }
-                
+
                 if (paramsChanged) {
                     view.layoutParams = lp
                 }
@@ -57,33 +91,7 @@ object ProjectionViewScaler {
                 view.translationX = 0f
                 view.translationY = 0f
 
-                AppLog.i("[UI_DEBUG] FORCED & STRETCH On: Resized view to ${targetW}x${targetH} (centered)")
-            } else {
-                // Mode B: Stretch to fill the usable area exactly (ignores aspect ratio)
-                if (lp.width != usableW || lp.height != usableH) {
-                    lp.width = usableW
-                    lp.height = usableH
-                    paramsChanged = true
-                }
-                
-                if (lp is FrameLayout.LayoutParams) {
-                    val targetGravity = Gravity.TOP or Gravity.START
-                    if (lp.gravity != targetGravity) {
-                        lp.gravity = targetGravity
-                        paramsChanged = true
-                    }
-                }
-                
-                if (paramsChanged) {
-                    view.layoutParams = lp
-                }
-
-                view.scaleX = 1.0f * mirrorFactor
-                view.scaleY = 1.0f
-                view.translationX = 0f
-                view.translationY = 0f
-
-                AppLog.i("[UI_DEBUG] FORCED & STRETCH Off: Resized view to match screen exactly: ${usableW}x${usableH}")
+                AppLog.i("[UI_DEBUG] FORCED ${settings.videoFitMode}: Resized view to ${targetW}x${targetH} (centered)")
             }
         } else {
             // Modern way / TextureView: Use View scaling properties on a full-screen view

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -234,8 +234,11 @@
     <string name="add_new">إضافة جديد</string>
     <string name="cancel">إلغاء</string>
     <string name="enable">تمكين</string>
-    <string name="pref_stretch_screen_title">تمديد لملء الشاشة</string>
-    <string name="pref_stretch_screen_summary">يتجاهل نسبة العرض إلى الارتفاع لملء الشاشة بأكملها (يزيل الأشرطة السوداء)</string>
+    <string name="video_fit_mode">ملاءمة الفيديو</string>
+    <string name="change_video_fit_mode">تغيير ملاءمة الفيديو</string>
+    <string name="video_fit_mode_fill">تمديد للملء (بدون أشرطة، قد يشوّه الصورة)</string>
+    <string name="video_fit_mode_contain">احتواء مع أشرطة (بدون اقتصاص أو تشويه)</string>
+    <string name="video_fit_mode_cover">ملء بالاقتصاص (بدون أشرطة أو تشويه)</string>
 
     <!-- Audio Settings -->
     <string name="forced_scale">قياس إجباري (إصلاح قديم)</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -869,8 +869,6 @@
     <string name="cannot_open_settings">Could not open system settings</string>
     <string name="static_bssid_enter_value">Enter BSSID (XX:XX:XX:XX:XX:XX)</string>
     <string name="static_bssid_desc">اضبط BSSID للاتصال اللاسلكي يدويًا. لا يلزم إلا عندما لا يذكره أي مصدر في هذا الجهاز؛ يسرد السجل كل مصدر تم سؤاله.</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
     <string name="media_key_routing">Send Media Buttons To Android Auto</string>
     <string name="media_key_routing_always">Always</string>
     <string name="media_key_routing_auto">Automatic</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -871,8 +871,6 @@
     <string name="cannot_open_settings">Could not open system settings</string>
     <string name="static_bssid_enter_value">Enter BSSID (XX:XX:XX:XX:XX:XX)</string>
     <string name="static_bssid_desc">Nastavte BSSID pro bezdrátové spojení ručně. Potřeba jen tam, kde ji žádný zdroj v tomto zařízení neuvádí; protokol vypíše každý dotázaný zdroj.</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
     <string name="media_key_routing">Send Media Buttons To Android Auto</string>
     <string name="media_key_routing_always">Always</string>
     <string name="media_key_routing_auto">Automatic</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -234,8 +234,11 @@
     <string name="add_new">Přidat nové</string>
     <string name="cancel">Zrušit</string>
     <string name="enable">Povolit</string>
-    <string name="pref_stretch_screen_title">Roztáhnout na celou obrazovku</string>
-    <string name="pref_stretch_screen_summary">Ignoruje poměr stran a vyplní celý displej (odstraní černé pruhy)</string>
+    <string name="video_fit_mode">Přizpůsobení obrazu</string>
+    <string name="change_video_fit_mode">Změnit přizpůsobení obrazu</string>
+    <string name="video_fit_mode_fill">Roztáhnout na celou plochu (bez pruhů, může deformovat)</string>
+    <string name="video_fit_mode_contain">Vejít se s pruhy (bez oříznutí a deformace)</string>
+    <string name="video_fit_mode_cover">Vyplnit oříznutím (bez pruhů a deformace)</string>
 
     <!-- Audio Settings -->
     <string name="forced_scale">Vynucené měřítko (Legacy oprava)</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -298,8 +298,11 @@
     <string name="add_new">Hinzufügen</string>
     <string name="cancel">Abbrechen</string>
     <string name="enable">Aktivieren</string>
-    <string name="pref_stretch_screen_title">Auf Bildschirmgröße strecken</string>
-    <string name="pref_stretch_screen_summary">Ignoriert das Seitenverhältnis, um das gesamte Display auszufüllen (entfernt schwarze Balken)</string>
+    <string name="video_fit_mode">Bildanpassung</string>
+    <string name="change_video_fit_mode">Bildanpassung ändern</string>
+    <string name="video_fit_mode_fill">Auf Vollbild strecken (keine Balken, kann verzerren)</string>
+    <string name="video_fit_mode_contain">Mit Balken einpassen (kein Beschnitt, keine Verzerrung)</string>
+    <string name="video_fit_mode_cover">Durch Beschneiden füllen (keine Balken, keine Verzerrung)</string>
     <string name="forced_scale">Erzwungene Skalierung (Legacy Fix)</string>
     <string name="forced_scale_description">Korrigiert Skalierungsprobleme auf einigen älteren Geräten mit SurfaceView. Nur verwenden, wenn das Bild verzerrt oder verschoben aussieht.</string>
     <string name="hud_mirroring">HUD-Modus (Horizontale Spiegelung)</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -921,8 +921,6 @@
     <string name="dpi_size_l">L</string>
     <string name="dpi_size_xl">XL</string>
     <string name="dpi_value_format">%1$d DPI</string>
-    <string name="use_measured_touch_surface">Experimentelle Fixierung für Touch-Ausrichtung</string>
-    <string name="use_measured_touch_surface_description">Normalisiert Touch-Eingaben über dem gemessenen Projektionsbereich. Hilft, wenn kleine Android Auto Bedienelemente versetzt wirken.</string>
 
     <string-array name="vehicle_brands">
         <item>Google</item>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -234,8 +234,11 @@
     <string name="add_new">Añadir nuevo</string>
     <string name="cancel">Cancelar</string>
     <string name="enable">Activar</string>
-    <string name="pref_stretch_screen_title">Estirar para llenar la pantalla</string>
-    <string name="pref_stretch_screen_summary">Ignora la relación de aspecto para rellenar toda la pantalla (elimina las barras negras)</string>
+    <string name="video_fit_mode">Ajuste de vídeo</string>
+    <string name="change_video_fit_mode">Cambiar ajuste de vídeo</string>
+    <string name="video_fit_mode_fill">Estirar para llenar (sin barras, puede deformar)</string>
+    <string name="video_fit_mode_contain">Ajustar con barras (sin recorte ni deformación)</string>
+    <string name="video_fit_mode_cover">Llenar recortando (sin barras ni deformación)</string>
 
     <!-- Audio Settings -->
     <string name="forced_scale">Escalado forzado (Corrección heredada)</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -880,8 +880,6 @@
     <string name="cannot_open_settings">Could not open system settings</string>
     <string name="static_bssid_enter_value">Enter BSSID (XX:XX:XX:XX:XX:XX)</string>
     <string name="static_bssid_desc">Establece a mano la BSSID para el enlace inalámbrico. Solo hace falta si ninguna fuente de este dispositivo indica una; el registro nombra cada fuente consultada.</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
     <string name="media_key_routing">Send Media Buttons To Android Auto</string>
     <string name="media_key_routing_always">Always</string>
     <string name="media_key_routing_auto">Automatic</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -879,8 +879,6 @@
     <string name="cannot_open_settings">Could not open system settings</string>
     <string name="static_bssid_enter_value">Enter BSSID (XX:XX:XX:XX:XX:XX)</string>
     <string name="static_bssid_desc">Establece a mano la BSSID para el enlace inalámbrico. Solo hace falta si ninguna fuente de este dispositivo indica una; el registro nombra cada fuente consultada.</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
     <string name="media_key_routing">Send Media Buttons To Android Auto</string>
     <string name="media_key_routing_always">Always</string>
     <string name="media_key_routing_auto">Automatic</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -234,8 +234,11 @@
     <string name="add_new">Añadir nuevo</string>
     <string name="cancel">Cancelar</string>
     <string name="enable">Activar</string>
-    <string name="pref_stretch_screen_title">Estirar para llenar la pantalla</string>
-    <string name="pref_stretch_screen_summary">Ignora la relación de aspecto para rellenar toda la pantalla (elimina las barras negras)</string>
+    <string name="video_fit_mode">Ajuste de vídeo</string>
+    <string name="change_video_fit_mode">Cambiar ajuste de vídeo</string>
+    <string name="video_fit_mode_fill">Estirar para llenar (sin barras, puede deformar)</string>
+    <string name="video_fit_mode_contain">Ajustar con barras (sin recorte ni deformación)</string>
+    <string name="video_fit_mode_cover">Llenar recortando (sin barras ni deformación)</string>
 
     <!-- Audio Settings -->
     <string name="forced_scale">Escalado forzado (Corrección heredada)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -443,8 +443,6 @@
     <string name="forced_scale_description">Corrige les problèmes de mise à l\'échelle sur certains appareils plus anciens utilisant SurfaceView. À utiliser uniquement si l\'image semble déformée ou décalée.</string>
     <string name="hud_mirroring">Mode HUD (Miroir horizontal)</string>
     <string name="hud_mirroring_description">Retourne l\'affichage horizontalement pour le reflet sur le pare-brise (Affichage Tête Haute). Nécessite le mode de vue TextureView ou GLES20 (ne fonctionne pas avec SurfaceView).</string>
-    <string name="use_measured_touch_surface">Correction expérimentale de l\'alignement tactile</string>
-    <string name="use_measured_touch_surface_description">Normaliser la saisie tactile par rapport à la superposition de projection mesurée. Peut aider lorsque les petits contrôles d\'Android Auto semblent décalés.</string>
 
 
     <!-- Audio Settings -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -434,8 +434,11 @@
     <string name="add_new">Ajouter un nouveau</string>
     <string name="cancel">Annuler</string>
     <string name="enable">Activer</string>
-    <string name="pref_stretch_screen_title">Étirer pour remplir l\'écran</string>
-    <string name="pref_stretch_screen_summary">Ignore le ratio d\'aspect pour remplir tout l\'écran (supprime les bandes noires)</string>
+    <string name="video_fit_mode">Ajustement de la vidéo</string>
+    <string name="change_video_fit_mode">Modifier l\'ajustement de la vidéo</string>
+    <string name="video_fit_mode_fill">Étirer pour remplir (sans bandes, peut déformer)</string>
+    <string name="video_fit_mode_contain">Ajuster avec des bandes (sans rognage ni déformation)</string>
+    <string name="video_fit_mode_cover">Remplir en rognant (sans bandes ni déformation)</string>
     <string name="forced_scale">Échelle forcée (Correction héritée)</string>
     <string name="forced_scale_description">Corrige les problèmes de mise à l\'échelle sur certains appareils plus anciens utilisant SurfaceView. À utiliser uniquement si l\'image semble déformée ou décalée.</string>
     <string name="hud_mirroring">Mode HUD (Miroir horizontal)</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -867,8 +867,6 @@
     <string name="cannot_open_settings">Could not open system settings</string>
     <string name="static_bssid_enter_value">Enter BSSID (XX:XX:XX:XX:XX:XX)</string>
     <string name="static_bssid_desc">A vezeték nélküli kapcsolat BSSID-jének kézi megadása. Csak akkor kell, ha az eszközön egyetlen forrás sem ad meg egyet; a napló felsorolja az összes megkérdezett forrást.</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
     <string name="media_key_routing">Send Media Buttons To Android Auto</string>
     <string name="media_key_routing_always">Always</string>
     <string name="media_key_routing_auto">Automatic</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -233,8 +233,11 @@
     <string name="add_new">Új hozzáadása</string>
     <string name="cancel">Mégse</string>
     <string name="enable">Engedélyezés</string>
-    <string name="pref_stretch_screen_title">Kinyújtás teljes képernyőre</string>
-    <string name="pref_stretch_screen_summary">Figyelmen kívül hagyja a képarányt a teljes kijelző kitöltéséhez (eltávolítja a fekete sávokat)</string>
+    <string name="video_fit_mode">Képillesztés</string>
+    <string name="change_video_fit_mode">Képillesztés módosítása</string>
+    <string name="video_fit_mode_fill">Nyújtás kitöltéshez (nincsenek sávok, torzulhat)</string>
+    <string name="video_fit_mode_contain">Illesztés sávokkal (nincs levágás vagy torzulás)</string>
+    <string name="video_fit_mode_cover">Kitöltés levágással (nincsenek sávok vagy torzulás)</string>
 
     <!-- Audio Settings -->
     <string name="forced_scale">Kényszerített méretezés (Legacy javítás)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -259,8 +259,11 @@
     <string name="add_new">Aggiungi nuovo</string>
     <string name="cancel">Annulla</string>
     <string name="enable">Abilita</string>
-    <string name="pref_stretch_screen_title">Adatta allo schermo</string>
-    <string name="pref_stretch_screen_summary">Ignora le proporzioni per riempire l\'intero display (rimuove le barre nere)</string>
+    <string name="video_fit_mode">Adattamento video</string>
+    <string name="change_video_fit_mode">Cambia adattamento video</string>
+    <string name="video_fit_mode_fill">Allunga per riempire (senza bande, può distorcere)</string>
+    <string name="video_fit_mode_contain">Adatta con bande (senza ritaglio né distorsione)</string>
+    <string name="video_fit_mode_cover">Riempi ritagliando (senza bande né distorsione)</string>
     <string name="forced_scale">Scala forzata (Fix Legacy)</string>
     <string name="forced_scale_description">Corregge i problemi di ridimensionamento su alcuni dispositivi più vecchi che utilizzano SurfaceView. Utilizzare solo se l\'immagine appare distorta o spostata.</string>
     <string name="hud_mirroring">Modalità HUD (Capovolgimento orizzontale)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -874,8 +874,6 @@
     <string name="cannot_open_settings">Could not open system settings</string>
     <string name="static_bssid_enter_value">Enter BSSID (XX:XX:XX:XX:XX:XX)</string>
     <string name="static_bssid_desc">Imposta a mano il BSSID per l\'handshake wireless. Serve solo se nessuna fonte su questo dispositivo ne indica uno; il log elenca ogni fonte interrogata.</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
     <string name="media_key_routing">Send Media Buttons To Android Auto</string>
     <string name="media_key_routing_always">Always</string>
     <string name="media_key_routing_auto">Automatic</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -875,8 +875,6 @@
     <string name="cannot_open_settings">Could not open system settings</string>
     <string name="static_bssid_enter_value">Enter BSSID (XX:XX:XX:XX:XX:XX)</string>
     <string name="static_bssid_desc">ワイヤレス接続のBSSIDを手動で設定します。この端末のどのソースも返さない場合にのみ必要です。ログには問い合わせたすべてのソースが記録されます。</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
     <string name="media_key_routing">Send Media Buttons To Android Auto</string>
     <string name="media_key_routing_always">Always</string>
     <string name="media_key_routing_auto">Automatic</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -258,8 +258,11 @@
     <string name="add_new">新規追加</string>
     <string name="cancel">キャンセル</string>
     <string name="enable">有効にする</string>
-    <string name="pref_stretch_screen_title">画面いっぱいに伸ばす</string>
-    <string name="pref_stretch_screen_summary">アスペクト比を無視して画面全体に表示します（黒帯を削除）。</string>
+    <string name="video_fit_mode">映像のフィット</string>
+    <string name="change_video_fit_mode">映像のフィットを変更</string>
+    <string name="video_fit_mode_fill">引き伸ばして全画面 (帯なし、ゆがむ場合あり)</string>
+    <string name="video_fit_mode_contain">帯を付けて全体表示 (切り取りやゆがみなし)</string>
+    <string name="video_fit_mode_cover">切り取って全画面 (帯やゆがみなし)</string>
 
 
     <!-- Audio Settings -->

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -262,8 +262,11 @@
     <string name="add_new">ახლის დამატება</string>
     <string name="cancel">გაუქმება</string>
     <string name="enable">ჩართვა</string>
-    <string name="pref_stretch_screen_title">გაწელვა მთელ ეკრანზე</string>
-    <string name="pref_stretch_screen_summary">უგულებელყოფს გვერდების თანაფარდობას მთელი ეკრანის შესავსებად (აქრობს შავ ზოლებს)</string>
+    <string name="video_fit_mode">ვიდეოს მორგება</string>
+    <string name="change_video_fit_mode">ვიდეოს მორგების შეცვლა</string>
+    <string name="video_fit_mode_fill">გაწელვა შესავსებად (ზოლების გარეშე, შეიძლება დამახინჯდეს)</string>
+    <string name="video_fit_mode_contain">ჩასმა ზოლებით (ჩამოჭრისა და დამახინჯების გარეშე)</string>
+    <string name="video_fit_mode_cover">შევსება ჩამოჭრით (ზოლებისა და დამახინჯების გარეშე)</string>
     <string name="forced_scale">იძულებითი მასშტაბირება (Legacy Fix)</string>
     <string name="forced_scale_description">ასწორებს მასშტაბირების პრობლემებს ზოგიერთ ძველ მოწყობილობაზე SurfaceView-ს გამოყენებისას. გამოიყენეთ მხოლოდ იმ შემთხვევაში, თუ გამოსახულება დამახინჯებულია ან გადაადგილებულია.</string>
     <string name="hud_mirroring">HUD რეჟიმი (ჰორიზონტალური სარკე)</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -799,8 +799,6 @@
     <string name="cannot_open_settings">Could not open system settings</string>
     <string name="static_bssid_enter_value">Enter BSSID (XX:XX:XX:XX:XX:XX)</string>
     <string name="static_bssid_desc">დააყენეთ BSSID უსადენო კავშირისთვის ხელით. საჭიროა მხოლოდ მაშინ, როცა ამ მოწყობილობის არცერთი წყარო არ ასახელებს მას; ჟურნალი ჩამოთვლის ყველა გამოკითხულ წყაროს.</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
     <string name="media_key_routing">Send Media Buttons To Android Auto</string>
     <string name="media_key_routing_always">Always</string>
     <string name="media_key_routing_auto">Automatic</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -269,8 +269,11 @@
     <string name="add_new">새로 추가</string>
     <string name="cancel">취소</string>
     <string name="enable">활성화</string>
-    <string name="pref_stretch_screen_title">화면에 맞게 늘리기</string>
-    <string name="pref_stretch_screen_summary">화면 비율을 무시하고 전체 화면을 채웁니다(검정색 바 제거)</string>
+    <string name="video_fit_mode">화면 맞춤</string>
+    <string name="change_video_fit_mode">화면 맞춤 변경</string>
+    <string name="video_fit_mode_fill">늘려서 채우기 (여백 없음, 왜곡될 수 있음)</string>
+    <string name="video_fit_mode_contain">여백을 두고 맞추기 (잘림 없음, 왜곡 없음)</string>
+    <string name="video_fit_mode_cover">잘라서 채우기 (여백 없음, 왜곡 없음)</string>
     <string name="forced_scale">강제 화면 배율 조정(구형 기기 보정)</string>
     <string name="forced_scale_description">SurfaceView를 사용하는 일부 구형 기기에서 화면 크기 조정 문제를 보정합니다. 이미지가 왜곡되거나 위치가 어긋나 보일 때만 사용하세요.</string>
     <string name="hud_mirroring">HUD 모드 (좌우 반전)</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -869,8 +869,6 @@
     <string name="pixel_aspect_ratio">Pixel aspect ratio</string>
     <string name="enter_pixel_aspect_ratio_value">Pixel aspect ratio x10000 (10000 = square pixels)</string>
     <string name="cannot_open_settings">Could not open system settings</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
     <string name="media_key_routing">Send Media Buttons To Android Auto</string>
     <string name="media_key_routing_always">Always</string>
     <string name="media_key_routing_auto">Automatic</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -233,8 +233,11 @@
     <string name="add_new">Nieuwe toevoegen</string>
     <string name="cancel">Annuleren</string>
     <string name="enable">Inschakelen</string>
-    <string name="pref_stretch_screen_title">Uitrekken om scherm te vullen</string>
-    <string name="pref_stretch_screen_summary">Negeert de beeldverhouding om het volledige display te vullen (verwijdert zwarte balken)</string>
+    <string name="video_fit_mode">Videopassing</string>
+    <string name="change_video_fit_mode">Videopassing wijzigen</string>
+    <string name="video_fit_mode_fill">Uitrekken om te vullen (geen balken, kan vervormen)</string>
+    <string name="video_fit_mode_contain">Passend met balken (geen bijsnijden of vervorming)</string>
+    <string name="video_fit_mode_cover">Vullen door bij te snijden (geen balken of vervorming)</string>
 
     <!-- Audio Settings -->
     <string name="forced_scale">Geforceerde schaal (Legacy Fix)</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -871,8 +871,6 @@
     <string name="cannot_open_settings">Could not open system settings</string>
     <string name="static_bssid_enter_value">Enter BSSID (XX:XX:XX:XX:XX:XX)</string>
     <string name="static_bssid_desc">Stel de BSSID voor de draadloze handshake handmatig in. Alleen nodig als geen enkele bron op dit apparaat er een noemt; het logboek noemt elke bevraagde bron.</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
     <string name="media_key_routing">Send Media Buttons To Android Auto</string>
     <string name="media_key_routing_always">Always</string>
     <string name="media_key_routing_auto">Automatic</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -870,8 +870,6 @@
     <string name="cannot_open_settings">Could not open system settings</string>
     <string name="static_bssid_enter_value">Enter BSSID (XX:XX:XX:XX:XX:XX)</string>
     <string name="static_bssid_desc">Ustaw BSSID połączenia bezprzewodowego ręcznie. Potrzebne tylko wtedy, gdy żadne źródło w tym urządzeniu go nie podaje; dziennik wymienia każde odpytane źródło.</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
     <string name="media_key_routing">Send Media Buttons To Android Auto</string>
     <string name="media_key_routing_always">Always</string>
     <string name="media_key_routing_auto">Automatic</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -234,8 +234,11 @@
     <string name="add_new">Dodaj nowy</string>
     <string name="cancel">Anuluj</string>
     <string name="enable">Włącz</string>
-    <string name="pref_stretch_screen_title">Rozciągnij na cały ekran</string>
-    <string name="pref_stretch_screen_summary">Ignoruje proporcje ekranu, aby wypełnić cały wyświetlacz (usuwa czarne paski)</string>
+    <string name="video_fit_mode">Dopasowanie obrazu</string>
+    <string name="change_video_fit_mode">Zmień dopasowanie obrazu</string>
+    <string name="video_fit_mode_fill">Rozciągnij, aby wypełnić (bez pasów, może zniekształcać)</string>
+    <string name="video_fit_mode_contain">Dopasuj z pasami (bez przycinania i zniekształceń)</string>
+    <string name="video_fit_mode_cover">Wypełnij przycinaniem (bez pasów i zniekształceń)</string>
 
     <!-- Audio Settings -->
     <string name="forced_scale">Wymuszone skalowanie (Poprawka legacy)</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -872,8 +872,6 @@
     <string name="cannot_open_settings">Could not open system settings</string>
     <string name="static_bssid_enter_value">Enter BSSID (XX:XX:XX:XX:XX:XX)</string>
     <string name="static_bssid_desc">Defina o BSSID da conexão sem fio manualmente. Só é necessário quando nenhuma fonte deste dispositivo informa um; o registro nomeia cada fonte consultada.</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
     <string name="media_key_routing">Send Media Buttons To Android Auto</string>
     <string name="media_key_routing_always">Always</string>
     <string name="media_key_routing_auto">Automatic</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -234,8 +234,11 @@
     <string name="add_new">Adicionar novo</string>
     <string name="cancel">Cancelar</string>
     <string name="enable">Ativar</string>
-    <string name="pref_stretch_screen_title">Esticar para preencher a tela</string>
-    <string name="pref_stretch_screen_summary">Ignora a proporção original para preencher todo o visor (remove as barras pretas)</string>
+    <string name="video_fit_mode">Ajuste do vídeo</string>
+    <string name="change_video_fit_mode">Alterar ajuste do vídeo</string>
+    <string name="video_fit_mode_fill">Esticar para preencher (sem barras, pode distorcer)</string>
+    <string name="video_fit_mode_contain">Ajustar com barras (sem corte nem distorção)</string>
+    <string name="video_fit_mode_cover">Preencher cortando (sem barras nem distorção)</string>
 
     <!-- Audio Settings -->
     <string name="forced_scale">Escala forçada (Modo de compatibilidade)</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -255,8 +255,11 @@
     <string name="add_new">Adaugă nou</string>
     <string name="cancel">Anulează</string>
     <string name="enable">Activează</string>
-    <string name="pref_stretch_screen_title">Întindere pentru a umple ecranul</string>
-    <string name="pref_stretch_screen_summary">Ignoră raportul de aspect pentru a umple întregul afișaj (elimină barele negre)</string>
+    <string name="video_fit_mode">Încadrarea imaginii</string>
+    <string name="change_video_fit_mode">Schimbă încadrarea imaginii</string>
+    <string name="video_fit_mode_fill">Întinde pentru umplere (fără bare, poate deforma)</string>
+    <string name="video_fit_mode_contain">Încadrează cu bare (fără decupare sau deformare)</string>
+    <string name="video_fit_mode_cover">Umple prin decupare (fără bare sau deformare)</string>
 
     <!-- Audio Settings -->
     <string name="forced_scale">Scalare forțată (Fix legacy)</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -868,8 +868,6 @@
     <string name="cannot_open_settings">Could not open system settings</string>
     <string name="static_bssid_enter_value">Enter BSSID (XX:XX:XX:XX:XX:XX)</string>
     <string name="static_bssid_desc">Setați manual BSSID-ul pentru conexiunea wireless. Necesar doar când nicio sursă de pe acest dispozitiv nu indică una; jurnalul numește fiecare sursă interogată.</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
     <string name="media_key_routing">Send Media Buttons To Android Auto</string>
     <string name="media_key_routing_always">Always</string>
     <string name="media_key_routing_auto">Automatic</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -237,8 +237,11 @@
     <string name="add_new">Добавить</string>
     <string name="cancel">Отмена</string>
     <string name="enable">Включить</string>
-    <string name="pref_stretch_screen_title">Растянуть на весь экран</string>
-    <string name="pref_stretch_screen_summary">Игнорирует соотношение сторон для заполнения всего дисплея (убирает черные полосы)</string>
+    <string name="video_fit_mode">Вписывание видео</string>
+    <string name="change_video_fit_mode">Изменить вписывание видео</string>
+    <string name="video_fit_mode_fill">Растянуть на весь экран (без полос, возможны искажения)</string>
+    <string name="video_fit_mode_contain">Вписать с полосами (без обрезки и искажений)</string>
+    <string name="video_fit_mode_cover">Заполнить обрезкой (без полос и искажений)</string>
 
     <!-- Audio Settings -->
     <string name="forced_scale">Принудительное масштабирование (Legacy Fix)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -870,8 +870,6 @@
     <string name="cannot_open_settings">Could not open system settings</string>
     <string name="static_bssid_enter_value">Enter BSSID (XX:XX:XX:XX:XX:XX)</string>
     <string name="static_bssid_desc">Задайте BSSID для беспроводного подключения вручную. Нужно только там, где ни один источник на устройстве его не называет; в журнале перечислен каждый опрошенный источник.</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
     <string name="media_key_routing">Send Media Buttons To Android Auto</string>
     <string name="media_key_routing_always">Always</string>
     <string name="media_key_routing_auto">Automatic</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -255,8 +255,11 @@
     <string name="add_new">Yeni ekle</string>
     <string name="cancel">İptal</string>
     <string name="enable">Etkinleştir</string>
-    <string name="pref_stretch_screen_title">Ekranı doldurmak için uzat</string>
-    <string name="pref_stretch_screen_summary">Tüm ekranı doldurmak için en boy oranını yok sayar (siyah çubukları kaldırır)</string>
+    <string name="video_fit_mode">Video sığdırma</string>
+    <string name="change_video_fit_mode">Video sığdırmayı değiştir</string>
+    <string name="video_fit_mode_fill">Doldurmak için genişlet (çubuk yok, bozulabilir)</string>
+    <string name="video_fit_mode_contain">Çubuklarla sığdır (kırpma ve bozulma yok)</string>
+    <string name="video_fit_mode_cover">Kırparak doldur (çubuk ve bozulma yok)</string>
     <string name="forced_scale">Zorunlu Ölçekleme (Eski Düzeltme)</string>
     <string name="forced_scale_description">SurfaceView kullanan bazı eski cihazlardaki ölçekleme sorunlarını düzeltir. Sadece görüntü bozuk veya kaymış görünüyorsa kullanın.</string>
     <string name="hud_mirroring">HUD Modu (Yatay Çevirme)</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -866,8 +866,6 @@
     <string name="cannot_open_settings">Could not open system settings</string>
     <string name="static_bssid_enter_value">Enter BSSID (XX:XX:XX:XX:XX:XX)</string>
     <string name="static_bssid_desc">Kablosuz bağlantı için BSSID\'yi elle ayarlayın. Yalnızca bu cihazdaki hiçbir kaynak bildirmediğinde gerekir; günlük, sorulan her kaynağı listeler.</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
     <string name="media_key_routing">Send Media Buttons To Android Auto</string>
     <string name="media_key_routing_always">Always</string>
     <string name="media_key_routing_auto">Automatic</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -872,8 +872,6 @@
     <string name="cannot_open_settings">Could not open system settings</string>
     <string name="static_bssid_enter_value">Enter BSSID (XX:XX:XX:XX:XX:XX)</string>
     <string name="static_bssid_desc">Задайте BSSID для бездротового з\'єднання вручну. Потрібно лише там, де жодне джерело на пристрої її не називає; у журналі перелічено кожне опитане джерело.</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
     <string name="media_key_routing">Send Media Buttons To Android Auto</string>
     <string name="media_key_routing_always">Always</string>
     <string name="media_key_routing_auto">Automatic</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -234,8 +234,11 @@
     <string name="add_new">Додати новий</string>
     <string name="cancel">Скасувати</string>
     <string name="enable">Увімкнути</string>
-    <string name="pref_stretch_screen_title">Розтягнути на весь екран</string>
-    <string name="pref_stretch_screen_summary">Ігнорує співвідношення сторін для заповнення всього дисплея (прибирає чорні смуги)</string>
+    <string name="video_fit_mode">Вписування відео</string>
+    <string name="change_video_fit_mode">Змінити вписування відео</string>
+    <string name="video_fit_mode_fill">Розтягнути на весь екран (без смуг, можливі спотворення)</string>
+    <string name="video_fit_mode_contain">Вписати зі смугами (без обрізання та спотворень)</string>
+    <string name="video_fit_mode_cover">Заповнити обрізанням (без смуг і спотворень)</string>
 
     <!-- Audio Settings -->
     <string name="forced_scale">Примусове масштабування (Legacy Fix)</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -874,8 +874,6 @@
     <string name="cannot_open_settings">Could not open system settings</string>
     <string name="static_bssid_enter_value">Enter BSSID (XX:XX:XX:XX:XX:XX)</string>
     <string name="static_bssid_desc">Đặt BSSID cho kết nối không dây thủ công. Chỉ cần khi không nguồn nào trên thiết bị này cho biết; nhật ký nêu tên từng nguồn đã hỏi.</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
     <string name="media_key_routing">Send Media Buttons To Android Auto</string>
     <string name="media_key_routing_always">Always</string>
     <string name="media_key_routing_auto">Automatic</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -250,8 +250,11 @@
     <string name="add_new">Thêm mới</string>
     <string name="cancel">Huỷ</string>
     <string name="enable">Bật</string>
-    <string name="pref_stretch_screen_title">Kéo dãn lấp đầy màn hình</string>
-    <string name="pref_stretch_screen_summary">Bỏ qua tỉ lệ khung hình để lấp đầy màn hình (loại bỏ viền đen)</string>
+    <string name="video_fit_mode">Cách vừa khung hình</string>
+    <string name="change_video_fit_mode">Đổi cách vừa khung hình</string>
+    <string name="video_fit_mode_fill">Kéo giãn để lấp đầy (không viền, có thể méo)</string>
+    <string name="video_fit_mode_contain">Vừa khung có viền (không cắt, không méo)</string>
+    <string name="video_fit_mode_cover">Lấp đầy bằng cách cắt (không viền, không méo)</string>
     <string name="forced_scale">Tỉ lệ ép buộc (Khắc phục cho máy cũ)</string>
     <string name="forced_scale_description">Khắc phục lỗi tỉ lệ trên một số máy cũ dùng SurfaceView. Chỉ dùng khi hình bị méo hoặc lệch.</string>
     <string name="hud_mirroring">Chế độ HUD (Lật ngang)</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -870,8 +870,6 @@
     <string name="cannot_open_settings">Could not open system settings</string>
     <string name="static_bssid_enter_value">Enter BSSID (XX:XX:XX:XX:XX:XX)</string>
     <string name="static_bssid_desc">手動設定無線連線的 BSSID。只有在本機沒有任何來源回報時才需要；記錄檔會列出詢問過的每個來源。</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
     <string name="media_key_routing">Send Media Buttons To Android Auto</string>
     <string name="media_key_routing_always">Always</string>
     <string name="media_key_routing_auto">Automatic</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -233,8 +233,11 @@
     <string name="add_new">加入新的</string>
     <string name="cancel">取消</string>
     <string name="enable">啟用</string>
-    <string name="pref_stretch_screen_title">延展以填滿螢幕</string>
-    <string name="pref_stretch_screen_summary">忽略長寬比以填滿整個顯示器（移除黑邊）</string>
+    <string name="video_fit_mode">影像縮放方式</string>
+    <string name="change_video_fit_mode">變更影像縮放方式</string>
+    <string name="video_fit_mode_fill">拉伸填滿 (無黑邊，可能變形)</string>
+    <string name="video_fit_mode_contain">完整顯示 (有黑邊，不裁切不變形)</string>
+    <string name="video_fit_mode_cover">裁切填滿 (無黑邊，不變形)</string>
 
     <!-- Audio Settings -->
     <string name="forced_scale">強制縮放 (舊版修正)</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -33,4 +33,11 @@
         <item>@string/orientation_portrait_reverse</item>
     </string-array>
 
+    <!-- Order must match Settings.VideoFitMode: FILL(0), CONTAIN(1), COVER(2) -->
+    <string-array name="video_fit_mode">
+        <item>@string/video_fit_mode_fill</item>
+        <item>@string/video_fit_mode_contain</item>
+        <item>@string/video_fit_mode_cover</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -495,8 +495,6 @@
     <string name="video_fit_mode_fill">Stretch to fill (no bars, may distort)</string>
     <string name="video_fit_mode_contain">Fit with bars (no crop, no distortion)</string>
     <string name="video_fit_mode_cover">Fill by cropping (no bars, no distortion)</string>
-    <string name="pref_optimize_ultrawide_title" translatable="false">Optimize for Ultrawide displays</string>
-    <string name="pref_optimize_ultrawide_summary" translatable="false">Forces 720p scaling, dynamic aspect ratio, and 1:1 touch overlay mapping for wide screens (1920x720 / 1780x720)</string>
 
     <!-- More Features Settings -->
     <string name="category_more_features" translatable="false">More Features</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -508,8 +508,6 @@
     <string name="forced_scale_description">Corrects scaling issues on some older devices using SurfaceView. Only use if the image looks distorted or shifted.</string>
     <string name="hud_mirroring">HUD Mode (Horizontal Flip)</string>
     <string name="hud_mirroring_description">Flips the display horizontally for windshield reflection (Head-Up Display). Requires TextureView or GLES20 view mode (does not work with SurfaceView).</string>
-    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
-    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
 
 
     <!-- Audio Settings -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -490,8 +490,11 @@
     <string name="add_new">Add new</string>
     <string name="cancel">Cancel</string>
     <string name="enable">Enable</string>
-    <string name="pref_stretch_screen_title">Stretch to fill screen</string>
-    <string name="pref_stretch_screen_summary">Ignores aspect ratio to fill the entire display (removes black bars)</string>
+    <string name="video_fit_mode">Video fit</string>
+    <string name="change_video_fit_mode">Change video fit</string>
+    <string name="video_fit_mode_fill">Stretch to fill (no bars, may distort)</string>
+    <string name="video_fit_mode_contain">Fit with bars (no crop, no distortion)</string>
+    <string name="video_fit_mode_cover">Fill by cropping (no bars, no distortion)</string>
     <string name="pref_optimize_ultrawide_title" translatable="false">Optimize for Ultrawide displays</string>
     <string name="pref_optimize_ultrawide_summary" translatable="false">Forces 720p scaling, dynamic aspect ratio, and 1:1 touch overlay mapping for wide screens (1920x720 / 1780x720)</string>
 

--- a/app/src/test/java/com/andrerinas/openheadunit/input/TouchCoordinateMapperTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/input/TouchCoordinateMapperTest.kt
@@ -25,8 +25,11 @@ class TouchCoordinateMapperTest {
         assertEquals(540, point.y)
     }
 
+    // Android Auto anchors its canvas at the buffer's top-left with the announced margin at the
+    // bottom, measured on hardware from the coordinate it logged receiving. Centring this mapping
+    // instead cost 135 panel px on a 2400x1080 unit and hit the control one rail slot below.
     @Test
-    fun `touch mapping accounts for android auto vertical margin`() {
+    fun `a margined canvas is anchored at the buffer top-left`() {
         val point = TouchCoordinateMapper.map(
             rawX = 1200f,
             rawY = 540f,
@@ -42,6 +45,31 @@ class TouchCoordinateMapperTest {
 
         assertEquals(960, point.x)
         assertEquals(443, point.y)
+    }
+
+    // The panel the ultra-wide work is measured on: a 1280x720 buffer with no margin at all, so
+    // the mapping is the panel scaled straight onto the buffer.
+    @Test
+    fun `an ultra-wide panel maps onto the whole buffer`() {
+        fun at(x: Float, y: Float) = TouchCoordinateMapper.map(
+            rawX = x,
+            rawY = y,
+            inputSurfaceWidth = 1920f,
+            inputSurfaceHeight = 720f,
+            negotiatedWidth = 1280,
+            negotiatedHeight = 720,
+            marginWidth = 0f,
+            marginHeight = 0f,
+            fitMode = Settings.VideoFitMode.FILL,
+            hudMirroring = false
+        )
+
+        assertEquals(0, at(0f, 0f).x)
+        assertEquals(0, at(0f, 0f).y)
+        assertEquals(640, at(960f, 360f).x)
+        assertEquals(360, at(960f, 360f).y)
+        assertEquals(1280, at(1920f, 720f).x)
+        assertEquals(720, at(1920f, 720f).y)
     }
 
     @Test

--- a/app/src/test/java/com/andrerinas/openheadunit/input/TouchCoordinateMapperTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/input/TouchCoordinateMapperTest.kt
@@ -1,5 +1,6 @@
 package com.andrerinas.openheadunit.input
 
+import com.andrerinas.openheadunit.utils.Settings
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -16,7 +17,7 @@ class TouchCoordinateMapperTest {
             negotiatedHeight = 1080,
             marginWidth = 0f,
             marginHeight = 0f,
-            stretchToFill = true,
+            fitMode = Settings.VideoFitMode.FILL,
             hudMirroring = false
         )
 
@@ -35,7 +36,7 @@ class TouchCoordinateMapperTest {
             negotiatedHeight = 1080,
             marginWidth = 0f,
             marginHeight = 194f,
-            stretchToFill = true,
+            fitMode = Settings.VideoFitMode.FILL,
             hudMirroring = false
         )
 
@@ -54,11 +55,55 @@ class TouchCoordinateMapperTest {
             negotiatedHeight = 1080,
             marginWidth = 0f,
             marginHeight = 0f,
-            stretchToFill = true,
+            fitMode = Settings.VideoFitMode.FILL,
             hudMirroring = true
         )
 
         assertEquals(1728, point.x)
         assertEquals(540, point.y)
+    }
+
+    @Test
+    fun `contain mode clamps touches in the letterbox bar to the video edge`() {
+        // Surface is 2560x1080 (wider than the 1920x1080 video); CONTAIN pillarboxes it to
+        // 1920x1080 centered, leaving 320px bars on each side. A touch at the surface's own
+        // top-left corner lands inside the left bar, which should clamp to video x=0.
+        val point = TouchCoordinateMapper.map(
+            rawX = 0f,
+            rawY = 0f,
+            inputSurfaceWidth = 2560f,
+            inputSurfaceHeight = 1080f,
+            negotiatedWidth = 1920,
+            negotiatedHeight = 1080,
+            marginWidth = 0f,
+            marginHeight = 0f,
+            fitMode = Settings.VideoFitMode.CONTAIN,
+            hudMirroring = false
+        )
+
+        assertEquals(0, point.x)
+        assertEquals(0, point.y)
+    }
+
+    @Test
+    fun `cover mode crops instead of bars so the same corner maps into cropped video content`() {
+        // Same 2560x1080 surface and 1920x1080 video as above, but COVER crops instead of
+        // bars: it scales up to 2560x1440 (cropping 180px off the top and bottom), so the
+        // surface's top-left corner is 135 video-pixels below the video's actual top edge.
+        val point = TouchCoordinateMapper.map(
+            rawX = 0f,
+            rawY = 0f,
+            inputSurfaceWidth = 2560f,
+            inputSurfaceHeight = 1080f,
+            negotiatedWidth = 1920,
+            negotiatedHeight = 1080,
+            marginWidth = 0f,
+            marginHeight = 0f,
+            fitMode = Settings.VideoFitMode.COVER,
+            hudMirroring = false
+        )
+
+        assertEquals(0, point.x)
+        assertEquals(135, point.y)
     }
 }

--- a/app/src/test/java/com/andrerinas/openheadunit/input/TouchCoordinateMapperTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/input/TouchCoordinateMapperTest.kt
@@ -47,6 +47,33 @@ class TouchCoordinateMapperTest {
         assertEquals(443, point.y)
     }
 
+    // #809 in Screen mode Normal: the events come from an overlay the ROM sidebar narrowed, while
+    // the screen config still described the display. Dividing by the config figure sent a tap on
+    // the bottom row to the row below the buffer and every tap left of where it landed.
+    @Test
+    fun `the denominator is the surface the events came from`() {
+        fun at(surfaceW: Float, surfaceH: Float) = TouchCoordinateMapper.map(
+            rawX = 1740f,
+            rawY = 715f,
+            inputSurfaceWidth = surfaceW,
+            inputSurfaceHeight = surfaceH,
+            negotiatedWidth = 1280,
+            negotiatedHeight = 720,
+            marginWidth = 0f,
+            marginHeight = 0f,
+            fitMode = Settings.VideoFitMode.FILL,
+            hudMirroring = false
+        )
+
+        val measured = at(1748f, 720f)
+        assertEquals(1274, measured.x)
+        assertEquals(715, measured.y)
+
+        val fromDisplayMetrics = at(1920f, 642f)
+        assertEquals(1160, fromDisplayMetrics.x)
+        assertEquals(720, fromDisplayMetrics.y)
+    }
+
     // The panel the ultra-wide work is measured on: a 1280x720 buffer with no margin at all, so
     // the mapping is the panel scaled straight onto the buffer.
     @Test

--- a/app/src/test/java/com/andrerinas/openheadunit/utils/MarginAnnouncementPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/utils/MarginAnnouncementPolicyTest.kt
@@ -1,0 +1,34 @@
+package com.andrerinas.openheadunit.utils
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Measured on a Moto edge 30 neo whose window insets were still settling: 0x102 went on the wire
+ * from a transient 2237x1080 reading and 0x144 was used for touch a few seconds later.
+ */
+class MarginAnnouncementPolicyTest {
+
+    private val none = MarginAnnouncementPolicy.NOT_ANNOUNCED
+
+    @Test
+    fun `a margin that moved after it was announced is re-announced`() {
+        assertTrue(MarginAnnouncementPolicy.shouldReannounce(0, 102, 0, 144))
+        assertTrue(MarginAnnouncementPolicy.shouldReannounce(480, 360, 0, 360))
+    }
+
+    @Test
+    fun `a margin that did not move is left alone`() {
+        assertFalse(MarginAnnouncementPolicy.shouldReannounce(0, 144, 0, 144))
+        assertFalse(MarginAnnouncementPolicy.shouldReannounce(0, 0, 0, 0))
+    }
+
+    // Every recalculate before the capability message would otherwise look like a drift.
+    @Test
+    fun `nothing announced yet is not a drift`() {
+        assertFalse(MarginAnnouncementPolicy.shouldReannounce(none, none, 0, 144))
+        assertFalse(MarginAnnouncementPolicy.shouldReannounce(none, 144, 0, 144))
+        assertFalse(MarginAnnouncementPolicy.shouldReannounce(0, none, 0, 144))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/utils/MarginStrategyPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/utils/MarginStrategyPolicyTest.kt
@@ -1,0 +1,90 @@
+package com.andrerinas.openheadunit.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The panels are the ones this was measured or reported on: a 1920x720 reporter unit (1780 and
+ * 640 usable with its bars), the 1440x720 rig unit, 2400x1080 rig phones, and a 1024x600 unit.
+ */
+class MarginStrategyPolicyTest {
+
+    private val fill = Settings.VideoFitMode.FILL
+    private val contain = Settings.VideoFitMode.CONTAIN
+    private val cover = Settings.VideoFitMode.COVER
+    private val par = MarginStrategyPolicy.Strategy.PAR
+    private val margin = MarginStrategyPolicy.Strategy.MARGIN
+
+    private fun select(mode: Settings.VideoFitMode, panelW: Int, panelH: Int, videoW: Int, videoH: Int) =
+        MarginStrategyPolicy.select(mode, panelW, panelH, videoW, videoH)
+
+    private fun margins(panelW: Int, panelH: Int, videoW: Int, videoH: Int): Pair<Int, Int> {
+        val sf = ProjectionGeometryPolicy.fit(panelW, panelH, videoW, videoH).scaleFactor
+        return ProjectionGeometryPolicy.widthMargin(videoW, panelW, sf) to
+            ProjectionGeometryPolicy.heightMargin(videoH, panelH, sf)
+    }
+
+    // The stored resolution used to decide this: 720p on the reporter panel was already margin-free
+    // and 1080p hid a third of the frame. Both rungs now describe the panel the same way.
+    @Test
+    fun `fill on a panel wider than its buffer rides on the pixel ratio at any resolution`() {
+        assertEquals(par, select(fill, 1920, 720, 1920, 1080))
+        assertEquals(par, select(fill, 1920, 720, 1280, 720))
+        assertEquals(par, select(fill, 1780, 720, 1280, 720))
+        assertEquals(par, select(fill, 1920, 640, 1920, 1080))
+        assertEquals(par, select(fill, 1440, 720, 1920, 1080))
+        assertEquals(par, select(fill, 2400, 900, 1920, 1080))
+        assertEquals(par, select(fill, 2400, 1080, 1920, 1080))
+    }
+
+    @Test
+    fun `a 16 by 9 panel keeps the margin path and its margin is zero`() {
+        assertEquals(margin, select(fill, 1920, 1080, 1920, 1080))
+        assertEquals(0 to 0, margins(1920, 1080, 1920, 1080))
+        assertEquals(margin, select(fill, 1280, 720, 1280, 720))
+    }
+
+    // Below square the ratio has field evidence only from a phone, so that direction keeps the
+    // margin until a round on such a panel says otherwise.
+    @Test
+    fun `a panel taller than its buffer keeps the margin`() {
+        assertEquals(margin, select(fill, 1024, 600, 1280, 720))
+        assertEquals(margin, select(fill, 1080, 2400, 1080, 1920))
+    }
+
+    @Test
+    fun `contain and cover keep the margin`() {
+        assertEquals(margin, select(contain, 1920, 720, 1920, 1080))
+        assertEquals(margin, select(cover, 1920, 720, 1920, 1080))
+        assertEquals(margin, select(contain, 1920, 720, 1280, 720))
+    }
+
+    // A 1920x480 bar display derives 22500, past what the ratio is allowed to carry.
+    @Test
+    fun `a shape past the clamp keeps the margin`() {
+        assertEquals(margin, select(fill, 1920, 480, 1280, 720))
+        assertEquals(margin, select(fill, 4000, 200, 1280, 720))
+    }
+
+    @Test
+    fun `a degenerate size keeps the margin`() {
+        assertEquals(margin, select(fill, 0, 720, 1280, 720))
+        assertEquals(margin, select(fill, 1920, 0, 1280, 720))
+        assertEquals(margin, select(fill, 1920, 720, 0, 0))
+    }
+
+    // The whole chain at the rung the wizard stores on these panels. With the margin gone every
+    // scale is 1.0, so the buffer, the picture and the touch surface coincide, and the panel's shape
+    // rides on the ratio exactly as it does at 720p.
+    @Test
+    fun `1080p on a wide panel needs no margin and no transform`() {
+        for ((panelW, expectedPar) in listOf(1920 to 15000, 1440 to 11250)) {
+            assertEquals(par, select(fill, panelW, 720, 1920, 1080))
+            assertEquals(1.0f, ProjectionGeometryPolicy.scaleX(fill, false, panelW, 720, 1920, 1080, 0, 0), 0.0001f)
+            assertEquals(1.0f, ProjectionGeometryPolicy.scaleY(fill, false, panelW, 720, 1920, 1080, 0, 0), 0.0001f)
+            assertEquals(expectedPar, ProjectionGeometryPolicy.pixelAspectRatioE4(fill, panelW, 720, 1920, 1080, 0, 0))
+        }
+        assertEquals(12500, ProjectionGeometryPolicy.pixelAspectRatioE4(fill, 2400, 1080, 1920, 1080, 0, 0))
+        assertEquals(16875, ProjectionGeometryPolicy.pixelAspectRatioE4(fill, 1920, 640, 1920, 1080, 0, 0))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/utils/NegotiatedResolutionPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/utils/NegotiatedResolutionPolicyTest.kt
@@ -1,0 +1,114 @@
+package com.andrerinas.openheadunit.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NegotiatedResolutionPolicyTest {
+
+    private fun select(
+        locked: Boolean,
+        selected: Settings.Resolution?,
+        panelW: Int = 1440,
+        panelH: Int = 720,
+        fitMode: Settings.VideoFitMode = Settings.VideoFitMode.FILL,
+        hevc: Boolean = true,
+        canHevcHighRes: Boolean = true,
+        sdkInt: Int = 30
+    ) = NegotiatedResolutionPolicy.select(locked, selected, panelW, panelH, fitMode, hevc, canHevcHighRes, sdkInt)
+
+    // The bug: a locked session fell through to the manual branch, where AUTO has no codec and the
+    // fallback is 480p, so it silently downgraded itself mid-drive.
+    @Test
+    fun `a locked session is never renegotiated`() {
+        assertNull(select(locked = true, selected = Settings.Resolution.AUTO))
+        assertNull(select(locked = true, selected = Settings.Resolution._1280x720))
+        assertNull(select(locked = true, selected = null))
+    }
+
+    @Test
+    fun `an unlocked manual choice is taken as given`() {
+        assertEquals(Settings.Resolution._1920x1080, select(false, Settings.Resolution._1920x1080))
+        assertEquals(Settings.Resolution._800x480, select(false, Settings.Resolution._800x480))
+    }
+
+    // A corrupt resolutionId reads back as null. That used to mean 480p; it now means AUTO.
+    @Test
+    fun `an unreadable stored resolution falls into the AUTO ladder`() {
+        assertEquals(Settings.Resolution._1280x720, select(false, null, panelW = 1440, panelH = 720))
+    }
+
+    @Test
+    fun `the AUTO ladder picks by the panel's short side`() {
+        assertEquals(Settings.Resolution._800x480, select(false, Settings.Resolution.AUTO, 800, 480))
+        assertEquals(Settings.Resolution._1280x720, select(false, Settings.Resolution.AUTO, 1280, 720))
+        assertEquals(Settings.Resolution._1920x1080, select(false, Settings.Resolution.AUTO, 1920, 1080))
+        assertEquals(Settings.Resolution._2560x1440, select(false, Settings.Resolution.AUTO, 2560, 1440))
+        assertEquals(Settings.Resolution._3840x2160, select(false, Settings.Resolution.AUTO, 3840, 2160))
+    }
+
+    // Asking a 720-row panel for 1080 rows only buys a height margin that hides them again, and
+    // the margin is what cancelled the pixel aspect ratio back to square. These are the panels the
+    // short-side rule changes, and every one of them is wider than 16:9.
+    @Test
+    fun `an ultra-wide panel is asked for the rows it actually has`() {
+        assertEquals(Settings.Resolution._1280x720, select(false, Settings.Resolution.AUTO, 1920, 720))
+        assertEquals(Settings.Resolution._1280x720, select(false, Settings.Resolution.AUTO, 1780, 720))
+        assertEquals(Settings.Resolution._1280x720, select(false, Settings.Resolution.AUTO, 1440, 720))
+        assertEquals(Settings.Resolution._1280x720, select(false, Settings.Resolution.AUTO, 2560, 720))
+        assertEquals(Settings.Resolution._1920x1080, select(false, Settings.Resolution.AUTO, 2560, 1080))
+    }
+
+    // CONTAIN and COVER announce square pixels, so the width has to come from the buffer: on a
+    // 1920x720 panel 720p is a 1280-wide picture between pillars, and 1080p with a height margin
+    // fills the width at 1:1, which is what every release before the short-side rule negotiated.
+    @Test
+    fun `without the pixel aspect ratio a wide panel needs the columns again`() {
+        for (mode in listOf(Settings.VideoFitMode.CONTAIN, Settings.VideoFitMode.COVER)) {
+            assertEquals(Settings.Resolution._1920x1080, select(false, Settings.Resolution.AUTO, 1920, 720, mode))
+            assertEquals(Settings.Resolution._1920x1080, select(false, Settings.Resolution.AUTO, 1440, 720, mode))
+            assertEquals(Settings.Resolution._1920x1080, select(false, Settings.Resolution.AUTO, 1780, 720, mode))
+            assertEquals(Settings.Resolution._1280x720, select(false, Settings.Resolution.AUTO, 1280, 720, mode))
+            assertEquals(Settings.Resolution._1280x720, select(false, Settings.Resolution.AUTO, 1024, 600, mode))
+            assertEquals(Settings.Resolution._800x480, select(false, Settings.Resolution.AUTO, 800, 480, mode))
+            assertEquals(Settings.Resolution._1920x1080, select(false, Settings.Resolution.AUTO, 1920, 1080, mode))
+            assertEquals(Settings.Resolution._2560x1440, select(false, Settings.Resolution.AUTO, 2560, 1440, mode))
+        }
+    }
+
+    // The regression net for everyone who is fine today: a panel whose rows already match a rung
+    // is asked for exactly what it was asked for before.
+    @Test
+    fun `a panel that matches a rung is left alone`() {
+        assertEquals(Settings.Resolution._800x480, select(false, Settings.Resolution.AUTO, 800, 480))
+        assertEquals(Settings.Resolution._1280x720, select(false, Settings.Resolution.AUTO, 1024, 600))
+        assertEquals(Settings.Resolution._1280x720, select(false, Settings.Resolution.AUTO, 1280, 480))
+        assertEquals(Settings.Resolution._1920x1080, select(false, Settings.Resolution.AUTO, 2400, 1080))
+        assertEquals(Settings.Resolution._1920x1080, select(false, Settings.Resolution.AUTO, 1280, 800))
+    }
+
+    @Test
+    fun `the high resolutions need both HEVC and a new enough platform`() {
+        assertEquals(
+            Settings.Resolution._1920x1080,
+            select(false, Settings.Resolution.AUTO, 2560, 1440, canHevcHighRes = false)
+        )
+        assertEquals(
+            Settings.Resolution._1920x1080,
+            select(false, Settings.Resolution.AUTO, 3840, 2160, hevc = false, canHevcHighRes = false)
+        )
+        assertEquals(
+            Settings.Resolution._1920x1080,
+            select(false, Settings.Resolution.AUTO, 2560, 1440, sdkInt = 23)
+        )
+    }
+
+    // The short-side rule is orientation-agnostic, so portrait needs no branch of its own:
+    // HeadUnitScreenConfig.protoForResolution transposes whichever rung comes back.
+    @Test
+    fun `a portrait panel lands on the same rung as its landscape twin`() {
+        assertEquals(Settings.Resolution._1280x720, select(false, Settings.Resolution.AUTO, 720, 1280))
+        assertEquals(Settings.Resolution._1920x1080, select(false, Settings.Resolution.AUTO, 1080, 1920))
+        assertEquals(Settings.Resolution._1920x1080, select(false, Settings.Resolution.AUTO, 1200, 2000))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/utils/ProjectionCanvasPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/utils/ProjectionCanvasPolicyTest.kt
@@ -1,0 +1,140 @@
+package com.andrerinas.openheadunit.utils
+
+import com.andrerinas.openheadunit.utils.ProjectionCanvasPolicy.Measurement
+import com.andrerinas.openheadunit.utils.ProjectionCanvasPolicy.Source
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProjectionCanvasPolicyTest {
+
+    private val hash = 4711
+
+    private fun choose(
+        immersive: Boolean = false,
+        surface: Measurement? = null,
+        window: Measurement? = null,
+        cached: Measurement? = null,
+        hash: Int = this.hash,
+    ) = ProjectionCanvasPolicy.choose(
+        immersive = immersive,
+        realW = 1920, realH = 720,
+        usableW = 1920, usableH = 642,
+        surface = surface, window = window, cached = cached, hash = hash,
+    )
+
+    @Test
+    fun `nothing measured yet reads the panel in immersive`() {
+        val choice = choose(immersive = true)
+        assertEquals(1920, choice.width)
+        assertEquals(720, choice.height)
+        assertEquals(Source.DISPLAY, choice.source)
+    }
+
+    @Test
+    fun `nothing measured yet reads the window metrics outside immersive`() {
+        val choice = choose(immersive = false)
+        assertEquals(1920, choice.width)
+        assertEquals(642, choice.height)
+        assertEquals(Source.DISPLAY, choice.source)
+    }
+
+    // #809's unit: getSize() reports 1920x642 for a window a ROM sidebar has narrowed to 1748x720,
+    // so the display reading describes neither the panel nor the canvas the video is drawn into.
+    @Test
+    fun `a measured surface outranks the display metrics`() {
+        val choice = choose(surface = Measurement(1748, 720, hash))
+        assertEquals(1748, choice.width)
+        assertEquals(720, choice.height)
+        assertEquals(Source.SURFACE, choice.source)
+    }
+
+    @Test
+    fun `a live window outranks a stored surface`() {
+        val choice = choose(window = Measurement(1748, 720, hash), cached = Measurement(1600, 700, hash))
+        assertEquals(1748, choice.width)
+        assertEquals(Source.WINDOW, choice.source)
+    }
+
+    @Test
+    fun `the projection surface outranks the window it is inside`() {
+        val choice = choose(surface = Measurement(1748, 720, hash), window = Measurement(1920, 720, hash))
+        assertEquals(1748, choice.width)
+        assertEquals(Source.SURFACE, choice.source)
+    }
+
+    @Test
+    fun `a cached surface is used when nothing has been measured this session`() {
+        val choice = choose(cached = Measurement(1748, 720, hash))
+        assertEquals(1748, choice.width)
+        assertEquals(Source.CACHE, choice.source)
+    }
+
+    // Changing the screen mode changes the hash, and every reading described the old window.
+    @Test
+    fun `a measurement taken under other settings is ignored`() {
+        val stale = Measurement(1920, 720, hash + 1)
+        val choice = choose(surface = stale, window = stale, cached = stale)
+        assertEquals(1920, choice.width)
+        assertEquals(642, choice.height)
+        assertEquals(Source.DISPLAY, choice.source)
+    }
+
+    @Test
+    fun `an empty measurement is not a measurement`() {
+        val choice = choose(surface = Measurement(0, 0, hash), immersive = true)
+        assertEquals(720, choice.height)
+        assertEquals(Source.DISPLAY, choice.source)
+    }
+
+    // Measured in Screen mode STATUS_ONLY on a 1440x720 panel with a 136 px OEM bar: the window was
+    // measured before the bar arrived, the anchor was left at 1304, and the bar was then taken off
+    // it again, so 1168 was the canvas the pixel shape would have been derived from.
+    @Test
+    fun `a bar that arrives after the canvas was measured does not shrink it twice`() {
+        val anchor = ProjectionCanvasPolicy.anchor(1304, 720, 136, 0)
+        assertEquals(1440, anchor.width)
+        assertEquals(720, anchor.height)
+
+        val canvas = ProjectionCanvasPolicy.canvas(anchor.width, anchor.height, 136, 0)
+        assertEquals(1304, canvas.width)
+        assertEquals(720, canvas.height)
+    }
+
+    @Test
+    fun `the canvas inside an anchor is the canvas the anchor was built from`() {
+        for (insetW in intArrayOf(0, 1, 136, 480)) {
+            for (insetH in intArrayOf(0, 1, 216)) {
+                val anchor = ProjectionCanvasPolicy.anchor(1280, 720, insetW, insetH)
+                val canvas = ProjectionCanvasPolicy.canvas(anchor.width, anchor.height, insetW, insetH)
+                assertEquals(1280, canvas.width)
+                assertEquals(720, canvas.height)
+            }
+        }
+    }
+
+    @Test
+    fun `insets that would empty the canvas are ignored rather than obeyed`() {
+        val canvas = ProjectionCanvasPolicy.canvas(1280, 720, 1280, 0)
+        assertEquals(1280, canvas.width)
+        assertEquals(720, canvas.height)
+    }
+
+    // The panel reading this is checked against is the one that moved 2400x1080 -> 2237x1080 ->
+    // 2300x1017 mid-connect, so an exact test would reject the very cache it is meant to protect.
+    @Test
+    fun `a stored canvas survives a panel reading that wobbled`() {
+        assertTrue(ProjectionCanvasPolicy.fitsPanel(2400, 1080, 2237, 1080))
+    }
+
+    @Test
+    fun `a stored canvas from a bigger panel is not this panel's canvas`() {
+        assertFalse(ProjectionCanvasPolicy.fitsPanel(2400, 1080, 1024, 600))
+    }
+
+    @Test
+    fun `nothing is known about the panel yet, so nothing is rejected`() {
+        assertTrue(ProjectionCanvasPolicy.fitsPanel(2400, 1080, 0, 0))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/utils/ProjectionGeometryPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/utils/ProjectionGeometryPolicyTest.kt
@@ -1,0 +1,199 @@
+package com.andrerinas.openheadunit.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Fixtures are the two panels this was measured on: a 1440x720 rig unit and a 1920x720 reporter
+ * unit, plus the 1780x720 usable area the same unit reports with its sidebar showing.
+ */
+class ProjectionGeometryPolicyTest {
+
+    private val fill = Settings.VideoFitMode.FILL
+    private val contain = Settings.VideoFitMode.CONTAIN
+    private val cover = Settings.VideoFitMode.COVER
+
+    private fun scaleY(
+        mode: Settings.VideoFitMode,
+        panelW: Int,
+        panelH: Int,
+        videoW: Int,
+        videoH: Int,
+        marginW: Int = 0,
+        marginH: Int = 0
+    ) = ProjectionGeometryPolicy.scaleY(mode, false, panelW, panelH, videoW, videoH, marginW, marginH)
+
+    private fun scaleX(
+        mode: Settings.VideoFitMode,
+        panelW: Int,
+        panelH: Int,
+        videoW: Int,
+        videoH: Int,
+        marginW: Int = 0,
+        marginH: Int = 0
+    ) = ProjectionGeometryPolicy.scaleX(mode, false, panelW, panelH, videoW, videoH, marginW, marginH)
+
+    /** The margins a panel/video pair actually produces, so no fixture invents its own. */
+    private fun margins(panelW: Int, panelH: Int, videoW: Int, videoH: Int): Pair<Int, Int> {
+        val sf = ProjectionGeometryPolicy.fit(panelW, panelH, videoW, videoH).scaleFactor
+        return ProjectionGeometryPolicy.widthMargin(videoW, panelW, sf) to
+            ProjectionGeometryPolicy.heightMargin(videoH, panelH, sf)
+    }
+
+    // The regression. Before the fit modes, getScaleY() fell through to panel aspect over video
+    // aspect whenever the negotiated height already fit, blowing the picture up and cropping it.
+    @Test
+    fun `720p on an ultra-wide panel is not stretched vertically`() {
+        assertEquals(1.0f, scaleY(fill, 1920, 720, 1280, 720), 0.0001f)
+        assertEquals(1.0f, scaleY(fill, 1440, 720, 1280, 720), 0.0001f)
+        assertEquals(1.0f, scaleY(fill, 1780, 720, 1280, 720), 0.0001f)
+        assertEquals(1.0f, scaleX(fill, 1920, 720, 1280, 720), 0.0001f)
+    }
+
+    @Test
+    fun `a 16 by 9 panel at its own resolution is untouched`() {
+        assertEquals(1.0f, scaleY(fill, 1920, 1080, 1920, 1080), 0.0001f)
+        assertEquals(1.0f, scaleX(fill, 1920, 1080, 1920, 1080), 0.0001f)
+        assertEquals(0, ProjectionGeometryPolicy.heightMargin(1080, 1080, 1.0f))
+        assertEquals(0, ProjectionGeometryPolicy.widthMargin(1920, 1920, 1.0f))
+    }
+
+    // 1080p into a 1440x720 panel is the case that already worked: the margin mechanism describes
+    // the usable canvas inside the bigger buffer, and both axes still scale up to reach it.
+    @Test
+    fun `1080p on the rig panel keeps its margins and its scale`() {
+        assertEquals(480, ProjectionGeometryPolicy.widthMargin(1920, 1440, 1.0f))
+        assertEquals(360, ProjectionGeometryPolicy.heightMargin(1080, 720, 1.0f))
+        assertEquals(1.3333f, scaleX(fill, 1440, 720, 1920, 1080, 480, 360), 0.0001f)
+        assertEquals(1.5f, scaleY(fill, 1440, 720, 1920, 1080, 480, 360), 0.0001f)
+    }
+
+    // A panel wider than 1920 leaves the small-screen bucket, so fit() scales the buffer up to the
+    // panel width and the leftover height becomes a margin. Returning 1.0f there deleted the crop
+    // that makes that margin true and squashed the picture by a fifth. Measured on two 2400x1080
+    // phones: 0x144 at 720p and 0x216 at 1080p.
+    @Test
+    fun `a panel wider than 1920 crops the margin instead of showing it`() {
+        assertEquals(0 to 144, margins(2400, 1080, 1280, 720))
+        assertEquals(1.0f, scaleX(fill, 2400, 1080, 1280, 720, 0, 144), 0.0001f)
+        assertEquals(1.25f, scaleY(fill, 2400, 1080, 1280, 720, 0, 144), 0.0001f)
+
+        assertEquals(0 to 216, margins(2400, 1080, 1920, 1080))
+        assertEquals(1.0f, scaleX(fill, 2400, 1080, 1920, 1080, 0, 216), 0.0001f)
+        assertEquals(1.25f, scaleY(fill, 2400, 1080, 1920, 1080, 0, 216), 0.0001f)
+    }
+
+    // The whole rule, on every panel measured. A margin of zero is the only case that leaves the
+    // buffer alone, which is why the ultra-wide 720p fix and this crop are the same expression.
+    @Test
+    fun `the fill scale is always the buffer over the visible canvas`() {
+        val cases = listOf(
+            intArrayOf(1440, 720, 1280, 720),
+            intArrayOf(1920, 720, 1280, 720),
+            intArrayOf(1440, 720, 1920, 1080),
+            intArrayOf(2400, 1080, 1280, 720),
+            intArrayOf(2400, 1080, 1920, 1080),
+            intArrayOf(1200, 2000, 1280, 720)
+        )
+        for (c in cases) {
+            val (panelW, panelH, videoW, videoH) = listOf(c[0], c[1], c[2], c[3])
+            val (mW, mH) = margins(panelW, panelH, videoW, videoH)
+            val label = "${panelW}x$panelH <- ${videoW}x$videoH"
+            assertEquals(
+                label, videoW.toFloat() / (videoW - mW), scaleX(fill, panelW, panelH, videoW, videoH, mW, mH), 0.0001f
+            )
+            assertEquals(
+                label, videoH.toFloat() / (videoH - mH), scaleY(fill, panelW, panelH, videoW, videoH, mW, mH), 0.0001f
+            )
+        }
+    }
+
+    // The portrait fit branch used to have its own arm. Substituting the margin reproduces it,
+    // which is the evidence the one expression is the rule the file was written against.
+    @Test
+    fun `a portrait panel showing a landscape buffer is unchanged`() {
+        val (mW, mH) = margins(1200, 2000, 1280, 720)
+        assertEquals(848 to 0, mW to mH)
+        assertEquals(2.963f, scaleX(fill, 1200, 2000, 1280, 720, mW, mH), 0.001f)
+        assertEquals(1.0f, scaleY(fill, 1200, 2000, 1280, 720, mW, mH), 0.0001f)
+    }
+
+    @Test
+    fun `1080p on the reporter panel is pillarbox-free and letterboxed`() {
+        assertEquals(0, ProjectionGeometryPolicy.widthMargin(1920, 1920, 1.0f))
+        assertEquals(360, ProjectionGeometryPolicy.heightMargin(1080, 720, 1.0f))
+    }
+
+    @Test
+    fun `contain shrinks the wider axis and leaves the other alone`() {
+        // min(1440/1280, 720/720) = 1.0, so only the x axis comes back below 1: a pillarbox.
+        assertEquals(0.8889f, scaleX(contain, 1440, 720, 1280, 720), 0.0001f)
+        assertEquals(1.0f, scaleY(contain, 1440, 720, 1280, 720), 0.0001f)
+    }
+
+    @Test
+    fun `cover fills the wider axis and crops the other`() {
+        // max(1440/1280, 720/720) = 1.125, so x reaches exactly 1 and y overshoots and is cropped.
+        assertEquals(1.0f, scaleX(cover, 1440, 720, 1280, 720), 0.0001f)
+        assertEquals(1.125f, scaleY(cover, 1440, 720, 1280, 720), 0.0001f)
+    }
+
+    @Test
+    fun `cover never downscales a video that already has the pixels`() {
+        assertEquals(1.0f, ProjectionGeometryPolicy.coverScaleFactor(1440, 720, 1920, 1080), 0.0001f)
+        assertEquals(1920, ProjectionGeometryPolicy.coverWidth(1440, 720, 1920, 1080))
+        assertEquals(1080, ProjectionGeometryPolicy.coverHeight(1440, 720, 1920, 1080))
+    }
+
+    // A margin that already shapes the canvas to the panel leaves nothing to letterbox or crop, so
+    // both modes collapse onto FILL. TouchCoordinateMapper reaches the same verdict from the same
+    // canvas, which is what keeps a tap in a bar it can no longer be in.
+    @Test
+    fun `contain and cover measure the canvas, not the buffer`() {
+        for (mode in listOf(contain, cover)) {
+            assertEquals(1.0f, scaleX(mode, 2400, 1080, 1280, 720, 0, 144), 0.0001f)
+            assertEquals(1.25f, scaleY(mode, 2400, 1080, 1280, 720, 0, 144), 0.0001f)
+        }
+    }
+
+    @Test
+    fun `the legacy forcedScale path scales neither axis`() {
+        for (mode in Settings.VideoFitMode.values()) {
+            assertEquals(1.0f, ProjectionGeometryPolicy.scaleX(mode, true, 1920, 720, 1280, 720, 0, 0), 0.0001f)
+            assertEquals(1.0f, ProjectionGeometryPolicy.scaleY(mode, true, 1920, 720, 1280, 720, 0, 0), 0.0001f)
+        }
+    }
+
+    @Test
+    fun `both real panels count as small so nothing rescales the buffer`() {
+        assertFalse(ProjectionGeometryPolicy.isSmallScreen(2400, 1080))
+        assertTrue(ProjectionGeometryPolicy.isSmallScreen(1440, 720))
+        assertTrue(ProjectionGeometryPolicy.isSmallScreen(1920, 720))
+        assertTrue(ProjectionGeometryPolicy.isSmallScreen(1920, 1080))
+        assertFalse(ProjectionGeometryPolicy.isSmallScreen(2560, 1440))
+    }
+
+    // A small screen leaves isPortraitScaled untouched rather than recomputing it, which is why the
+    // policy reports null instead of a value the caller would latch.
+    @Test
+    fun `a small screen reports no portrait-scaled verdict`() {
+        val small = ProjectionGeometryPolicy.fit(1440, 720, 1280, 720)
+        assertEquals(1.0f, small.scaleFactor, 0.0001f)
+        assertTrue(small.isSmallScreen)
+        assertNull(small.isPortraitScaled)
+
+        val large = ProjectionGeometryPolicy.fit(2560, 1440, 1920, 1080)
+        assertEquals(1.3333f, large.scaleFactor, 0.0001f)
+        assertFalse(large.isSmallScreen)
+        assertEquals(false, large.isPortraitScaled)
+    }
+
+    @Test
+    fun `a degenerate size never divides by zero`() {
+        assertEquals(1.0f, ProjectionGeometryPolicy.fit(1440, 720, 0, 0).scaleFactor, 0.0001f)
+        assertEquals(0, ProjectionGeometryPolicy.widthMargin(1280, 1440, 0.0f))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/utils/ProjectionGeometryPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/utils/ProjectionGeometryPolicyTest.kt
@@ -196,4 +196,73 @@ class ProjectionGeometryPolicyTest {
         assertEquals(1.0f, ProjectionGeometryPolicy.fit(1440, 720, 0, 0).scaleFactor, 0.0001f)
         assertEquals(0, ProjectionGeometryPolicy.widthMargin(1280, 1440, 0.0f))
     }
+
+    // Telling the phone the pixels are not square is the only lever a non-16:9 panel has, because
+    // the proto offers no non-16:9 resolution to ask for. Measured on a 1440x720 panel: the derived
+    // 11250 drew Android Auto's chrome circles 60x60 px, square 10001 drew them 67x60. What is left
+    // on the panel is derived/announced, so the derived value is the one that cancels.
+    @Test
+    fun `a wide panel at 720p advertises its real pixel shape`() {
+        assertEquals(15000, ProjectionGeometryPolicy.pixelAspectRatioE4(fill, 1920, 720, 1280, 720, 0, 0))
+        assertEquals(11250, ProjectionGeometryPolicy.pixelAspectRatioE4(fill, 1440, 720, 1280, 720, 0, 0))
+        assertEquals(13906, ProjectionGeometryPolicy.pixelAspectRatioE4(fill, 1780, 720, 1280, 720, 0, 0))
+    }
+
+    @Test
+    fun `a 16 by 9 panel stays square`() {
+        assertEquals(10000, ProjectionGeometryPolicy.pixelAspectRatioE4(fill, 1920, 1080, 1920, 1080, 0, 0))
+    }
+
+    // The margins already describe a correctly shaped canvas inside the bigger buffer, so measuring
+    // against the raw negotiated size would correct a second time and skew the case that works.
+    @Test
+    fun `a margined canvas is already square and is left alone`() {
+        assertEquals(10000, ProjectionGeometryPolicy.pixelAspectRatioE4(fill, 1440, 720, 1920, 1080, 480, 360))
+        assertEquals(10000, ProjectionGeometryPolicy.pixelAspectRatioE4(fill, 1920, 720, 1920, 1080, 0, 360))
+    }
+
+    // The whole chain on the panel this was reported from, with the resolution the short-side
+    // ladder now picks for it. Every scale is 1.0 and there is no margin, so the buffer, the
+    // picture and the touch surface all coincide, and the panel's shape rides on the pixel ratio.
+    @Test
+    fun `an ultra-wide panel needs no margin and no transform`() {
+        for ((panelW, expectedPar) in listOf(1920 to 15000, 1780 to 13906)) {
+            assertEquals(0 to 0, margins(panelW, 720, 1280, 720))
+            assertEquals(1.0f, scaleX(fill, panelW, 720, 1280, 720), 0.0001f)
+            assertEquals(1.0f, scaleY(fill, panelW, 720, 1280, 720), 0.0001f)
+            assertEquals(
+                expectedPar,
+                ProjectionGeometryPolicy.pixelAspectRatioE4(fill, panelW, 720, 1280, 720, 0, 0)
+            )
+        }
+    }
+
+    // An impossible panel reading is a bad measurement, not a panel. Say square rather than put a
+    // number on the wire that no phone can lay a UI out for.
+    @Test
+    fun `an impossible panel cannot put nonsense on the wire`() {
+        assertEquals(10000, ProjectionGeometryPolicy.pixelAspectRatioE4(fill, 4000, 200, 1280, 720, 0, 0))
+        assertEquals(10000, ProjectionGeometryPolicy.pixelAspectRatioE4(fill, 200, 4000, 1280, 720, 0, 0))
+    }
+
+    @Test
+    fun `a near-square panel is not worth correcting`() {
+        // 1940x1080 derives 10104, which is 1 percent off square and inside the tolerance.
+        assertEquals(10000, ProjectionGeometryPolicy.pixelAspectRatioE4(fill, 1940, 1080, 1920, 1080, 0, 0))
+    }
+
+    // The correction and the two aspect-preserving modes are alternatives, not layers: announcing
+    // 11250 and then pillarboxing with square pixels squeezes the phone's UI by the correction.
+    @Test
+    fun `only fill claims the pixels are not square`() {
+        assertEquals(10000, ProjectionGeometryPolicy.pixelAspectRatioE4(contain, 1920, 720, 1280, 720, 0, 0))
+        assertEquals(10000, ProjectionGeometryPolicy.pixelAspectRatioE4(cover, 1920, 720, 1280, 720, 0, 0))
+        assertEquals(15000, ProjectionGeometryPolicy.pixelAspectRatioE4(fill, 1920, 720, 1280, 720, 0, 0))
+    }
+
+    @Test
+    fun `a degenerate canvas reports square pixels`() {
+        assertEquals(10000, ProjectionGeometryPolicy.pixelAspectRatioE4(fill, 1920, 720, 1280, 720, 1280, 0))
+        assertEquals(10000, ProjectionGeometryPolicy.pixelAspectRatioE4(fill, 0, 0, 1280, 720, 0, 0))
+    }
 }

--- a/app/src/test/java/com/andrerinas/openheadunit/utils/ScreenOrientationPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/utils/ScreenOrientationPolicyTest.kt
@@ -1,0 +1,78 @@
+package com.andrerinas.openheadunit.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ScreenOrientationPolicyTest {
+
+    private fun normalisation(
+        setting: Settings.ScreenOrientation,
+        landscape: Boolean = false,
+        portrait: Boolean = false,
+    ) = ScreenOrientationPolicy.normalisation(setting, landscape, portrait)
+
+    @Test
+    fun `an explicit orientation ignores what the configuration says`() {
+        assertEquals(
+            ScreenOrientationPolicy.Normalisation.LANDSCAPE,
+            normalisation(Settings.ScreenOrientation.LANDSCAPE, portrait = true)
+        )
+        assertEquals(
+            ScreenOrientationPolicy.Normalisation.PORTRAIT,
+            normalisation(Settings.ScreenOrientation.PORTRAIT, landscape = true)
+        )
+    }
+
+    @Test
+    fun `a reversed orientation normalises like its forward twin`() {
+        assertEquals(
+            normalisation(Settings.ScreenOrientation.LANDSCAPE),
+            normalisation(Settings.ScreenOrientation.LANDSCAPE_REVERSE)
+        )
+        assertEquals(
+            normalisation(Settings.ScreenOrientation.PORTRAIT),
+            normalisation(Settings.ScreenOrientation.PORTRAIT_REVERSE)
+        )
+    }
+
+    // The rig runs AUTO/SYSTEM, and the surface path used to omit this fallback entirely: it took
+    // the four explicit settings only, so on the rig every surface reading was left as it came.
+    @Test
+    fun `auto and system take the orientation the configuration is in`() {
+        assertEquals(
+            ScreenOrientationPolicy.Normalisation.LANDSCAPE,
+            normalisation(Settings.ScreenOrientation.AUTO, landscape = true)
+        )
+        assertEquals(
+            ScreenOrientationPolicy.Normalisation.PORTRAIT,
+            normalisation(Settings.ScreenOrientation.SYSTEM, portrait = true)
+        )
+    }
+
+    @Test
+    fun `a configuration in neither orientation leaves the reading alone`() {
+        assertEquals(
+            ScreenOrientationPolicy.Normalisation.AS_READ,
+            normalisation(Settings.ScreenOrientation.AUTO)
+        )
+        val read = ScreenOrientationPolicy.normalise(1080, 2400, ScreenOrientationPolicy.Normalisation.AS_READ)
+        assertEquals(1080, read.width)
+        assertEquals(2400, read.height)
+    }
+
+    // Measured: a 2400x1080 phone reported its window content as the portrait 1080x2400 for 61 ms
+    // and the head unit announced a portrait resolution from it.
+    @Test
+    fun `a portrait window reading becomes the landscape canvas`() {
+        val turned = ScreenOrientationPolicy.normalise(1080, 2400, ScreenOrientationPolicy.Normalisation.LANDSCAPE)
+        assertEquals(2400, turned.width)
+        assertEquals(1080, turned.height)
+    }
+
+    @Test
+    fun `a reading already the right way up is left as it is`() {
+        val turned = ScreenOrientationPolicy.normalise(1440, 720, ScreenOrientationPolicy.Normalisation.LANDSCAPE)
+        assertEquals(1440, turned.width)
+        assertEquals(720, turned.height)
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/utils/ScreenSettingsHashTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/utils/ScreenSettingsHashTest.kt
@@ -1,0 +1,72 @@
+package com.andrerinas.openheadunit.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class ScreenSettingsHashTest {
+
+    private fun hash(
+        resolutionId: Int = 2,
+        dpiPixelDensity: Int = 240,
+        pixelAspectRatioE4: Int = 10000,
+        insetLeft: Int = 0,
+        insetTop: Int = 0,
+        insetRight: Int = 0,
+        insetBottom: Int = 0,
+        viewMode: Int = 0,
+        screenOrientation: Int = 0,
+        fullscreenMode: Int = 0,
+        videoFitMode: Int = 0,
+        forcedScale: Boolean = false,
+        normalisation: ScreenOrientationPolicy.Normalisation = ScreenOrientationPolicy.Normalisation.LANDSCAPE,
+    ) = ScreenSettingsHash.of(
+        resolutionId, dpiPixelDensity, pixelAspectRatioE4,
+        insetLeft, insetTop, insetRight, insetBottom,
+        viewMode, screenOrientation, fullscreenMode, videoFitMode, forcedScale, normalisation,
+    )
+
+    @Test
+    fun `the same settings hash the same way`() {
+        assertEquals(hash(), hash())
+    }
+
+    // The question a hardware round could not settle: applying a screen-mode change on the rig needs
+    // a force-stop, which restarts the session by definition. The mode has to invalidate a reading.
+    @Test
+    fun `a screen mode change drops every measurement taken in the old one`() {
+        assertNotEquals(hash(fullscreenMode = 0), hash(fullscreenMode = 1))
+        assertNotEquals(hash(fullscreenMode = 2), hash(fullscreenMode = 3))
+    }
+
+    @Test
+    fun `every setting the canvas depends on moves the hash`() {
+        val base = hash()
+        assertNotEquals(base, hash(resolutionId = 3))
+        assertNotEquals(base, hash(dpiPixelDensity = 213))
+        assertNotEquals(base, hash(pixelAspectRatioE4 = 11250))
+        assertNotEquals(base, hash(insetLeft = 1))
+        assertNotEquals(base, hash(insetTop = 1))
+        assertNotEquals(base, hash(insetRight = 1))
+        assertNotEquals(base, hash(insetBottom = 1))
+        assertNotEquals(base, hash(viewMode = 1))
+        assertNotEquals(base, hash(screenOrientation = 1))
+        assertNotEquals(base, hash(videoFitMode = 1))
+        assertNotEquals(base, hash(forcedScale = true))
+    }
+
+    // Under AUTO and SYSTEM a rotation does not move the orientation setting, so this term is what
+    // invalidates a landscape measurement after the panel turns.
+    @Test
+    fun `a rotation still invalidates a measurement`() {
+        assertNotEquals(
+            hash(normalisation = ScreenOrientationPolicy.Normalisation.LANDSCAPE),
+            hash(normalisation = ScreenOrientationPolicy.Normalisation.PORTRAIT)
+        )
+    }
+
+    @Test
+    fun `two settings exchanged are not the same settings`() {
+        assertNotEquals(hash(insetLeft = 5, insetTop = 9), hash(insetLeft = 9, insetTop = 5))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/utils/SystemOptimizerCeilingTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/utils/SystemOptimizerCeilingTest.kt
@@ -1,0 +1,71 @@
+package com.andrerinas.openheadunit.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The recommendation and the hard cap are different questions, and conflating them silently
+ * overrode a resolution the user had picked through the settings dialog's "Use anyway".
+ */
+class SystemOptimizerCeilingTest {
+
+    private fun recommended(w: Int, h: Int) = SystemOptimizer.panelCeiling(w, h, canHevc = false)
+    private fun hard(w: Int, h: Int) = SystemOptimizer.hardCeiling(w, h, canHevc = false)
+
+    // The reported panel. AUTO should ask for 720p and let the pixel ratio carry the width, but a
+    // 1920-wide buffer is fully used here: every column lands on a column, only rows are hidden.
+    @Test
+    fun `an ultra-wide panel is recommended 720p and still allowed 1080p`() {
+        assertEquals(Settings.Resolution._1280x720, recommended(1920, 720))
+        assertEquals(Settings.Resolution._1920x1080, hard(1920, 720))
+    }
+
+    @Test
+    fun `the rig panel and the other reported 720-row panels behave the same way`() {
+        for ((w, h) in listOf(1440 to 720, 1780 to 720)) {
+            assertEquals(Settings.Resolution._1280x720, recommended(w, h))
+            assertEquals(Settings.Resolution._1920x1080, hard(w, h))
+        }
+    }
+
+    // A wide panel with more than 720 rows is not in the margin-free class at all: the ladder
+    // already asks for 1080p, so the recommendation and the cap have nothing to disagree about.
+    @Test
+    fun `a wide panel with more than 720 rows was never capped`() {
+        assertEquals(Settings.Resolution._1920x1080, recommended(2400, 900))
+        assertEquals(Settings.Resolution._1920x1080, hard(2400, 900))
+    }
+
+    // The panel issue #650 is about. Both answers stay 720p, so the per-frame downscale that
+    // stalls the MediaTek scaler is still refused however the resolution was chosen.
+    @Test
+    fun `a genuinely small panel is capped by both`() {
+        assertEquals(Settings.Resolution._1280x720, recommended(1024, 600))
+        assertEquals(Settings.Resolution._1280x720, hard(1024, 600))
+        assertEquals(Settings.Resolution._800x480, recommended(800, 480))
+        assertEquals(Settings.Resolution._800x480, hard(800, 480))
+    }
+
+    @Test
+    fun `a 16 by 9 panel gets the same answer from both`() {
+        for ((w, h) in listOf(1280 to 720, 1920 to 1080, 0 to 0)) {
+            assertEquals(recommended(w, h), hard(w, h))
+        }
+    }
+
+    // A cap below the recommendation would undo AUTO's own choice on the next connect.
+    @Test
+    fun `the hard ceiling never sits below the recommendation`() {
+        for (w in listOf(0, 480, 800, 1024, 1280, 1440, 1780, 1920, 2400, 2560, 3840)) {
+            for (h in listOf(0, 480, 600, 720, 800, 900, 1080, 1440)) {
+                val rec = recommended(w, h)
+                val cap = hard(w, h)
+                assertTrue(
+                    "hard ceiling ${cap.resName} below recommended ${rec.resName} for ${w}x$h",
+                    cap.width * cap.height >= rec.width * rec.height
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/utils/VideoFitPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/utils/VideoFitPolicyTest.kt
@@ -1,0 +1,85 @@
+package com.andrerinas.openheadunit.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VideoFitPolicyTest {
+
+    private val surface = Settings.ViewMode.SURFACE.value
+    private val texture = Settings.ViewMode.TEXTURE.value
+
+    @Test
+    fun `a stored mode is used as-is`() {
+        assertEquals(
+            Settings.VideoFitMode.COVER,
+            VideoFitPolicy.resolve(storedFitMode = 2, legacyStretch = null, legacyForcedScale = false, legacyViewMode = texture)
+        )
+    }
+
+    @Test
+    fun `a stored mode that is out of range falls back to FILL`() {
+        assertEquals(
+            Settings.VideoFitMode.FILL,
+            VideoFitPolicy.resolve(storedFitMode = 99, legacyStretch = null, legacyForcedScale = false, legacyViewMode = texture)
+        )
+    }
+
+    @Test
+    fun `a stored mode wins over the legacy boolean`() {
+        assertEquals(
+            Settings.VideoFitMode.CONTAIN,
+            VideoFitPolicy.resolve(storedFitMode = 1, legacyStretch = true, legacyForcedScale = false, legacyViewMode = texture)
+        )
+    }
+
+    @Test
+    fun `a fresh install with no preference at all gets FILL`() {
+        assertEquals(
+            Settings.VideoFitMode.FILL,
+            VideoFitPolicy.resolve(storedFitMode = null, legacyStretch = null, legacyForcedScale = false, legacyViewMode = texture)
+        )
+    }
+
+    @Test
+    fun `off the legacy path the boolean maps straight across`() {
+        assertEquals(
+            Settings.VideoFitMode.FILL,
+            VideoFitPolicy.resolve(storedFitMode = null, legacyStretch = true, legacyForcedScale = false, legacyViewMode = texture)
+        )
+        assertEquals(
+            Settings.VideoFitMode.CONTAIN,
+            VideoFitPolicy.resolve(storedFitMode = null, legacyStretch = false, legacyForcedScale = false, legacyViewMode = texture)
+        )
+    }
+
+    // The legacy forcedScale/SurfaceView path read the boolean inverted: true meant bars, not
+    // stretch. Migrating it straight across would flip what these users see.
+    @Test
+    fun `on the legacy forcedScale SurfaceView path the boolean is inverted`() {
+        assertEquals(
+            Settings.VideoFitMode.CONTAIN,
+            VideoFitPolicy.resolve(storedFitMode = null, legacyStretch = true, legacyForcedScale = true, legacyViewMode = surface)
+        )
+        assertEquals(
+            Settings.VideoFitMode.FILL,
+            VideoFitPolicy.resolve(storedFitMode = null, legacyStretch = false, legacyForcedScale = true, legacyViewMode = surface)
+        )
+    }
+
+    // The old getter read an unwritten boolean as true, and on this path true meant bars.
+    @Test
+    fun `a forced scale user who never touched the toggle keeps the bars`() {
+        assertEquals(
+            Settings.VideoFitMode.CONTAIN,
+            VideoFitPolicy.resolve(storedFitMode = null, legacyStretch = null, legacyForcedScale = true, legacyViewMode = surface)
+        )
+    }
+
+    @Test
+    fun `forcedScale off SurfaceView is inactive so the boolean is not inverted`() {
+        assertEquals(
+            Settings.VideoFitMode.FILL,
+            VideoFitPolicy.resolve(storedFitMode = null, legacyStretch = true, legacyForcedScale = true, legacyViewMode = texture)
+        )
+    }
+}


### PR DESCRIPTION
Closes #809. Adapted in part from Sesam17's #943, credited on the second commit

---

## What

- "Stretch to fill screen" becomes **Video fit** with three choices, named after the CSS vocabulary they behave like: **Fill** (reach the panel edges), **Contain** (whole picture, bars) and **Cover** (fill, crop the overflow). Fill is the default and is what the old toggle's own default migrated to.
- Every view scale is now the negotiated buffer over the visible canvas, `videoDim / (videoDim - margin)`. That is `1.0` where there is no margin, which is the ultra-wide 720p fault, and the margin's own crop where there is one.
- Touch mapping goes through `TouchCoordinateMapper` on both the measured and the unmeasured path. The duplicate inline touch maths and a `forcedScale` inversion hack are gone, and the fit mode is now part of the transform.
- A locked AUTO session no longer renegotiates down to `800x480` when the surface is recalculated mid-session.
- A non-16:9 panel advertises its real pixel shape through `pixelAspectRatioE4`, derived from the margin-reduced canvas, so Android Auto lays out for the panel while still encoding a 16:9 buffer. Only Fill claims non-square pixels.
- Margins that move after they were announced are re-announced, instead of leaving one number on the wire and a different one in use.
- Two new log lines: `[ServiceDiscovery] PixelAspectRatioE4 is: N` at INFO, and `[UI_DEBUG] Touch map: raw=… -> video=…` at Verbose. Neither existed, which is why "the touch is off" reports could not be measured.

## Why

- On the reporter's 1920x720 panel at 720p, `getScaleY()` fell through both its guards and returned panel aspect over video aspect, so `setVideoScale(1.0, 1.5)` blew the picture up 1.5x about the view centre and threw the overflow away. Nothing told the touch mapper, which still worked from the unscaled view size. That is the missed icons, the squished picture and the UI off the edge, in one line.
- On a 16:9 panel that factor is exactly 1.0, which is why this survived for years. It is also why the existing "Experimental touch alignment fix" could not help: both of its branches measure 1920x720 on that unit, and neither knows about the video scale.
- Replacing the expression with `1.0` is only right where the margin is zero. On a panel wider than 1920 the same expression is the crop that makes the announced margin true, and deleting it squashes the picture about a fifth vertically and shows rows the phone was told were invisible. One expression covers both cases and reproduces the two special-case arms it replaces.
- The protocol offers only five fixed 16:9 and 9:16 resolutions, so there is no non-16:9 resolution to ask for. The pixel aspect ratio is the only lever a 2.0 or 2.67 panel has.
- Contain and Cover preserve the aspect themselves, so asking the phone to pre-compensate for a stretch that is not applied squeezes its UI by the correction. That is why the derivation is gated to Fill.

## The commits

- `ce21188f` **Video fit**: adds `Settings.VideoFitMode` and `VideoFitPolicy` (the migration, including the inverted legacy `forcedScale` case), rewrites `ProjectionGeometryPolicy.scaleX`/`scaleY` onto the canvas expression, points Contain and Cover at the canvas rather than the raw buffer, routes both touch paths through `TouchCoordinateMapper`, and adds the settings row and its strings in all 20 locales.
- `0b6497b4` **Screen config**: adds `NegotiatedResolutionPolicy` so a locked session keeps what it negotiated, derives `pixelAspectRatioE4` in Fill only, and adds `MarginAnnouncementPolicy` plus the re-announce. The first two are adapted from Sesam17's report and he is co-authored on the commit.

## Validation

- **1453 JVM unit tests, 0 failures** (`main` is 1414). New: `ProjectionGeometryPolicyTest`, `NegotiatedResolutionPolicyTest`, `VideoFitPolicyTest`, `MarginAnnouncementPolicyTest`, plus two Contain/Cover cases on `TouchCoordinateMapperTest`. `HeadUnitScreenConfig` had no tests before this.
- **Three hardware rounds**, both arms built and compared against `main` each time.
  - **1440x720 head unit, 720p:** baseline `scaleY: 1.125`, candidate `1.0`, and all five `input tap` points land on the predicted coordinates with y equal to raw y. 1080p unchanged and bit-identical to the baseline.
  - **2400x1080 panels:** baseline `scaleY: 1.25` at both 720p and 1080p, candidate matches it, and photographs of the two are the same proportions. An earlier candidate that returned `1.0` here is what the second commit's canvas expression fixes.
  - **Contain and Cover** collapse onto Fill on those panels, with no bar and no crop on screen, which is correct once the margin has already shaped the canvas to the panel.
  - **The re-announce** was caught firing on a real device: three margins in 570 ms (102, 154, 144), each back-solving exactly to one of the device's transient screen readings, and each followed by an `UpdateUiConfigRequest`.

## Migration and compatibility

- New installs get Fill. `stretch_to_fill = true`, which was the old default, migrates to Fill, so an existing install sees no change it did not ask for.
- `stretch_to_fill = false` migrates to Contain, and the legacy `forcedScale` plus SurfaceView combination is inverted because `true` meant bars there.
- **The old toggle only ever bit on part of its own range.** `stretchToFill` was read in one place that reached the picture, `getScaleY()`, and only where the negotiated height exceeded the panel height. On a 16:9 panel the margins are zero at every resolution, so Fill and Contain agree and nothing changes for anyone there.
- **What changes for a non-16:9 panel with the toggle off.** At 1080p the old off branch produced `scaleX 1.3333 / scaleY 1.125`, a 25% vertical squash; Contain now equals Fill there, because the `480x360` margin has already shaped the canvas, so the picture is simply correct. At 720p the toggle did nothing at all, and Contain now pillarboxes, which is a visibly different picture from what that user has been getting.
- That second one is the only surprise in the set, and it is the setting starting to do what its name says. The default was on, so anybody who has it off chose it.
- `SettingsBackupManager` keeps `stretch_to_fill` as a known key so a pre-3.3 backup still restores and is converted on first read, and adds `video-fit-mode` to the keys that need a projection restart.

## What this does not change

- The forced-scale SurfaceView path still sizes the view from the raw buffer rather than the canvas. It is legacy, gated on an "Experimental" toggle, and no round has exercised it.
- Whether Android Auto's own layout responds to a derived pixel aspect ratio, as opposed to the picture merely being correctly shaped, is unmeasured. The rig derives 11250 and the reporter's unit 15000, and only the second is extreme enough for a layout change to be obvious.
- The touch configuration still advertises the full negotiated size while the mapper emits margin-reduced coordinates. That combination is field-proven at 1080p on every head unit, so it is left alone, but the two announcements disagree on paper.
- A mid-session screen-metrics change still drops the resolution lock, because `computeSettingsHash` includes the physical dimensions. The margin drift it causes is repaired; the unlock is not touched.
- The reporter's own 1920x720 panel has not been on a rig. It is the same margin-zero class as the 1440x720 unit that was tested, differing only in deriving 15000 rather than 11250.
- Portrait panels are covered by the unit tests and by the algebra, not by hardware.
