### PR TITLE
Native AA: recover a wedged create and a stopped poke, rename the group on every API level, connect faster, and pick the driver among real phones

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -89,6 +89,7 @@ import com.andrerinas.openheadunit.utils.HotspotManager
 import com.andrerinas.openheadunit.connection.wifi.WifiLauncherManager
 import com.andrerinas.openheadunit.connection.wifi.WifiLauncherMode
 import com.andrerinas.openheadunit.connection.wifi.WifiLauncherStopSequence
+import com.andrerinas.openheadunit.connection.wifi.direct.P2pIdentityRotationPolicy
 import com.andrerinas.openheadunit.connection.wifi.direct.StationScanMonitor
 import com.andrerinas.openheadunit.connection.wifi.direct.StationStandDown
 import com.andrerinas.openheadunit.connection.wifi.modes.WifiLauncherHelper
@@ -2444,6 +2445,7 @@ class AapService : Service() {
                     wifiLauncherManager.startDiscovery(oneShot = true)
             }
             ACTION_STOP_WIRELESS         -> wifiLauncherManager.stop()
+            ACTION_ROTATE_WIFI_DIRECT_IDENTITY -> rotateWifiDirectIdentity()
             ACTION_NATIVE_AA_POKE        -> {
                 val mac = intent?.getStringExtra(EXTRA_MAC)
                 if (mac != null) {
@@ -2654,6 +2656,30 @@ class AapService : Service() {
             }
         }
         return START_STICKY
+    }
+
+    /**
+     * Puts the newly drawn WiFi Direct identity on the air now rather than at the next connection.
+     * Refused while the group is in use, and the stored pair is then what the next create asks for.
+     */
+    private fun rotateWifiDirectIdentity() {
+        val native = wifiLauncherManager.active as? WifiLauncherNative
+        val handshake = native?.handshakeManager
+        val reason = P2pIdentityRotationPolicy.deferralReason(
+            sessionLive = commManager.isConnected,
+            handshakeInFlight = handshake?.isHandshakeInFlight() == true ||
+                handshake?.isHandoffSettling() == true,
+            nativeWifiDirectActive = native?.strategy == NativeStrategy.WIFI_DIRECT,
+        )
+        val wifiDirect = wifiLauncherManager.sharedServices.wifiDirectManager
+        if (reason != null || wifiDirect == null) {
+            AppLog.i(
+                "AapService: the new WiFi Direct identity waits for the next create: " +
+                    (reason ?: "this mode has no WiFi Direct manager running")
+            )
+            return
+        }
+        wifiDirect.rotateNativeIdentityNow()
     }
 
     // -------------------------------------------------------------------------
@@ -2954,6 +2980,7 @@ class AapService : Service() {
         const val ACTION_BT_AUTO_START              = "com.andrerinas.openheadunit.ACTION_BT_AUTO_START"
         const val ACTION_START_WIRELESS_SCAN       = "com.andrerinas.openheadunit.ACTION_START_WIRELESS_SCAN"
         const val ACTION_STOP_WIRELESS             = "com.andrerinas.openheadunit.ACTION_STOP_WIRELESS"
+        const val ACTION_ROTATE_WIFI_DIRECT_IDENTITY = "com.andrerinas.openheadunit.ACTION_ROTATE_WIFI_DIRECT_IDENTITY"
         const val ACTION_NATIVE_AA_POKE            = "com.andrerinas.openheadunit.ACTION_NATIVE_AA_POKE"
         const val ACTION_NATIVE_AA_SWITCH_DEVICE   = "com.andrerinas.openheadunit.ACTION_NATIVE_AA_SWITCH_DEVICE"
         const val ACTION_NATIVE_AA_CANCEL_POKE      = "com.andrerinas.openheadunit.ACTION_NATIVE_AA_CANCEL_POKE"

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -2465,6 +2465,16 @@ class AapService : Service() {
                         if (wifiLauncherManager.activeMode != WifiLauncherMode.NATIVE) {
                             AppLog.i("AapService: Initializing Native AA mode before poke...")
                             wifiLauncherManager.setActiveFromSettings(force = true)
+                        } else if (activeLauncher is WifiLauncherNative && activeLauncher.handshakeManager?.isStarted() != true) {
+                            // Never started, or stopped. rearmAfterSessionEnd() cannot help here:
+                            // it returns on the same flag, so the button used to promise a repair
+                            // it never made and the phone had nothing to connect back to.
+                            val why = activeLauncher.handshakeManager?.notStartedReason()
+                            AppLog.w(
+                                "AapService: the Native AA handshake servers are not running" +
+                                    (why?.let { " ($it)" } ?: "") + ", so nothing could answer the phone. Starting them before the poke."
+                            )
+                            activeLauncher.handshakeManager?.start()
                         } else if (activeLauncher is WifiLauncherNative && activeLauncher.handshakeManager?.isActive() != true) {
                             // A completed handoff closes the AA listeners while leaving the manager
                             // running, and start() returns immediately on isRunning, so calling it here

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -2665,13 +2665,15 @@ class AapService : Service() {
     private fun rotateWifiDirectIdentity() {
         val native = wifiLauncherManager.active as? WifiLauncherNative
         val handshake = native?.handshakeManager
+        val wifiDirect = wifiLauncherManager.sharedServices.wifiDirectManager
         val reason = P2pIdentityRotationPolicy.deferralReason(
             sessionLive = commManager.isConnected,
             handshakeInFlight = handshake?.isHandshakeInFlight() == true ||
                 handshake?.isHandoffSettling() == true,
             nativeWifiDirectActive = native?.strategy == NativeStrategy.WIFI_DIRECT,
+            createOutstanding = wifiDirect?.isCreatingGroup == true ||
+                wifiDirect?.isAcceptedCreatePending == true,
         )
-        val wifiDirect = wifiLauncherManager.sharedServices.wifiDirectManager
         if (reason != null || wifiDirect == null) {
             AppLog.i(
                 "AapService: the new WiFi Direct identity waits for the next create: " +

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/GroupIpResolutionPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/GroupIpResolutionPolicy.kt
@@ -1,0 +1,32 @@
+package com.andrerinas.openheadunit.connection.wifi.direct
+
+/**
+ * How long to look for the group interface's own IP before handing the phone the one the platform
+ * fixes anyway.
+ *
+ * A P2P group owner is always 192.168.49.1, and the delivery already fell back to it - after up to
+ * fifteen one-second reads. Waiting for a number we are going to substitute delays the credentials,
+ * and the wake poke behind them.
+ */
+object GroupIpResolutionPolicy {
+
+    /** The address AOSP gives every P2P group owner. */
+    const val GROUP_OWNER_IP = "192.168.49.1"
+
+    /** Re-reads a client spends waiting for its DHCP lease, one per second, after the first read. */
+    const val CLIENT_RETRIES = 15
+
+    /**
+     * Re-reads to spend after the first one. A group owner has a fallback that is always right, so
+     * it takes the first answer either way; a client has none and has to wait for its lease.
+     */
+    fun retriesAfterFirstRead(isGroupOwner: Boolean): Int =
+        if (isGroupOwner) 0 else CLIENT_RETRIES
+
+    /**
+     * The address to deliver, or null when there is none to send. [readIp] is what the interface
+     * answered, or null when it did not.
+     */
+    fun resolve(readIp: String?, isGroupOwner: Boolean): String? =
+        readIp ?: if (isGroupOwner) GROUP_OWNER_IP else null
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/NativeRefreshPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/NativeRefreshPolicy.kt
@@ -14,11 +14,21 @@ object NativeRefreshPolicy {
     /** How long a createGroup is given to answer before a refresh stops waiting on it. */
     const val CREATE_GRACE_MS = 15_000L
 
+    /**
+     * How long an accepted create is given to turn into a group: the twenty one-second group-info
+     * reads, plus one. A refresh inside it used to remake the group underneath those reads.
+     */
+    const val GROUP_INFO_WINDOW_MS = 21_000L
+
     enum class Action { REDELIVER, WAIT, RECREATE }
 
     /** Whether a create asked for this long ago is still owed an answer. */
     fun withinCreateGrace(elapsedMs: Long?): Boolean =
         elapsedMs != null && elapsedMs in 0 until CREATE_GRACE_MS
+
+    /** Whether a create accepted this long ago is still owed a group. */
+    fun withinGroupInfoWindow(elapsedMs: Long?): Boolean =
+        elapsedMs != null && elapsedMs in 0 until GROUP_INFO_WINDOW_MS
 
     /**
      * The same question read off the stamp, for callers that have to decide before the group can
@@ -28,9 +38,22 @@ object NativeRefreshPolicy {
     fun createInFlight(requestedAtMs: Long, nowMs: Long): Boolean =
         requestedAtMs != 0L && withinCreateGrace(nowMs - requestedAtMs)
 
-    fun decide(groupExists: Boolean, isGroupOwner: Boolean, createInFlightForMs: Long?): Action = when {
+    fun decide(
+        groupExists: Boolean,
+        isGroupOwner: Boolean,
+        createInFlightForMs: Long?,
+        acceptedCreatePendingForMs: Long? = null,
+    ): Action = when {
         groupExists && isGroupOwner -> Action.REDELIVER
         withinCreateGrace(createInFlightForMs) -> Action.WAIT
+        withinGroupInfoWindow(acceptedCreatePendingForMs) -> Action.WAIT
         else -> Action.RECREATE
+    }
+
+    /** How long a WAIT asks again in: once the longer of the two windows is up, plus a little. */
+    fun recheckDelayMs(createInFlightForMs: Long?, acceptedCreatePendingForMs: Long?): Long {
+        val graceLeft = if (withinCreateGrace(createInFlightForMs)) CREATE_GRACE_MS - createInFlightForMs!! else 0L
+        val windowLeft = if (withinGroupInfoWindow(acceptedCreatePendingForMs)) GROUP_INFO_WINDOW_MS - acceptedCreatePendingForMs!! else 0L
+        return maxOf(graceLeft, windowLeft) + 500L
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pCreateWedgePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pCreateWedgePolicy.kt
@@ -24,12 +24,30 @@ object P2pCreateWedgePolicy {
      */
     const val CREATE_STALL_FLOOR_MS = 8_000L
 
+    /** How long a cancelConnect is given to answer before the ladder carries on without it. */
+    const val CANCEL_ANSWER_TIMEOUT_MS = 3_000L
+
+    /** One cancel per variant: the same request goes back accepted and hanging, so each cancel drops something. */
+    const val MAX_CANCELS_PER_BRING_UP = 3
+
     enum class Step {
         /** Ask again on the existing ladder. */
         RETRY,
 
         /** Cancel the creation the platform is still holding, then ask again. */
         CANCEL_FIRST,
+    }
+
+    /** Which create the platform accepted, by what it asked for. */
+    enum class Variant {
+        /** A named, persistent group on a requested band or frequency. */
+        BANDED,
+
+        /** A named, persistent group with the band left to the platform. */
+        NAMED_NO_BAND,
+
+        /** The two-argument create: whatever profile the platform stored last. */
+        FRAMEWORK_PROFILE,
     }
 
     /**
@@ -45,6 +63,27 @@ object P2pCreateWedgePolicy {
         !isOurCreatePending(reason, msSinceAcceptedCreate) -> Step.RETRY
         msSinceAcceptedCreate!! < CREATE_STALL_FLOOR_MS -> Step.RETRY
         else -> Step.CANCEL_FIRST
+    }
+
+    /**
+     * The same question once the group-info retries have run out on an accepted create. No BUSY has
+     * to arrive for that: the platform said yes, twenty seconds passed, and there is no group.
+     */
+    fun stepAfterGroupInfoExhausted(
+        msSinceAcceptedCreate: Long?,
+        cancelAlreadySpent: Boolean,
+    ): Step = stepAfterBusy(BUSY, msSinceAcceptedCreate, cancelAlreadySpent)
+
+    /**
+     * The create to ask for after [stuck] was cancelled, or null once there is nothing left to drop.
+     * [cancelsSpent] counts the cancel just spent. Below API 29 only the framework profile exists,
+     * so the first cancel there is the last.
+     */
+    fun nextAfterCancel(stuck: Variant, cancelsSpent: Int): Variant? = when {
+        cancelsSpent >= MAX_CANCELS_PER_BRING_UP -> null
+        stuck == Variant.BANDED -> Variant.NAMED_NO_BAND
+        stuck == Variant.NAMED_NO_BAND -> Variant.FRAMEWORK_PROFILE
+        else -> null
     }
 
     /**

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pCreateWedgePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pCreateWedgePolicy.kt
@@ -1,0 +1,64 @@
+package com.andrerinas.openheadunit.connection.wifi.direct
+
+/**
+ * What to do when the platform answers BUSY to a group create it has already accepted one of.
+ *
+ * A createGroup the framework accepts puts it in GroupCreatingState, where every later createGroup
+ * and removeGroup falls through to a blanket BUSY until GROUP_CREATING_TIMED_OUT fires two minutes
+ * later. Retrying and removing inside that window cannot succeed; cancelConnect is the one call
+ * that state accepts, and it drops straight back to Inactive.
+ */
+object P2pCreateWedgePolicy {
+
+    /** [android.net.wifi.p2p.WifiP2pManager.BUSY]. */
+    const val BUSY = 2
+
+    /** AOSP `WifiP2pServiceImpl.GROUP_CREATING_WAIT_TIME_MS`, unchanged since KitKat. */
+    const val FRAMEWORK_CREATE_TIMEOUT_MS = 120_000L
+
+    /**
+     * How long an accepted create is left alone before it counts as stuck.
+     *
+     * A healthy create reaches the group in tens of milliseconds; this sits well above that and well
+     * below the 20 s the group-info retry loop spends, so a create that is merely slow is never cut off.
+     */
+    const val CREATE_STALL_FLOOR_MS = 8_000L
+
+    enum class Step {
+        /** Ask again on the existing ladder. */
+        RETRY,
+
+        /** Cancel the creation the platform is still holding, then ask again. */
+        CANCEL_FIRST,
+    }
+
+    /**
+     * [msSinceAcceptedCreate] is null when no create of ours has been accepted without producing a
+     * group, which is when a BUSY really does belong to somebody else and there is nothing to cancel.
+     */
+    fun stepAfterBusy(
+        reason: Int,
+        msSinceAcceptedCreate: Long?,
+        cancelAlreadySpent: Boolean,
+    ): Step = when {
+        cancelAlreadySpent -> Step.RETRY
+        !isOurCreatePending(reason, msSinceAcceptedCreate) -> Step.RETRY
+        msSinceAcceptedCreate!! < CREATE_STALL_FLOOR_MS -> Step.RETRY
+        else -> Step.CANCEL_FIRST
+    }
+
+    /**
+     * Whether the terminal rung may call this unit's refusal a refusal.
+     *
+     * A BUSY arriving while the platform is still finishing a create of ours describes our own
+     * timing, not the radio's ability to host a group, and a banner saying otherwise sends the user
+     * to change a setting that had nothing to do with it.
+     */
+    fun isRefusalHonest(reason: Int, msSinceAcceptedCreate: Long?): Boolean =
+        !isOurCreatePending(reason, msSinceAcceptedCreate)
+
+    private fun isOurCreatePending(reason: Int, msSinceAcceptedCreate: Long?): Boolean =
+        reason == BUSY &&
+            msSinceAcceptedCreate != null &&
+            msSinceAcceptedCreate < FRAMEWORK_CREATE_TIMEOUT_MS
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pIdentityRotationPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pIdentityRotationPolicy.kt
@@ -1,0 +1,54 @@
+package com.andrerinas.openheadunit.connection.wifi.direct
+
+/**
+ * How a new WiFi Direct network identity reaches the air, and whether it may go out now.
+ *
+ * From API 29 the app names the group itself, so a recreate carries the new pair. Below 29 every
+ * create reinvokes the platform's own stored profile, so that profile has to be deleted first or
+ * the name never changes.
+ */
+object P2pIdentityRotationPolicy {
+
+    /** The first level where `WifiP2pConfig.Builder` can name the group this app creates. */
+    const val NAMED_CREATE_SDK = 29
+
+    enum class Mechanism { NAMED_RECREATE, PURGE_PROFILE_THEN_RECREATE }
+
+    fun mechanism(sdkInt: Int): Mechanism =
+        if (sdkInt >= NAMED_CREATE_SDK) Mechanism.NAMED_RECREATE
+        else Mechanism.PURGE_PROFILE_THEN_RECREATE
+
+    /**
+     * Whether the group may be recreated for the new identity right now. A projecting session or a
+     * handshake mid-exchange owns the group, and taking it away costs the user the drive.
+     */
+    fun applyNow(
+        sessionLive: Boolean,
+        handshakeInFlight: Boolean,
+        nativeWifiDirectActive: Boolean,
+    ): Boolean = deferralReason(sessionLive, handshakeInFlight, nativeWifiDirectActive) == null
+
+    /** Why the rotation waits for the next create, or null when it can be applied now. */
+    fun deferralReason(
+        sessionLive: Boolean,
+        handshakeInFlight: Boolean,
+        nativeWifiDirectActive: Boolean,
+    ): String? = when {
+        !nativeWifiDirectActive ->
+            "no WiFi Direct group of this mode is up, so there is nothing to rename yet"
+        sessionLive ->
+            "a phone is projecting on this group and recreating it would end the session"
+        handshakeInFlight ->
+            "a phone is being handed the credentials right now and would be given a network that is going away"
+        else -> null
+    }
+
+    /**
+     * Whether the platform's stored profile must be deleted before the create.
+     *
+     * Below 29 it is the only rename lever there is, and it is also how "a new network on every
+     * connection" can be honoured on a platform that otherwise reinvokes the same profile forever.
+     */
+    fun purgeBeforeCreate(sdkInt: Int, keepIdentity: Boolean, rotationPending: Boolean): Boolean =
+        sdkInt < NAMED_CREATE_SDK && (rotationPending || !keepIdentity)
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pIdentityRotationPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pIdentityRotationPolicy.kt
@@ -26,13 +26,15 @@ object P2pIdentityRotationPolicy {
         sessionLive: Boolean,
         handshakeInFlight: Boolean,
         nativeWifiDirectActive: Boolean,
-    ): Boolean = deferralReason(sessionLive, handshakeInFlight, nativeWifiDirectActive) == null
+        createOutstanding: Boolean = false,
+    ): Boolean = deferralReason(sessionLive, handshakeInFlight, nativeWifiDirectActive, createOutstanding) == null
 
     /** Why the rotation waits for the next create, or null when it can be applied now. */
     fun deferralReason(
         sessionLive: Boolean,
         handshakeInFlight: Boolean,
         nativeWifiDirectActive: Boolean,
+        createOutstanding: Boolean = false,
     ): String? = when {
         !nativeWifiDirectActive ->
             "no WiFi Direct group of this mode is up, so there is nothing to rename yet"
@@ -40,6 +42,9 @@ object P2pIdentityRotationPolicy {
             "a phone is projecting on this group and recreating it would end the session"
         handshakeInFlight ->
             "a phone is being handed the credentials right now and would be given a network that is going away"
+        // A second create under one the platform is still holding is answered BUSY for two minutes.
+        createOutstanding ->
+            "a group is still being asked for, and the next create after it carries the new identity"
         else -> null
     }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pPersistentGroupPurge.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pPersistentGroupPurge.kt
@@ -1,0 +1,159 @@
+package com.andrerinas.openheadunit.connection.wifi.direct
+
+import android.annotation.SuppressLint
+import android.net.wifi.p2p.WifiP2pGroup
+import android.net.wifi.p2p.WifiP2pManager
+import android.os.Handler
+import com.andrerinas.openheadunit.utils.AppLog
+import java.lang.reflect.Proxy
+
+/**
+ * Deletes this unit's own stored P2P group profiles, the only way to rename the group below API 29.
+ *
+ * The two-argument createGroup reinvokes whatever profile the platform kept, so a fresh name and
+ * passphrase are minted only once no profile of ours is left. Both calls are hidden API, reached by
+ * reflection, and refused from Android 11 where the app names the group itself instead.
+ */
+object P2pPersistentGroupPurge {
+
+    /** A listener that never answers must not hold the create up; the group matters more. */
+    private const val ANSWER_TIMEOUT_MS = 3000L
+
+    private const val LISTENER_CLASS = "android.net.wifi.p2p.WifiP2pManager\$PersistentGroupInfoListener"
+
+    /**
+     * Deletes every stored profile this unit owns, then reports a short verdict for the log.
+     * [onDone] always runs exactly once, whatever the platform answered.
+     */
+    @SuppressLint("MissingPermission")
+    fun purge(
+        manager: WifiP2pManager,
+        channel: WifiP2pManager.Channel,
+        ownAddress: String?,
+        handler: Handler,
+        onDone: (verdict: String) -> Unit,
+    ) {
+        var finished = false
+        val timeout = Runnable {
+            if (!finished) {
+                finished = true
+                onDone("unavailable (no answer in ${ANSWER_TIMEOUT_MS / 1000}s)")
+            }
+        }
+        val finish = { verdict: String ->
+            if (!finished) {
+                finished = true
+                handler.removeCallbacks(timeout)
+                onDone(verdict)
+            }
+        }
+
+        try {
+            val listenerClass = Class.forName(LISTENER_CLASS)
+            val request = manager.javaClass.getMethod(
+                "requestPersistentGroupInfo",
+                WifiP2pManager.Channel::class.java,
+                listenerClass,
+            )
+            val listener = Proxy.newProxyInstance(
+                listenerClass.classLoader,
+                arrayOf(listenerClass),
+            ) { proxy, method, args ->
+                when (method.name) {
+                    "onPersistentGroupInfoAvailable" -> {
+                        deleteOurs(manager, channel, ownAddress, args?.getOrNull(0), finish)
+                        null
+                    }
+                    "hashCode" -> System.identityHashCode(proxy)
+                    "equals" -> proxy === args?.getOrNull(0)
+                    "toString" -> "P2pPersistentGroupPurge"
+                    else -> null
+                }
+            }
+            handler.postDelayed(timeout, ANSWER_TIMEOUT_MS)
+            request.invoke(manager, channel, listener)
+        } catch (t: Throwable) {
+            handler.removeCallbacks(timeout)
+            finish("unavailable (${t.javaClass.simpleName}: ${t.message})")
+        }
+    }
+
+    /** Never a profile we did not own: a phone's own saved group is not ours to forget. */
+    @SuppressLint("MissingPermission")
+    private fun deleteOurs(
+        manager: WifiP2pManager,
+        channel: WifiP2pManager.Channel,
+        ownAddress: String?,
+        groupList: Any?,
+        finish: (String) -> Unit,
+    ) {
+        val ours = try {
+            val list = groupList?.javaClass?.getMethod("getGroupList")?.invoke(groupList) as? Collection<*>
+            list.orEmpty().filterIsInstance<WifiP2pGroup>().filter { isOurs(it, ownAddress) }
+        } catch (t: Throwable) {
+            finish("unavailable (${t.javaClass.simpleName}: ${t.message})")
+            return
+        }
+        if (ours.isEmpty()) {
+            finish("no profile of ours")
+            return
+        }
+
+        val delete = try {
+            manager.javaClass.getMethod(
+                "deletePersistentGroup",
+                WifiP2pManager.Channel::class.java,
+                Int::class.javaPrimitiveType,
+                WifiP2pManager.ActionListener::class.java,
+            )
+        } catch (t: Throwable) {
+            finish("unavailable (${t.javaClass.simpleName}: ${t.message})")
+            return
+        }
+
+        var answered = 0
+        var purged = 0
+        var refusal: String? = null
+        val report = {
+            answered++
+            if (answered == ours.size) {
+                finish(if (purged > 0) "purged $purged of ${ours.size}" else "refused (${refusal ?: "unknown"})")
+            }
+        }
+        for (group in ours) {
+            val netId = group.networkId
+            val listener = object : WifiP2pManager.ActionListener {
+                override fun onSuccess() {
+                    purged++
+                    report()
+                }
+
+                override fun onFailure(reason: Int) {
+                    if (refusal == null) refusal = reasonName(reason)
+                    report()
+                }
+            }
+            try {
+                delete.invoke(manager, channel, netId, listener)
+            } catch (t: Throwable) {
+                AppLog.d("P2pPersistentGroupPurge: deletePersistentGroup(netId=$netId) threw: ${t.message}")
+                if (refusal == null) refusal = t.javaClass.simpleName
+                report()
+            }
+        }
+    }
+
+    private fun isOurs(group: WifiP2pGroup, ownAddress: String?): Boolean {
+        if (group.networkId < 0) return false
+        if (group.isGroupOwner) return true
+        val owner = group.owner?.deviceAddress ?: return false
+        return ownAddress != null && owner.equals(ownAddress, ignoreCase = true)
+    }
+
+    private fun reasonName(reason: Int): String = when (reason) {
+        WifiP2pManager.ERROR -> "ERROR"
+        WifiP2pManager.P2P_UNSUPPORTED -> "P2P_UNSUPPORTED"
+        WifiP2pManager.BUSY -> "BUSY"
+        else -> "reason $reason"
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/StationStandDown.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/StationStandDown.kt
@@ -31,6 +31,21 @@ object StationStandDown {
     const val VERIFY_DELAY_MS = 1_500L
 
     /**
+     * Whether this unit is still joined to its own network, or null when that cannot be read.
+     *
+     * Null is not "still there": an unreadable station must never hold the group up, which is what
+     * [StationStandDownSettlePolicy] does with it.
+     */
+    fun isStillAssociated(context: Context): Boolean? = try {
+        val wm = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager
+        @Suppress("DEPRECATION")
+        wm?.connectionInfo?.supplicantState?.let { it == SupplicantState.COMPLETED }
+    } catch (e: Exception) {
+        AppLog.d("StationStandDown: could not read the station back: ${e.message}")
+        null
+    }
+
+    /**
      * Leave the current network, recording it first so it can always be put back.
      *
      * The record is written before the call, not after: a crash between the two would otherwise
@@ -94,19 +109,14 @@ object StationStandDown {
             )
 
             Handler(Looper.getMainLooper()).postDelayed({
-                try {
-                    val still = wm.connectionInfo?.supplicantState == SupplicantState.COMPLETED
-                    if (still) {
-                        AppLog.w(
-                            "StationStandDown: this unit is still joined to its WiFi network " +
-                                "${VERIFY_DELAY_MS}ms later, so the group will have to share that " +
-                                "network's channel."
-                        )
-                    } else {
-                        AppLog.i("StationStandDown: this unit has left its WiFi network.")
-                    }
-                } catch (e: Exception) {
-                    AppLog.d("StationStandDown: could not read the station back: ${e.message}")
+                if (isStillAssociated(context) == true) {
+                    AppLog.w(
+                        "StationStandDown: this unit is still joined to its WiFi network " +
+                            "${VERIFY_DELAY_MS}ms later, so the group will have to share that " +
+                            "network's channel."
+                    )
+                } else {
+                    AppLog.i("StationStandDown: this unit has left its WiFi network.")
                 }
             }, VERIFY_DELAY_MS)
             return true

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/StationStandDownSettlePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/StationStandDownSettlePolicy.kt
@@ -1,0 +1,32 @@
+package com.andrerinas.openheadunit.connection.wifi.direct
+
+/**
+ * When the group may be created after the station was asked to leave its own network.
+ *
+ * The wait used to be a flat post of [StationStandDown.VERIFY_DELAY_MS], paid in full even on units
+ * that leave in a fraction of it. The same read that verified it afterwards answers the question
+ * early, so the delay becomes a ceiling rather than a cost.
+ */
+object StationStandDownSettlePolicy {
+
+    /** How often to ask whether the station has left. */
+    const val POLL_MS = 100L
+
+    /** Longest to wait; past this the group is created regardless, as it always was. */
+    const val CEILING_MS = StationStandDown.VERIFY_DELAY_MS
+
+    enum class Step {
+        /** Still associated and there is time left. Ask again. */
+        WAIT,
+
+        /** It has left, or the ceiling is reached. Create the group. */
+        CREATE
+    }
+
+    /**
+     * [stillAssociated] is the supplicant read; null means it could not be read, which is not
+     * evidence the station is still there and must not hold the group up.
+     */
+    fun step(stillAssociated: Boolean?, waitedMs: Long): Step =
+        if (stillAssociated == true && waitedMs < CEILING_MS) Step.WAIT else Step.CREATE
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiDirectManager.kt
@@ -246,6 +246,22 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     /** The [acceptedCreateWithoutGroupSinceMs] a cancel has already been spent on, so one is spent per stuck create. */
     private var wedgeCancelSpentForStampMs = 0L
 
+    /** What the create behind [acceptedCreateWithoutGroupSinceMs] asked for, so a cancel knows what to drop next. */
+    private var stuckCreateVariant = P2pCreateWedgePolicy.Variant.BANDED
+
+    /** Cancels spent this bring-up. Reset where [nativeRecreateCount] is. */
+    private var stuckCreateCancels = 0
+
+    /**
+     * Bumped by every create, cancel and stop, so a group-info retry loop posted under an earlier
+     * create cannot run its FATAL and reset the counter underneath the one now in flight.
+     */
+    private var groupInfoEpoch = 0
+
+    /** Whether the platform is holding a create of ours that has not produced a group. */
+    val isAcceptedCreatePending: Boolean
+        get() = msSinceAcceptedCreate() != null
+
     /** Re-asks once a claimed create has had its grace, so a refresh with nothing behind it is not the end of the road. */
     private val nativeRefreshRecheck = Runnable { refreshNativeCredentials() }
 
@@ -273,16 +289,23 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         AppLog.i("WifiDirectManager: a Native AA group create is claimed ($why); a refresh in the next ${NativeRefreshPolicy.CREATE_GRACE_MS / 1000}s waits for it.")
     }
 
-    /** A create the platform accepted. It owns the P2P state machine from here until a group arrives. */
-    private fun noteAcceptedCreate() {
-        acceptedCreateWithoutGroupSinceMs = SystemClock.elapsedRealtime()
+    /**
+     * A create the platform accepted. It owns the P2P state machine from here until a group arrives.
+     * Stamped on uptimeMillis because the framework's two-minute timeout is a Handler delay on that
+     * clock, and elapsedRealtime runs ahead of it through a doze.
+     */
+    private fun noteAcceptedCreate(variant: P2pCreateWedgePolicy.Variant) {
+        acceptedCreateWithoutGroupSinceMs = SystemClock.uptimeMillis()
         wedgeCancelSpentForStampMs = 0L
+        stuckCreateVariant = variant
+        groupInfoEpoch++
+        groupInfoRetries = 0
     }
 
     /** How long the platform has been holding a create of ours with no group to show for it, or null. */
     private fun msSinceAcceptedCreate(): Long? = acceptedCreateWithoutGroupSinceMs
         .takeIf { it != 0L }
-        ?.let { SystemClock.elapsedRealtime() - it }
+        ?.let { SystemClock.uptimeMillis() - it }
 
     /**
      * Whether this BUSY should be answered by cancelling the creation the platform is still holding.
@@ -297,33 +320,91 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             cancelAlreadySpent = wedgeCancelSpentForStampMs == acceptedCreateWithoutGroupSinceMs,
         ) == P2pCreateWedgePolicy.Step.CANCEL_FIRST
 
-    /** Drop the stuck creation, then hand back to [then] so the ladder carries on either way. */
-    private fun cancelStuckCreate(mgr: WifiP2pManager, ch: WifiP2pManager.Channel, then: () -> Unit) {
+    /**
+     * Drop the stuck creation. [onCancelled] asks for the next variant; [onRefused] repeats the rung
+     * that was refused, and the cancel may be tried again on the next BUSY.
+     */
+    private fun cancelStuckCreate(
+        mgr: WifiP2pManager,
+        ch: WifiP2pManager.Channel,
+        onCancelled: () -> Unit,
+        onRefused: () -> Unit,
+    ) {
         val heldMs = msSinceAcceptedCreate() ?: 0L
         wedgeCancelSpentForStampMs = acceptedCreateWithoutGroupSinceMs
+        groupInfoEpoch++
         AppLog.w(
             "WifiDirectManager: a group this unit accepted ${heldMs}ms ago never formed, and it " +
                 "refuses every new one until it gives up on that by itself " +
                 "(${P2pCreateWedgePolicy.FRAMEWORK_CREATE_TIMEOUT_MS / 1000}s). Cancelling it instead of waiting."
         )
         markP2pRequest()
+        var answered = false
+        val unanswered = Runnable {
+            if (answered) return@Runnable
+            answered = true
+            AppLog.w("WifiDirectManager: cancelling the stuck group creation went unanswered; asking again anyway.")
+            wedgeCancelSpentForStampMs = 0L
+            onRefused()
+        }
+        handler.postDelayed(unanswered, P2pCreateWedgePolicy.CANCEL_ANSWER_TIMEOUT_MS)
         mgr.cancelConnect(ch, object : WifiP2pManager.ActionListener {
             override fun onSuccess() {
-                AppLog.i("WifiDirectManager: the stuck group creation was cancelled; asking for a group again.")
+                if (answered) return
+                answered = true
+                handler.removeCallbacks(unanswered)
+                AppLog.i("WifiDirectManager: the stuck group creation was cancelled; asking for a group differently.")
                 acceptedCreateWithoutGroupSinceMs = 0L
-                handler.postDelayed({ then() }, 500L)
+                // Re-claimed so a refresh landing in the 500 ms below waits rather than remaking.
+                claimNativeCreateWindow("the stuck create was cancelled")
+                handler.postDelayed({ onCancelled() }, 500L)
             }
             override fun onFailure(reason: Int) {
+                if (answered) return
+                answered = true
+                handler.removeCallbacks(unanswered)
                 AppLog.w("WifiDirectManager: cancelling the stuck group creation was refused (${getP2pErrorString(reason)}); retrying anyway.")
-                handler.postDelayed({ then() }, 2000L)
+                wedgeCancelSpentForStampMs = 0L
+                handler.postDelayed({ onRefused() }, 2000L)
             }
         })
+    }
+
+    /**
+     * The create after a cancelled one. The same request goes back accepted and hanging, so each
+     * cancel drops something it asked for: the band first, then the name. Measured on a unit where
+     * the banded create was accepted four times in thirty minutes and never once formed a group.
+     */
+    private fun createAfterCancelledStuckCreate(mgr: WifiP2pManager, ch: WifiP2pManager.Channel) {
+        stuckCreateCancels++
+        when (P2pCreateWedgePolicy.nextAfterCancel(stuckCreateVariant, stuckCreateCancels)) {
+            P2pCreateWedgePolicy.Variant.NAMED_NO_BAND -> {
+                AppLog.w("WifiDirectManager: the create that never formed asked for a band, so the next one leaves the band to the platform.")
+                standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_FALLBACK)
+            }
+            P2pCreateWedgePolicy.Variant.FRAMEWORK_PROFILE -> {
+                namedFallbackRefused = true
+                AppLog.w("WifiDirectManager: the create that never formed named the group, so the next one asks for the platform's own profile.")
+                standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_FALLBACK)
+            }
+            P2pCreateWedgePolicy.Variant.BANDED -> createQuietGroup(0)
+            null -> {
+                AppLog.e(
+                    "WifiDirectManager: this unit accepts a group request and never forms the group, " +
+                        "on every kind of request it was offered ($stuckCreateCancels cancelled). " +
+                        "Nothing more is asked for until something asks for a group again."
+                )
+                reportGroupRefusal("accepted but never formed")
+                isGroupCreatingOrCreated = false
+                releaseNativeCreateWindow("every create variant was accepted and never formed")
+            }
+        }
     }
 
     private fun releaseNativeCreateWindow(why: String) {
         if (nativeCreateRequestedAtMs == 0L) return
         nativeCreateRequestedAtMs = 0L
-        AppLog.d("WifiDirectManager: the claimed create window is released ($why).")
+        AppLog.i("WifiDirectManager: the claimed create window is released ($why).")
     }
 
     /**
@@ -790,6 +871,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             // A group arrived, so nothing of ours is left half-created for the framework to hold.
             acceptedCreateWithoutGroupSinceMs = 0L
             wedgeCancelSpentForStampMs = 0L
+            stuckCreateCancels = 0
             val ssid = group.networkName
             val psk = group.passphrase ?: ""
             val isOwner = group.isGroupOwner
@@ -1150,7 +1232,9 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             if (groupInfoRetries < 20) {
                 groupInfoRetries++
                 AppLog.w("WifiDirectManager: Group info was null! Retrying in 1s (Attempt $groupInfoRetries/20)...")
+                val epoch = groupInfoEpoch
                 handler.postDelayed({
+                    if (epoch != groupInfoEpoch) return@postDelayed
                     channel?.let { ch ->
                         manager?.requestGroupInfo(ch, this)
                     }
@@ -1158,6 +1242,21 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             } else {
                 AppLog.e("WifiDirectManager: FATAL: Group info remained null after 20 retries.")
                 groupInfoRetries = 0
+                val mgr = manager
+                val ch = channel
+                val stalled = P2pCreateWedgePolicy.stepAfterGroupInfoExhausted(
+                    msSinceAcceptedCreate = msSinceAcceptedCreate(),
+                    cancelAlreadySpent = wedgeCancelSpentForStampMs == acceptedCreateWithoutGroupSinceMs,
+                ) == P2pCreateWedgePolicy.Step.CANCEL_FIRST
+                if (stalled && mgr != null && ch != null) {
+                    // The platform said yes and produced nothing: this is the stall, and no BUSY
+                    // has to arrive from a colliding refresh for the cancel to be spent.
+                    cancelStuckCreate(
+                        mgr, ch,
+                        onCancelled = { createAfterCancelledStuckCreate(mgr, ch) },
+                        onRefused = {},
+                    )
+                }
             }
         }
     }
@@ -1628,6 +1727,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         // stop() clears it, which ties the ladder to the mode rather than to a refresh.
         forgetPerGroupKeys()
         nativeRecreateCount = 0
+        stuckCreateCancels = 0
         cancelNativeJoinWatchdog()
         recreateNativeGroup(forceStandard = false)
     }
@@ -1656,10 +1756,12 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             val inFlightForMs = nativeCreateRequestedAtMs
                 .takeIf { it != 0L }
                 ?.let { SystemClock.elapsedRealtime() - it }
+            val acceptedForMs = msSinceAcceptedCreate()
             when (NativeRefreshPolicy.decide(
                 groupExists = group != null,
                 isGroupOwner = group?.isGroupOwner == true,
                 createInFlightForMs = inFlightForMs,
+                acceptedCreatePendingForMs = acceptedForMs,
             )) {
                 NativeRefreshPolicy.Action.REDELIVER -> {
                     AppLog.i(
@@ -1670,14 +1772,21 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                     onGroupInfoAvailable(group)
                 }
                 NativeRefreshPolicy.Action.WAIT -> {
-                    AppLog.i(
-                        "WifiDirectManager: refresh: a group was asked for ${inFlightForMs}ms ago and " +
-                            "has not answered yet, so nothing is remade underneath it."
-                    )
+                    if (NativeRefreshPolicy.withinCreateGrace(inFlightForMs)) {
+                        AppLog.i(
+                            "WifiDirectManager: refresh: a group was asked for ${inFlightForMs}ms ago and " +
+                                "has not answered yet, so nothing is remade underneath it."
+                        )
+                    } else {
+                        AppLog.i(
+                            "WifiDirectManager: refresh: a group was accepted ${acceptedForMs}ms ago and " +
+                                "is still being read for, so nothing is remade underneath it."
+                        )
+                    }
                     // Asked again once the grace is up. The session-end re-arm asks for credentials
                     // exactly once, so a create that never answers would otherwise leave the mode
                     // idle with nothing to notice it.
-                    val askAgainInMs = NativeRefreshPolicy.CREATE_GRACE_MS - (inFlightForMs ?: 0L) + 500L
+                    val askAgainInMs = NativeRefreshPolicy.recheckDelayMs(inFlightForMs, acceptedForMs)
                     AppLog.i("WifiDirectManager: refresh: asking again in ${askAgainInMs}ms, once that create's grace is up.")
                     handler.removeCallbacks(nativeRefreshRecheck)
                     handler.postDelayed(nativeRefreshRecheck, askAgainInMs)
@@ -1764,7 +1873,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 mgr.createGroup(ch, config, object : WifiP2pManager.ActionListener {
                     override fun onSuccess() {
                         AppLog.i("WifiDirectManager: $bandLabel createGroup SUCCESS!")
-                        noteAcceptedCreate()
+                        noteAcceptedCreate(P2pCreateWedgePolicy.Variant.BANDED)
                         noteGroupFormed()
                         // Only a create that carried the frequency disproves the record. A group
                         // formed on the driver's own pick is the failure it describes, not its cure.
@@ -1905,7 +2014,11 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     ) {
         // Ahead of the ladder: inside the platform's own create window nothing on it can succeed.
         if (shouldCancelStuckCreate(reason)) {
-            cancelStuckCreate(mgr, ch) { createQuietGroup(retryCount) }
+            cancelStuckCreate(
+                mgr, ch,
+                onCancelled = { createAfterCancelledStuckCreate(mgr, ch) },
+                onRefused = { createQuietGroup(retryCount) },
+            )
             return
         }
         val requestLabel =
@@ -2046,11 +2159,17 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 nativeCreateRequestedAtMs = SystemClock.elapsedRealtime()
                 AppLog.i("WifiDirectManager: standard createGroup as ${identity.networkName}, band left to the platform.")
                 mgr.createGroup(ch, config, object : WifiP2pManager.ActionListener {
-                    override fun onSuccess() { onStandardCreateSucceeded(mgr, ch, groupMode) }
+                    override fun onSuccess() {
+                        onStandardCreateSucceeded(mgr, ch, groupMode, P2pCreateWedgePolicy.Variant.NAMED_NO_BAND)
+                    }
                     override fun onFailure(reason: Int) {
                         val reasonStr = getP2pErrorString(reason)
                         if (shouldCancelStuckCreate(reason)) {
-                            cancelStuckCreate(mgr, ch) { standardCreateGroup(mgr, ch, retryCount, groupMode) }
+                            cancelStuckCreate(
+                                mgr, ch,
+                                onCancelled = { createAfterCancelledStuckCreate(mgr, ch) },
+                                onRefused = { standardCreateGroup(mgr, ch, retryCount, groupMode) },
+                            )
                             return
                         }
                         if (reason == 2 && retryCount < MAX_NATIVE_STANDARD_CREATE_RETRIES) {
@@ -2082,11 +2201,17 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         nativeRequestedIdentity = P2pGroupIdentity.FrameworkProfile
         nativeCreateRequestedAtMs = SystemClock.elapsedRealtime()
         mgr.createGroup(ch, object : WifiP2pManager.ActionListener {
-            override fun onSuccess() { onStandardCreateSucceeded(mgr, ch, groupMode) }
+            override fun onSuccess() {
+                onStandardCreateSucceeded(mgr, ch, groupMode, P2pCreateWedgePolicy.Variant.FRAMEWORK_PROFILE)
+            }
             override fun onFailure(reason: Int) {
                 val reasonStr = getP2pErrorString(reason)
                 if (shouldCancelStuckCreate(reason)) {
-                    cancelStuckCreate(mgr, ch) { standardCreateGroup(mgr, ch, retryCount, groupMode) }
+                    cancelStuckCreate(
+                        mgr, ch,
+                        onCancelled = { createAfterCancelledStuckCreate(mgr, ch) },
+                        onRefused = { standardCreateGroup(mgr, ch, retryCount, groupMode) },
+                    )
                     return
                 }
                 if (reason == 2 && retryCount < MAX_NATIVE_STANDARD_CREATE_RETRIES) {
@@ -2131,9 +2256,14 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         })
     }
 
-    private fun onStandardCreateSucceeded(mgr: WifiP2pManager, ch: WifiP2pManager.Channel, groupMode: String) {
+    private fun onStandardCreateSucceeded(
+        mgr: WifiP2pManager,
+        ch: WifiP2pManager.Channel,
+        groupMode: String,
+        variant: P2pCreateWedgePolicy.Variant,
+    ) {
         AppLog.i("WifiDirectManager: Standard createGroup SUCCESS!")
-        noteAcceptedCreate()
+        noteAcceptedCreate(variant)
         noteGroupFormed()
         // Read before releaseLegacyChannelRestriction() clears the flag. A group formed while the
         // restriction stood is on the channel that was asked for, and only that disproves the
@@ -2273,7 +2403,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         mgr.removeGroup(ch, object : WifiP2pManager.ActionListener {
             override fun onSuccess() { createFresh() }
             override fun onFailure(reason: Int) {
-                AppLog.d("WifiDirectManager: Native AA removeGroup before recreate failed (reason=${getP2pErrorString(reason)}); expected if no group existed")
+                AppLog.i("WifiDirectManager: Native AA removeGroup before recreate failed (reason=${getP2pErrorString(reason)}); expected if no group existed")
                 createFresh()
             }
         })
@@ -2538,6 +2668,8 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         isGroupCreatingOrCreated = false
         acceptedCreateWithoutGroupSinceMs = 0L
         wedgeCancelSpentForStampMs = 0L
+        stuckCreateCancels = 0
+        groupInfoEpoch++
         handler.removeCallbacksAndMessages(null)
         // Both of these guard an operation that is finished the moment we stop, and both used to be
         // cleared only by a posted runnable that the line above just cancelled - so a stop() landing

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiDirectManager.kt
@@ -233,6 +233,19 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     @Volatile
     private var nativeCreateRequestedAtMs = 0L
 
+    /**
+     * When a createGroup of ours was accepted and no group has arrived since, or 0.
+     *
+     * The framework holds that creation for two minutes and answers BUSY to every create and remove
+     * in the meantime, so this is what separates "the platform is still finishing our own request"
+     * from a radio that will not host a group at all.
+     */
+    @Volatile
+    private var acceptedCreateWithoutGroupSinceMs = 0L
+
+    /** The [acceptedCreateWithoutGroupSinceMs] a cancel has already been spent on, so one is spent per stuck create. */
+    private var wedgeCancelSpentForStampMs = 0L
+
     /** Re-asks once a claimed create has had its grace, so a refresh with nothing behind it is not the end of the road. */
     private val nativeRefreshRecheck = Runnable { refreshNativeCredentials() }
 
@@ -258,6 +271,53 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         // edges it provokes look like they came from another app.
         markP2pRequest()
         AppLog.i("WifiDirectManager: a Native AA group create is claimed ($why); a refresh in the next ${NativeRefreshPolicy.CREATE_GRACE_MS / 1000}s waits for it.")
+    }
+
+    /** A create the platform accepted. It owns the P2P state machine from here until a group arrives. */
+    private fun noteAcceptedCreate() {
+        acceptedCreateWithoutGroupSinceMs = SystemClock.elapsedRealtime()
+        wedgeCancelSpentForStampMs = 0L
+    }
+
+    /** How long the platform has been holding a create of ours with no group to show for it, or null. */
+    private fun msSinceAcceptedCreate(): Long? = acceptedCreateWithoutGroupSinceMs
+        .takeIf { it != 0L }
+        ?.let { SystemClock.elapsedRealtime() - it }
+
+    /**
+     * Whether this BUSY should be answered by cancelling the creation the platform is still holding.
+     *
+     * See [P2pCreateWedgePolicy]: inside that window every create and remove is refused, so the
+     * ladder below cannot win and only the cancel can.
+     */
+    private fun shouldCancelStuckCreate(reason: Int): Boolean =
+        P2pCreateWedgePolicy.stepAfterBusy(
+            reason = reason,
+            msSinceAcceptedCreate = msSinceAcceptedCreate(),
+            cancelAlreadySpent = wedgeCancelSpentForStampMs == acceptedCreateWithoutGroupSinceMs,
+        ) == P2pCreateWedgePolicy.Step.CANCEL_FIRST
+
+    /** Drop the stuck creation, then hand back to [then] so the ladder carries on either way. */
+    private fun cancelStuckCreate(mgr: WifiP2pManager, ch: WifiP2pManager.Channel, then: () -> Unit) {
+        val heldMs = msSinceAcceptedCreate() ?: 0L
+        wedgeCancelSpentForStampMs = acceptedCreateWithoutGroupSinceMs
+        AppLog.w(
+            "WifiDirectManager: a group this unit accepted ${heldMs}ms ago never formed, and it " +
+                "refuses every new one until it gives up on that by itself " +
+                "(${P2pCreateWedgePolicy.FRAMEWORK_CREATE_TIMEOUT_MS / 1000}s). Cancelling it instead of waiting."
+        )
+        markP2pRequest()
+        mgr.cancelConnect(ch, object : WifiP2pManager.ActionListener {
+            override fun onSuccess() {
+                AppLog.i("WifiDirectManager: the stuck group creation was cancelled; asking for a group again.")
+                acceptedCreateWithoutGroupSinceMs = 0L
+                handler.postDelayed({ then() }, 500L)
+            }
+            override fun onFailure(reason: Int) {
+                AppLog.w("WifiDirectManager: cancelling the stuck group creation was refused (${getP2pErrorString(reason)}); retrying anyway.")
+                handler.postDelayed({ then() }, 2000L)
+            }
+        })
     }
 
     private fun releaseNativeCreateWindow(why: String) {
@@ -724,6 +784,9 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             }
 
             groupInfoRetries = 0
+            // A group arrived, so nothing of ours is left half-created for the framework to hold.
+            acceptedCreateWithoutGroupSinceMs = 0L
+            wedgeCancelSpentForStampMs = 0L
             val ssid = group.networkName
             val psk = group.passphrase ?: ""
             val isOwner = group.isGroupOwner
@@ -1683,6 +1746,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 mgr.createGroup(ch, config, object : WifiP2pManager.ActionListener {
                     override fun onSuccess() {
                         AppLog.i("WifiDirectManager: $bandLabel createGroup SUCCESS!")
+                        noteAcceptedCreate()
                         noteGroupFormed()
                         // Only a create that carried the frequency disproves the record. A group
                         // formed on the driver's own pick is the failure it describes, not its cure.
@@ -1700,13 +1764,13 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                     }
                     override fun onFailure(reason: Int) {
                         onQuietGroupFailed(mgr, ch, retryCount, preference, chosenChannel,
-                            requestedFrequency, bandLabel, getP2pErrorString(reason), null)
+                            requestedFrequency, bandLabel, reason, getP2pErrorString(reason), null)
                     }
                 })
                 return
             } catch (t: Throwable) {
                 onQuietGroupFailed(mgr, ch, retryCount, preference, chosenChannel,
-                    requestedFrequency, bandLabel, "crashed before any async result", t)
+                    requestedFrequency, bandLabel, -1, "crashed before any async result", t)
                 return
             }
         }
@@ -1816,9 +1880,15 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         chosenChannel: Int,
         requestedFrequency: Int,
         bandLabel: String,
+        reason: Int,
         reasonStr: String,
         crash: Throwable?,
     ) {
+        // Ahead of the ladder: inside the platform's own create window nothing on it can succeed.
+        if (shouldCancelStuckCreate(reason)) {
+            cancelStuckCreate(mgr, ch) { createQuietGroup(retryCount) }
+            return
+        }
         val requestLabel =
             if (requestedFrequency > 0) "$bandLabel ${FiveGhzChannelPolicy.describe(chosenChannel)}"
             else bandLabel
@@ -1960,6 +2030,10 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                     override fun onSuccess() { onStandardCreateSucceeded(mgr, ch, groupMode) }
                     override fun onFailure(reason: Int) {
                         val reasonStr = getP2pErrorString(reason)
+                        if (shouldCancelStuckCreate(reason)) {
+                            cancelStuckCreate(mgr, ch) { standardCreateGroup(mgr, ch, retryCount, groupMode) }
+                            return
+                        }
                         if (reason == 2 && retryCount < MAX_NATIVE_STANDARD_CREATE_RETRIES) {
                             AppLog.w("WifiDirectManager: standard createGroup failed ($reasonStr), removing group and retrying standard in 2s...")
                             invalidateNativeGroupCredentials("the standard create was refused and is being retried")
@@ -1992,6 +2066,10 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             override fun onSuccess() { onStandardCreateSucceeded(mgr, ch, groupMode) }
             override fun onFailure(reason: Int) {
                 val reasonStr = getP2pErrorString(reason)
+                if (shouldCancelStuckCreate(reason)) {
+                    cancelStuckCreate(mgr, ch) { standardCreateGroup(mgr, ch, retryCount, groupMode) }
+                    return
+                }
                 if (reason == 2 && retryCount < MAX_NATIVE_STANDARD_CREATE_RETRIES) {
                     AppLog.w("WifiDirectManager: standard createGroup failed ($reasonStr), removing group and retrying standard in 2s...")
                     invalidateNativeGroupCredentials("the standard create was refused and is being retried")
@@ -2019,7 +2097,14 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                         createQuietGroup(0)
                     }
                 } else {
-                    reportGroupRefusal(reasonStr)
+                    if (P2pCreateWedgePolicy.isRefusalHonest(reason, msSinceAcceptedCreate())) {
+                        reportGroupRefusal(reasonStr)
+                    } else {
+                        AppLog.w(
+                            "WifiDirectManager: no group yet ($reasonStr), but this unit is still " +
+                                "finishing a create of ours rather than refusing to host one. Waiting for it."
+                        )
+                    }
                     isGroupCreatingOrCreated = false
                     releaseNativeCreateWindow("the unit refused the group")
                 }
@@ -2029,6 +2114,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
 
     private fun onStandardCreateSucceeded(mgr: WifiP2pManager, ch: WifiP2pManager.Channel, groupMode: String) {
         AppLog.i("WifiDirectManager: Standard createGroup SUCCESS!")
+        noteAcceptedCreate()
         noteGroupFormed()
         // Read before releaseLegacyChannelRestriction() clears the flag. A group formed while the
         // restriction stood is on the channel that was asked for, and only that disproves the
@@ -2408,6 +2494,8 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         generation++
         credentialsEpoch++
         isGroupCreatingOrCreated = false
+        acceptedCreateWithoutGroupSinceMs = 0L
+        wedgeCancelSpentForStampMs = 0L
         handler.removeCallbacksAndMessages(null)
         // Both of these guard an operation that is finished the moment we stop, and both used to be
         // cleared only by a posted runnable that the line above just cancelled - so a stop() landing

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiDirectManager.kt
@@ -433,6 +433,9 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     // group; nativeRecreateCount bounds how many times we recreate before giving up.
     private var nativeRecreateCount = 0
 
+    /** What the last profile purge did, so the group's read-back line says whether it worked. */
+    private var lastPersistentPurgeVerdict: String? = null
+
     /**
      * True once a projection session has run over the current group. The join watchdog recreates
      * a group no phone joined, and a recreate is what moves the group's address out from under
@@ -1040,7 +1043,8 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                         "WifiDirectManager: " + P2pGroupIdentityPolicy.describeReadBack(
                             nativeRequestedIdentity, ssid, psk, group.networkId) +
                             " bssid=$bssid stable=${GroupIdentityStabilityPolicy.label(verdict.stability)}" +
-                            " (${verdict.reason}) source=$bssidSource"
+                            " (${verdict.reason}) source=$bssidSource" +
+                            (lastPersistentPurgeVerdict?.let { " profilePurge=$it" } ?: "")
                     )
                 }
             }
@@ -1407,10 +1411,9 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             // PROV-DISC retry storm (confirmed via live-device bisection against `ebab63a8`,
             // whose only change was skipping this teardown on reuse) — tear down and recreate
             // on every reuse rather than trying to detect which ones are broken.
-            // NOTE: this used to also call deletePersistentGroup() to purge the profile (so a
-            // plain createGroup() wouldn't reuse the same SSID/netId) — confirmed on-device that
-            // call is rejected outright for every netId, including the profile's own real one.
-            // Dropped; likely a permission this app doesn't hold.
+            // No deletePersistentGroup() here: that call is refused from Android 11, and below API 29,
+            // where it still works, it is reserved for the Native AA rename (P2pPersistentGroupPurge).
+            // The Helper path only needs a clean registrar, which the teardown alone gives it.
             AppLog.i("WifiDirectManager: Existing P2P group found — removing and recreating fresh for a clean WPS/PBC registrar")
             // The next createGroup() call generates a brand-new GO interface with a new random
             // MAC — a cached BSSID from the group we're tearing down is now stale and must never
@@ -1537,6 +1540,19 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 context.startActivity(intent)
             } catch (e: Exception) {}
         }, 800L)
+    }
+
+    /**
+     * Puts a new network name and passphrase on the air now instead of at the next connection.
+     * Below API 29 the create reinvokes the platform's stored profile, so the profile is deleted
+     * first; from 29 the create names the group itself and the recreate is the whole of it.
+     */
+    fun rotateNativeIdentityNow() {
+        AppLog.i(
+            "WifiDirectManager: a new WiFi Direct identity was asked for now (" +
+                "${P2pIdentityRotationPolicy.mechanism(Build.VERSION.SDK_INT)}); recreating the group."
+        )
+        startNativeAaQuietHost()
     }
 
     @SuppressLint("MissingPermission")
@@ -2205,9 +2221,9 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
      * owner. It asks for nothing rather than asking for 2.4 GHz, so the platform decides.
      *
      * Fresh group, same name: the teardown stays, but the create asks for the kept identity (see
-     * [chooseNativeGroupIdentity]), so a recreate costs the phone nothing it saved. Used to also
-     * call deletePersistentGroup() here, as the Helper mode path does, but on-device that is
-     * rejected for every netId - a system permission this app cannot hold. Dropped.
+     * [chooseNativeGroupIdentity]), so a recreate costs the phone nothing it saved. Below API 29 the
+     * create can only reinvoke the platform's stored profile, so a rename has to delete it first;
+     * deletePersistentGroup is refused from Android 11, which is well above that range.
      */
     @SuppressLint("MissingPermission")
     private fun recreateNativeGroup(forceStandard: Boolean) {
@@ -2219,13 +2235,36 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         claimNativeCreateWindow("recreating the group")
         invalidateNativeGroupCredentials("recreating the group")
         val gen = generation
+        val appSettings = App.provide(context).settings
+        val create = {
+            if (forceStandard) standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_FALLBACK)
+            else delayedCreateQuietGroup(0)
+        }
         val createFresh = {
             // The removeGroup below is the teardown a user exit relies on. If stop() ran while it was
             // in flight, recreating here puts a group back up that nothing is managing and that the
             // phone will keep trying to join - the opposite of what the exit asked for.
-            if (supersededByStop(gen, "Native AA group recreate")) Unit
-            else if (forceStandard) standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_FALLBACK)
-            else delayedCreateQuietGroup(0)
+            if (supersededByStop(gen, "Native AA group recreate")) {
+                Unit
+            } else if (P2pIdentityRotationPolicy.purgeBeforeCreate(
+                    Build.VERSION.SDK_INT,
+                    appSettings.wifiDirectStableIdentity,
+                    appSettings.wifiDirectRotationPending,
+                )
+            ) {
+                // Consumed here, not after the create: a stop() landing mid-purge must not leave
+                // the request behind to purge a group nobody asked to rename.
+                appSettings.wifiDirectRotationPending = false
+                P2pPersistentGroupPurge.purge(mgr, ch, localDeviceAddress, handler) { verdict ->
+                    lastPersistentPurgeVerdict = verdict
+                    AppLog.i("WifiDirectManager: persistent profile purge: $verdict")
+                    if (!supersededByStop(gen, "Native AA group recreate")) create()
+                }
+            } else {
+                appSettings.wifiDirectRotationPending = false
+                lastPersistentPurgeVerdict = null
+                create()
+            }
         }
         markP2pRequest()
         mgr.removeGroup(ch, object : WifiP2pManager.ActionListener {
@@ -2519,6 +2558,8 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         lastChurnReportAtMs = 0L
         pinnedChannelAbandoned = false
         namedFallbackRefused = false
+        // The verdict describes a group that is going away; it must not survive into the next start().
+        lastPersistentPurgeVerdict = null
         // Before legacyChannelRequestUnanswered is reset, because that flag is what tells the
         // release a timed-out request may have left a restriction behind.
         manager?.let { mgr -> channel?.let { ch -> releaseLegacyChannelRestriction(mgr, ch, force = true) } }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/direct/WifiDirectManager.kt
@@ -1101,19 +1101,21 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 val deliveryStability =
                     if (isNativeAaMode() && isOwner) nativeIdentityStability
                     else GroupIdentityStability.NOT_MEASURED
+                val ipRetries = GroupIpResolutionPolicy.retriesAfterFirstRead(isOwner)
                 Thread {
                     try {
                         var ip = getWifiDirectIp(iface)
                         var retries = 0
-                        while (ip == null && retries < 15) {
-                            AppLog.d("WifiDirectManager: Waiting for IP on interface ${iface ?: "any p2p"} (Attempt ${retries + 1}/15)...")
+                        while (ip == null && retries < ipRetries) {
+                            AppLog.d("WifiDirectManager: Waiting for IP on interface ${iface ?: "any p2p"} (Attempt ${retries + 1}/$ipRetries)...")
                             Thread.sleep(1000)
                             ip = getWifiDirectIp(iface)
                             retries++
                         }
 
-                        // For Native AA, we almost always expect 192.168.49.1 if we are GO
-                        val finalIp = ip ?: (if (isOwner) "192.168.49.1" else null)
+                        // A group owner is 192.168.49.1 by platform, so waiting for the interface to
+                        // say so only delays the credentials and the wake poke behind them.
+                        val finalIp = GroupIpResolutionPolicy.resolve(ip, isOwner)
                         if (deliveryEpoch != credentialsEpoch) {
                             AppLog.i(
                                 "WifiDirectManager: not delivering credentials for $ssid - that group was " +
@@ -1773,10 +1775,11 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                             if (band == NativeGroupBandPolicy.Band.GHZ_2_4) NATIVE_GROUP_MODE_24GHZ_REQUESTED
                             else NATIVE_GROUP_MODE_5GHZ_REQUESTED
                         isGroupOwner = true
-                        handler.postDelayed({
-                            mgr.requestConnectionInfo(ch, this@WifiDirectManager)
-                            mgr.requestGroupInfo(ch, this@WifiDirectManager)
-                        }, 1000L)
+                        // Asked now rather than a second later: a group that cannot answer yet is
+                        // already covered by the 20 x 1s retry in onGroupInfoAvailable, so the wait
+                        // only ever cost a second it could not save.
+                        mgr.requestConnectionInfo(ch, this@WifiDirectManager)
+                        mgr.requestGroupInfo(ch, this@WifiDirectManager)
                     }
                     override fun onFailure(reason: Int) {
                         onQuietGroupFailed(mgr, ch, retryCount, preference, chosenChannel,

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/WifiLauncherNative.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/WifiLauncherNative.kt
@@ -6,6 +6,7 @@ import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.connection.CommManager
 import com.andrerinas.openheadunit.connection.wifi.direct.GroupIdentityStability
 import com.andrerinas.openheadunit.connection.wifi.direct.StationStandDown
+import com.andrerinas.openheadunit.connection.wifi.direct.StationStandDownSettlePolicy
 import com.andrerinas.openheadunit.connection.wifi.direct.WifiDirectManager
 import com.andrerinas.openheadunit.connection.wifi.modes.nativeaa.NativeAaHandshakeManager
 import com.andrerinas.openheadunit.connection.wifi.modes.nativeaa.SoftApCredentialsProvider
@@ -91,14 +92,11 @@ class WifiLauncherNative : WifiLauncher {
                     // in flight it remade a group underneath the one about to be asked for, and
                     // skipped the stand-down doing it.
                     wifiDirect.claimNativeCreateWindow("waiting for this unit to leave its own network")
-                    // Give the station its verify window to actually leave first. A group asked
-                    // for while it is still tearing down forms on the channel the stand-down was
-                    // meant to free, and stays there: a refresh no longer remakes a group.
-                    Handler(Looper.getMainLooper()).postDelayed({
-                        if (manager.active === this && manager.sharedServices.wifiDirectManager === wifiDirect) {
-                            wifiDirect.startNativeAaQuietHost()
-                        }
-                    }, StationStandDown.VERIFY_DELAY_MS)
+                    // A group asked for while the station is still tearing down forms on the
+                    // channel the stand-down was meant to free, and stays there. Ask whether it
+                    // has left rather than assuming the whole window is needed; the claim above
+                    // is held across every poll, so nothing else starts a create in the gap.
+                    awaitStandDownThenCreate(wifiDirect, waitedMs = 0L)
                 } else {
                     wifiDirect.startNativeAaQuietHost()
                 }
@@ -106,6 +104,31 @@ class WifiLauncherNative : WifiLauncher {
 
             // Start the official Bluetooth handshake servers
             handshakeManager?.start()
+
+            // The listeners are open now, so the phone can be woken while the group forms rather
+            // than after it. Refused unless there is genuinely nothing else to wait for.
+            handshakeManager?.triggerEarlyWake(service.userExitedAA)
+        }
+    }
+
+    /**
+     * Creates the group as soon as the station has actually left, or at the ceiling, whichever
+     * comes first. The create window stays claimed for every poll.
+     */
+    private fun awaitStandDownThenCreate(wifiDirect: WifiDirectManager, waitedMs: Long) {
+        if (manager.active !== this || manager.sharedServices.wifiDirectManager !== wifiDirect) return
+
+        val stillAssociated = StationStandDown.isStillAssociated(service)
+        when (StationStandDownSettlePolicy.step(stillAssociated, waitedMs)) {
+            StationStandDownSettlePolicy.Step.WAIT ->
+                Handler(Looper.getMainLooper()).postDelayed(
+                    { awaitStandDownThenCreate(wifiDirect, waitedMs + StationStandDownSettlePolicy.POLL_MS) },
+                    StationStandDownSettlePolicy.POLL_MS
+                )
+            StationStandDownSettlePolicy.Step.CREATE -> {
+                AppLog.i("WifiLauncherNative: creating the group ${waitedMs}ms after the stand-down (still joined=$stillAssociated).")
+                wifiDirect.startNativeAaQuietHost()
+            }
         }
     }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/DriverCandidatePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/DriverCandidatePolicy.kt
@@ -1,0 +1,118 @@
+package com.andrerinas.openheadunit.connection.wifi.modes.nativeaa
+
+/**
+ * Which paired Bluetooth devices can be a Native AA driver. Only a phone answers the wake poke,
+ * and anything that does calls looks like a phone by device class. A class that rules a device
+ * out wins over its records, because a car head unit with its own dialer advertises the Audio
+ * Gateway too; otherwise that record, the one the poke dials, is what "phone" means here.
+ */
+object DriverCandidatePolicy {
+
+    enum class Verdict { PHONE, UNKNOWN, NOT_A_PHONE }
+
+    enum class Reason {
+        AUDIO_GATEWAY, HANDS_FREE_UNIT, LOW_ENERGY_ONLY, CLASS_PHONE, CLASS_NOT_PHONE,
+        GATEWAY_BUT_CLASS_NOT_PHONE, PINNED, NO_SIGNAL
+    }
+
+    data class Classification(val verdict: Verdict, val reason: Reason)
+
+    /**
+     * How a stored MAC vouches for a device. USER is the preferred phone the user picked, and it
+     * can name a watch; PROVEN is written only by a completed handshake, so it is always a phone.
+     */
+    enum class Pin { NONE, USER, PROVEN }
+
+    /** Hands-Free and Headset Audio Gateway: the phone's half of the profile. */
+    const val HFP_AG_UUID = "0000111f-0000-1000-8000-00805f9b34fb"
+    const val HSP_AG_UUID = "00001112-0000-1000-8000-00805f9b34fb"
+
+    /** Hands-Free unit and A2DP Sink: the car's half, which a dongle, a radio or a headset carries. */
+    const val HFP_HF_UUID = HfpServiceRecordPolicy.HANDS_FREE_UUID
+    const val A2DP_SINK_UUID = "0000110b-0000-1000-8000-00805f9b34fb"
+
+    // Values of android.bluetooth.BluetoothClass.Device and BluetoothDevice.DEVICE_TYPE_LE, copied
+    // so the policy needs no android import.
+    const val MAJOR_PHONE = 0x0200
+    const val MAJOR_AUDIO_VIDEO = 0x0400
+    const val MAJOR_PERIPHERAL = 0x0500
+    const val MAJOR_IMAGING = 0x0600
+    const val MAJOR_WEARABLE = 0x0700
+    const val MAJOR_TOY = 0x0800
+    const val MAJOR_HEALTH = 0x0900
+    const val AV_WEARABLE_HEADSET = 0x0404
+    const val AV_HANDSFREE = 0x0408
+    const val AV_MICROPHONE = 0x0410
+    const val AV_LOUDSPEAKER = 0x0414
+    const val AV_HEADPHONES = 0x0418
+    const val AV_PORTABLE_AUDIO = 0x041c
+    const val AV_CAR_AUDIO = 0x0420
+    const val AV_HIFI_AUDIO = 0x0428
+    const val DEVICE_TYPE_UNKNOWN = 0
+    const val DEVICE_TYPE_LE = 2
+
+    private val AUDIO_GATEWAY_UUIDS = setOf(HFP_AG_UUID, HSP_AG_UUID)
+    private val CAR_SIDE_UUIDS = setOf(HFP_HF_UUID, A2DP_SINK_UUID)
+    private val NON_PHONE_MAJORS = setOf(MAJOR_WEARABLE, MAJOR_PERIPHERAL, MAJOR_IMAGING, MAJOR_HEALTH, MAJOR_TOY)
+    private val NON_PHONE_AUDIO = setOf(
+        AV_WEARABLE_HEADSET, AV_HANDSFREE, AV_MICROPHONE, AV_LOUDSPEAKER,
+        AV_HEADPHONES, AV_PORTABLE_AUDIO, AV_CAR_AUDIO, AV_HIFI_AUDIO
+    )
+
+    /**
+     * [uuids] are the bond's cached service records, null or empty when never fetched. A ruled-out
+     * class beats the gateway record, then the records beat the rest; an LE-only bond cannot carry
+     * the RFCOMM link at all; a class nobody ruled out is UNKNOWN, and a USER pin lifts only that.
+     */
+    fun classify(
+        uuids: Collection<String>?,
+        hasDeviceClass: Boolean,
+        majorDeviceClass: Int,
+        deviceClass: Int,
+        deviceType: Int,
+        pin: Pin = Pin.NONE
+    ): Classification {
+        if (pin == Pin.PROVEN) return Classification(Verdict.PHONE, Reason.PINNED)
+
+        val records = uuids.orEmpty().map { it.lowercase() }
+        val gateway = records.any { it in AUDIO_GATEWAY_UUIDS }
+        val ruledOutByClass = hasDeviceClass && (
+            majorDeviceClass in NON_PHONE_MAJORS ||
+                (majorDeviceClass == MAJOR_AUDIO_VIDEO && deviceClass in NON_PHONE_AUDIO)
+            )
+        if (gateway && ruledOutByClass) return Classification(Verdict.NOT_A_PHONE, Reason.GATEWAY_BUT_CLASS_NOT_PHONE)
+        if (gateway) return Classification(Verdict.PHONE, Reason.AUDIO_GATEWAY)
+        if (records.any { it in CAR_SIDE_UUIDS }) return Classification(Verdict.NOT_A_PHONE, Reason.HANDS_FREE_UNIT)
+
+        if (deviceType == DEVICE_TYPE_LE) return Classification(Verdict.NOT_A_PHONE, Reason.LOW_ENERGY_ONLY)
+
+        val byClass = when {
+            !hasDeviceClass -> Classification(Verdict.UNKNOWN, Reason.NO_SIGNAL)
+            majorDeviceClass == MAJOR_PHONE -> Classification(Verdict.PHONE, Reason.CLASS_PHONE)
+            ruledOutByClass -> Classification(Verdict.NOT_A_PHONE, Reason.CLASS_NOT_PHONE)
+            else -> Classification(Verdict.UNKNOWN, Reason.NO_SIGNAL)
+        }
+        if (pin == Pin.USER && byClass.verdict == Verdict.UNKNOWN) return Classification(Verdict.PHONE, Reason.PINNED)
+        return byClass
+    }
+
+    /** The tier a list is offered at: any phone wins, else the unclassified, else nothing. */
+    fun offeredVerdict(verdicts: Collection<Verdict>): Verdict = when {
+        Verdict.PHONE in verdicts -> Verdict.PHONE
+        Verdict.UNKNOWN in verdicts -> Verdict.UNKNOWN
+        else -> Verdict.NOT_A_PHONE
+    }
+
+    /** The reason in a reporter's words, for the log line beside each device. */
+    fun reasonText(classification: Classification, deviceClass: Int = 0): String = when (classification.reason) {
+        Reason.AUDIO_GATEWAY -> "advertises the Audio Gateway record"
+        Reason.HANDS_FREE_UNIT -> "advertises the Hands-Free unit or A2DP Sink record and no Audio Gateway"
+        Reason.LOW_ENERGY_ONLY -> "bonded over Bluetooth LE only"
+        Reason.CLASS_PHONE -> "device class is phone"
+        Reason.CLASS_NOT_PHONE -> "device class 0x%04x is not a phone".format(deviceClass)
+        Reason.GATEWAY_BUT_CLASS_NOT_PHONE ->
+            "advertises the Audio Gateway record but device class 0x%04x is not a phone".format(deviceClass)
+        Reason.PINNED -> if (classification.verdict == Verdict.PHONE) "vouched for by a stored MAC" else "pinned"
+        Reason.NO_SIGNAL -> "no service record or device class says either way"
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/EarlyWakePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/EarlyWakePolicy.kt
@@ -1,0 +1,44 @@
+package com.andrerinas.openheadunit.connection.wifi.modes.nativeaa
+
+/**
+ * Whether the wake poke may start before the WiFi credentials exist.
+ *
+ * The wake used to be triggered only by a credential delivery, so the phone was not woken until the
+ * group was up, its info had come back and its IP had resolved. The handshake does not need that
+ * ordering: it sends the version exchange first and waits for credentials afterwards, so the
+ * phone's own wake latency can run alongside the group forming instead of after it.
+ */
+object EarlyWakePolicy {
+
+    /**
+     * [listenersOpen] must be the real "the AA RFCOMM listener is accepting" read. A phone woken to
+     * a head unit with no listener finds nothing to dial and the log still says the poke worked.
+     */
+    fun mayWakeBeforeCredentials(
+        listenersOpen: Boolean,
+        credentialsPresent: Boolean,
+        userExited: Boolean,
+        sessionUp: Boolean,
+    ): Boolean = listenersOpen && !credentialsPresent && !userExited && !sessionUp
+
+    /**
+     * Whether a `triggerPoke()` with a new credential key should replace the running loop.
+     *
+     * False when the only change is credentials arriving under a loop that started without them:
+     * the loop re-reads them every pass, so restarting it throws away the head start an early wake
+     * just bought and pays the entry wait again.
+     */
+    fun shouldRestartLoop(
+        loopActive: Boolean,
+        previousKey: Triple<String, String, String>?,
+        newKey: Triple<String, String, String>,
+    ): Boolean = when {
+        !loopActive -> true
+        previousKey == newKey -> false
+        previousKey != null && isEmptyKey(previousKey) && !isEmptyKey(newKey) -> false
+        else -> true
+    }
+
+    private fun isEmptyKey(key: Triple<String, String, String>): Boolean =
+        key.first.isEmpty() && key.second.isEmpty() && key.third.isEmpty()
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/EarlyWakePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/EarlyWakePolicy.kt
@@ -11,8 +11,9 @@ package com.andrerinas.openheadunit.connection.wifi.modes.nativeaa
 object EarlyWakePolicy {
 
     /**
-     * [listenersOpen] must be the real "the AA RFCOMM listener is accepting" read. A phone woken to
-     * a head unit with no listener finds nothing to dial and the log still says the poke worked.
+     * [listenersOpen] is the manager's "started, and the listener not closed for this session"
+     * read. A phone woken to a head unit with no listener finds nothing to dial and the log still
+     * says the poke worked.
      */
     fun mayWakeBeforeCredentials(
         listenersOpen: Boolean,
@@ -39,6 +40,21 @@ object EarlyWakePolicy {
         else -> true
     }
 
-    private fun isEmptyKey(key: Triple<String, String, String>): Boolean =
+    /**
+     * Whether a wake loop may start with no credentials. Once one has brought the phone back to a
+     * head unit with no network, the next wake waits for the credentials to exist.
+     */
+    fun mayStartWithoutCredentials(keyIsEmpty: Boolean, earlyWakeSpent: Boolean): Boolean =
+        !keyIsEmpty || !earlyWakeSpent
+
+    /**
+     * Whether a handshake that ended for lack of credentials should stop the running wake loop.
+     * Only a loop that started empty: one started by a credential delivery is the ordinary wake,
+     * and a group that went away under it is re-delivered by the recreate.
+     */
+    fun stopAfterCredentialsFailure(loopStartedEmpty: Boolean, credentialsPresent: Boolean): Boolean =
+        loopStartedEmpty && !credentialsPresent
+
+    fun isEmptyKey(key: Triple<String, String, String>): Boolean =
         key.first.isEmpty() && key.second.isEmpty() && key.third.isEmpty()
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/NativeAaHandshakeManager.kt
@@ -54,6 +54,10 @@ class NativeAaHandshakeManager(
         /** How often the poke loop re-asks whether a prompt on screen still holds it off. */
         private const val PROMPT_POLL_MS = 1_000L
 
+        /** Ceiling on waiting for the AA listeners before poking anyway, and how often to ask. */
+        private const val POKE_READY_WAIT_MS = 2_000L
+        private const val POKE_READY_POLL_MS = 100L
+
         /** How long to wait for the AAP TCP port to be bound before giving up on a handshake. */
         private const val PORT_WAIT_MS = 3_000L
 
@@ -1270,6 +1274,23 @@ class NativeAaHandshakeManager(
      * re-delivery, and the phone *joining our group* is itself a P2P connection change, hence a
      * re-delivery. That put a real RFCOMM connect() in the middle of the phone's DHCP exchange.
      */
+    /**
+     * Wakes the phone while the group is still forming, rather than waiting for the credentials it
+     * does not need yet. The handshake opens with the version exchange and waits for credentials
+     * afterwards, so the phone's own wake latency runs alongside the bring-up instead of after it.
+     */
+    fun triggerEarlyWake(userExited: Boolean) {
+        if (!EarlyWakePolicy.mayWakeBeforeCredentials(
+                listenersOpen = isActive(),
+                credentialsPresent = credentials != null,
+                userExited = userExited,
+                sessionUp = commManager.isConnected,
+            )
+        ) return
+        AppLog.i("NativeAA: waking the phone while the WiFi group is still forming.")
+        triggerPoke()
+    }
+
     fun triggerPoke() {
         if (isHandoffSettling()) {
             // Info, not debug: this line is the evidence the suppression is working, and reporter
@@ -1301,8 +1322,9 @@ class NativeAaHandshakeManager(
         // a local called credentials would shadow it with a Triple that is never null.
         val snapshot = credentials
         val pokeKey = Triple(snapshot?.ssid ?: "", snapshot?.ip ?: "", snapshot?.bssid ?: "")
-        if (pokeJob?.isActive == true && pokeKey == lastPokeTriggerCredentials) {
-            AppLog.d("NativeAA: triggerPoke() called again with unchanged credentials while a poke is already running - not restarting it.")
+        if (!EarlyWakePolicy.shouldRestartLoop(pokeJob?.isActive == true, lastPokeTriggerCredentials, pokeKey)) {
+            AppLog.d("NativeAA: a wake poke is already running for these credentials - not restarting it.")
+            lastPokeTriggerCredentials = pokeKey
             return
         }
         lastPokeTriggerCredentials = pokeKey
@@ -1310,8 +1332,14 @@ class NativeAaHandshakeManager(
         pokeJob?.cancel()
         pokeDeferralLogged = false
         pokeJob = scope.launch(Dispatchers.IO + CoroutineName("NativeAa-Wakeup")) {
-            AppLog.d("NativeAA: triggerPoke() delay starting (2s)...")
-            delay(2000) // Small safety delay before connecting
+            // The listeners are what the woken phone dials back on, so wait for them rather than
+            // for a fixed two seconds that was only ever a guess at the same thing.
+            var waitedMs = 0L
+            while (!isActive() && waitedMs < POKE_READY_WAIT_MS && isActive) {
+                delay(POKE_READY_POLL_MS)
+                waitedMs += POKE_READY_POLL_MS
+            }
+            AppLog.d("NativeAA: wake poke starting (listeners ready after ${waitedMs}ms).")
 
             while (isRunning && isActive) {
                 // Asked of the screen, never of the settings, and on every pass rather than once on

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/NativeAaHandshakeManager.kt
@@ -216,6 +216,16 @@ class NativeAaHandshakeManager(
     // WifiDirectManager redelivers the same credentials, which was starving the poke before it
     // could ever finish.
     private var lastPokeTriggerCredentials: Triple<String, String, String>? = null
+
+    /** Whether the running wake loop was started with no credentials, by the early wake. */
+    private var pokeLoopStartedEmpty = false
+
+    /**
+     * Set once an early wake brought the phone back to a head unit with no network to hand it.
+     * Cleared when credentials arrive, so the ordinary credential-driven wake still runs.
+     */
+    @Volatile
+    private var earlyWakeSpent = false
     // elapsedRealtime() when handleHandshake() started, or 0 when no exchange is running; lets
     // WifiDirectManager's join watchdog know a real exchange is in progress.
     //
@@ -515,6 +525,7 @@ class NativeAaHandshakeManager(
     ) {
         AppLog.i("NativeAA: Credentials updated. SSID=$ssid, IP=$ip, BSSID=$bssid, identity stable=${GroupIdentityStabilityPolicy.label(identity)}")
         credentials = WifiCredentials(ssid = ssid, psk = psk, ip = ip, bssid = bssid, identity = identity)
+        earlyWakeSpent = false
     }
 
     /** Clears cached credentials so an in-progress wait doesn't hand out stale ones for a group
@@ -641,6 +652,7 @@ class NativeAaHandshakeManager(
 
         isRunning = true
         notStartedReason = null
+        earlyWakeSpent = false
         aaListenersClosedForSession = false
         // Local Bluetooth radio name; logged on every accept so a dual-radio head unit's logs
         // show which radio the phone actually reached (compare with the HU name in the phone's
@@ -1280,6 +1292,8 @@ class NativeAaHandshakeManager(
      * afterwards, so the phone's own wake latency runs alongside the bring-up instead of after it.
      */
     fun triggerEarlyWake(userExited: Boolean) {
+        // isActive() is "started, and the listener not closed for this session": the accept loop
+        // is launched in the same start() call, so this is as close to "accepting" as there is.
         if (!EarlyWakePolicy.mayWakeBeforeCredentials(
                 listenersOpen = isActive(),
                 credentialsPresent = credentials != null,
@@ -1325,15 +1339,22 @@ class NativeAaHandshakeManager(
         if (!EarlyWakePolicy.shouldRestartLoop(pokeJob?.isActive == true, lastPokeTriggerCredentials, pokeKey)) {
             AppLog.d("NativeAA: a wake poke is already running for these credentials - not restarting it.")
             lastPokeTriggerCredentials = pokeKey
+            // The loop re-reads credentials every pass, so from here it is a credentialed one.
+            if (!EarlyWakePolicy.isEmptyKey(pokeKey)) pokeLoopStartedEmpty = false
+            return
+        }
+        if (!EarlyWakePolicy.mayStartWithoutCredentials(EarlyWakePolicy.isEmptyKey(pokeKey), earlyWakeSpent)) {
+            AppLog.i("NativeAA: not waking the phone again before the WiFi group exists; the last wake brought it back to nothing.")
             return
         }
         lastPokeTriggerCredentials = pokeKey
+        pokeLoopStartedEmpty = EarlyWakePolicy.isEmptyKey(pokeKey)
 
         pokeJob?.cancel()
         pokeDeferralLogged = false
         pokeJob = scope.launch(Dispatchers.IO + CoroutineName("NativeAa-Wakeup")) {
-            // The listeners are what the woken phone dials back on, so wait for them rather than
-            // for a fixed two seconds that was only ever a guess at the same thing.
+            // isActive() goes true in the same start() that launches the accept loop, so this
+            // usually costs nothing; it is here for a poke triggered before start() has run.
             var waitedMs = 0L
             while (!isActive() && waitedMs < POKE_READY_WAIT_MS && isActive) {
                 delay(POKE_READY_POLL_MS)
@@ -1983,6 +2004,16 @@ class NativeAaHandshakeManager(
             val snapshot = credentials
             if (snapshot == null) {
                 AppLog.e("NativeAA: Handshake failed - No WiFi credentials available after ${CREDENTIALS_WAIT_MS / 1000}s wait.")
+                if (EarlyWakePolicy.stopAfterCredentialsFailure(pokeLoopStartedEmpty, credentialsPresent = false)) {
+                    // Woken before the group existed and the group never came. Waking it again
+                    // costs a 60 s wait and a hands-free hold each time for nothing; the
+                    // credential delivery restarts the wake once there is a network to hand over.
+                    AppLog.i("NativeAA: the early wake brought the phone back to no network; not waking it again until the WiFi group exists.")
+                    earlyWakeSpent = true
+                    pokeJob?.cancel()
+                    pokeJob = null
+                    pokeLoopStartedEmpty = false
+                }
                 abortedLocally = true
                 feed(WppEvent.CredentialsUnavailable)
                 return@withContext

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/NativeAaHandshakeManager.kt
@@ -143,7 +143,17 @@ class NativeAaHandshakeManager(
     // closeAaListeners()) without taking down the HFP ones too.
     private val extraAaServerSockets = Collections.synchronizedList(mutableListOf<BluetoothServerSocket>())
     private val extraHfpServerSockets = Collections.synchronizedList(mutableListOf<BluetoothServerSocket>())
-    private var isRunning = false
+    // Read from the poke and handshake loops on Dispatchers.IO and written from start()/stop() on
+    // the caller's thread, so the reads have to see the write.
+    @Volatile private var isRunning = false
+
+    /**
+     * Why [start] gave up, kept for whoever asks later.
+     *
+     * The reason is logged once at arming time and has rotated out of a reporter's buffer long
+     * before they press anything, so a poke on a manager that never started said nothing at all.
+     */
+    @Volatile private var notStartedReason: String? = null
     // Set by closeAaListeners() so the AA accept loops can tell "we closed this on purpose
     // after a successful handoff" apart from a real socket error, for logging only.
     @Volatile private var aaListenersClosedForSession = false
@@ -517,6 +527,16 @@ class NativeAaHandshakeManager(
     // "believed to be running."
     fun isActive(): Boolean = isRunning && !aaListenersClosedForSession
 
+    /**
+     * Whether the handshake servers were ever brought up, as opposed to [isActive]'s "can accept a
+     * connection right now". The two answers need different repairs: a closed listener is reopened
+     * by [rearmForNextSession], and only [start] can help one that was never opened.
+     */
+    fun isStarted(): Boolean = isRunning
+
+    /** Why [start] gave up, for a caller that found [isStarted] false and has to say something useful. */
+    fun notStartedReason(): String? = notStartedReason
+
     fun isHandshakeInFlight(): Boolean =
         NativeHandoffPolicy.isHandshaking(handshakeStartedAt, SystemClock.elapsedRealtime())
 
@@ -590,6 +610,7 @@ class NativeAaHandshakeManager(
         externalBtDiagnostic()?.let {
             if (!externalBtOverridden(context)) {
                 AppLog.e(it)
+                notStartedReason = it
                 return
             }
             AppLog.w("$it\nNativeAA: starting anyway, because the Bluetooth compatibility check is switched off in Settings.")
@@ -599,6 +620,7 @@ class NativeAaHandshakeManager(
             if (ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT)
                 != PackageManager.PERMISSION_GRANTED) {
                 AppLog.e("NativeAA: Missing BLUETOOTH_CONNECT permission. Handshake server cannot start.")
+                notStartedReason = "the app has no BLUETOOTH_CONNECT permission"
                 return
             }
         }
@@ -609,10 +631,12 @@ class NativeAaHandshakeManager(
             // re-arm check) need to see this as genuinely stopped so they retry later,
             // instead of believing the listener sockets are up when nothing was ever opened.
             AppLog.e("NativeAA: Bluetooth adapter not available or disabled")
+            notStartedReason = "this unit's Bluetooth was off or unavailable when the mode was armed"
             return
         }
 
         isRunning = true
+        notStartedReason = null
         aaListenersClosedForSession = false
         // Local Bluetooth radio name; logged on every accept so a dual-radio head unit's logs
         // show which radio the phone actually reached (compare with the HU name in the phone's
@@ -745,7 +769,15 @@ class NativeAaHandshakeManager(
      */
     @SuppressLint("MissingPermission")
     fun rearmForNextSession() {
-        if (!isRunning) return
+        if (!isRunning) {
+            // The one line whose absence made a reporter's capture unreadable: the caller has
+            // already said it is reopening the listeners, and nothing here can.
+            AppLog.w(
+                "NativeAA: the Android Auto listeners cannot be reopened because the handshake " +
+                    "servers are not running" + (notStartedReason?.let { " ($it)" } ?: "") + "."
+            )
+            return
+        }
         // The session that just ended answered the question the prompt asks. The chosen target is
         // left alone: the switch-driver path sets it from a coroutine that races this one.
         clearSelectionPrompt()
@@ -1405,6 +1437,7 @@ class NativeAaHandshakeManager(
                             delay(200)
                             waitedMs += 200
                         }
+                        if (waitedMs == 0 && !isRunning) AppLog.w("NativeAA: not waiting for credentials, because the handshake servers are not running.")
                     }
 
                     // A credential redelivery cancels this loop and starts a fresh one, and cancel
@@ -1484,7 +1517,8 @@ class NativeAaHandshakeManager(
                             delay(200)
                             waitedMs += 200
                         }
-                        AppLog.i("NativeAA: Pre-poke credential wait completed. SSID=${credentials?.ssid}, IP=${credentials?.ip} (waited ${waitedMs}ms)")
+                        val whyNotWaited = if (waitedMs == 0 && !isRunning) ", because the handshake servers are not running" else ""
+                        AppLog.i("NativeAA: Pre-poke credential wait completed. SSID=${credentials?.ssid}, IP=${credentials?.ip} (waited ${waitedMs}ms$whyNotWaited)")
                     }
 
                     // pokeJob.cancel() above cannot interrupt a blocking connect(), so the

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/NativeAaHandshakeManager.kt
@@ -1425,7 +1425,16 @@ class NativeAaHandshakeManager(
                         target.macs.forEach { mac ->
                             val reading = bondReadingFor(adapter, mac)
                             if (BluetoothWakePolicy.mayPoke(reading)) {
-                                try { bonded.add(adapter.getRemoteDevice(mac)) } catch (e: Exception) {}
+                                try {
+                                    val device = adapter.getRemoteDevice(mac)
+                                    val verdict = BluetoothHelper.classifyDevice(
+                                        device, BluetoothHelper.pinFor(
+                                            device, settings.nativePreferredDeviceMac, settings.lastConnectedNativeMac
+                                        )
+                                    )
+                                    AppLog.d("NativeAA: chosen wake target ${device.name} ($mac) reads as ${verdict.verdict}")
+                                    bonded.add(device)
+                                } catch (e: Exception) {}
                             }
                             if (BluetoothWakePolicy.shouldForget(reading)) staleMacs.add(mac)
                         }
@@ -1436,22 +1445,23 @@ class NativeAaHandshakeManager(
                         bonded
                     }
                     PokeTargets.AllPaired -> {
-                        AppLog.w("NativeAA: No wake poke device selected, and poking all paired devices is on. Poking all of them...")
-                        // Only a phone can answer Native AA, and a poke spent on a speaker or a
-                        // watch holds the hands-free slot for nothing. Fall back to the whole set
-                        // when the filter leaves none, so an unreadable device class cannot go mute.
-                        val allPaired = adapter.bondedDevices.toList()
-                        val phones = allPaired.filter {
-                            BluetoothHelper.isLikelyPhone(
-                                it, settings.nativePreferredDeviceMac, settings.lastConnectedNativeMac
+                        AppLog.w("NativeAA: No wake poke device selected, and poking all paired devices is on. Poking every paired phone...")
+                        // Only a phone answers Native AA: the one advertising the Audio Gateway
+                        // record this poke dials. A dongle, a radio or a watch holds the hands-free
+                        // slot for nothing, so a device ruled out is never poked here; a MAC chosen
+                        // in Auto Start settings is poked without this question.
+                        val candidates = BluetoothHelper.driverCandidates(
+                            context, settings.nativePreferredDeviceMac, settings.lastConnectedNativeMac
+                        )
+                        if (candidates.offered.isEmpty()) {
+                            AppLog.w(
+                                "NativeAA: no paired device advertises the Audio Gateway record, so nothing " +
+                                    "is poked. Choose the phone in Auto Start settings if this is wrong."
                             )
+                        } else if (candidates.hidden.isNotEmpty()) {
+                            AppLog.i("NativeAA: ${candidates.hidden.size} paired device(s) are not phones and are not poked.")
                         }
-                        if (phones.isEmpty()) allPaired else {
-                            if (phones.size < allPaired.size) {
-                                AppLog.i("NativeAA: ${allPaired.size - phones.size} paired device(s) are not phones and are not poked.")
-                            }
-                            phones
-                        }
+                        candidates.offered
                     }
                     PokeTargets.None -> {
                         AppLog.w("NativeAA: No wake poke device selected, so nothing is poked. Choose one in Auto Start settings.")

--- a/app/src/main/java/com/andrerinas/openheadunit/main/HomeFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/HomeFragment.kt
@@ -24,6 +24,7 @@ import androidx.navigation.fragment.findNavController
 import android.os.Build
 import android.bluetooth.BluetoothDevice
 import android.os.CountDownTimer
+import com.andrerinas.openheadunit.connection.wifi.modes.nativeaa.DriverCandidatePolicy
 import com.andrerinas.openheadunit.connection.wifi.modes.nativeaa.NativeDriverSelectionPolicy
 import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.R
@@ -521,13 +522,11 @@ class HomeFragment : Fragment() {
                         bluetoothPermissionLauncher.launch(android.Manifest.permission.BLUETOOTH_CONNECT)
                     } else {
                         val appSettings = App.provide(requireContext()).settings
-                        val adapter = BluetoothHelper.getBluetoothAdapter(requireContext())
-                        val bonded = adapter?.bondedDevices?.toList() ?: emptyList()
-                        val connected = BluetoothHelper.getConnectedBluetoothDevices(requireContext())
-                        val likelyPhones = bonded.filter {
-                            BluetoothHelper.isLikelyPhone(it, appSettings.nativePreferredDeviceMac, appSettings.lastConnectedNativeMac)
-                        }
-                        val candidates = if (likelyPhones.isNotEmpty()) likelyPhones else bonded
+                        val cands = BluetoothHelper.driverCandidates(
+                            requireContext(), appSettings.nativePreferredDeviceMac, appSettings.lastConnectedNativeMac
+                        )
+                        val candidates = cands.offered
+                        val connectedMacs = cands.connectedOffered.map { it.address }
                         val hasHistory = appSettings.lastConnectedNativeMac.isNotEmpty() ||
                             appSettings.nativePreferredDeviceMac.isNotEmpty() ||
                             appSettings.nativePokeBtMacs.isNotEmpty()
@@ -537,22 +536,22 @@ class HomeFragment : Fragment() {
                             lastUsedMac = NativeDriverSelectionPolicy.lastUsedMac(
                                 appSettings.lastConnectedNativeMac, appSettings.nativePokeBtMacs
                             ),
-                            connectedMacs = connected.map { it.address },
+                            connectedMacs = connectedMacs,
                             pairedMacs = candidates.map { it.address }
                         )
 
                         val shouldShow = NativeDriverSelectionPolicy.shouldShowSelector(
                             mode = appSettings.nativeDriverSelectionMode,
                             pairedCount = candidates.size,
-                            connectedCount = connected.size,
+                            connectedCount = connectedMacs.size,
                             hasHistory = hasHistory
                         )
 
                         if (appSettings.nativeDriverSelectionMode == NativeDriverSelectionPolicy.Mode.DISABLED) {
                             if (autoTargetMac != null) {
-                                val targetDev = bonded.firstOrNull { it.address.equals(autoTargetMac, ignoreCase = true) }
+                                val targetDev = cands.deviceFor(autoTargetMac)
                                 val devName = targetDev?.name ?: autoTargetMac
-                                connectToNativeDevice(autoTargetMac, devName, connected.map { it.address })
+                                connectToNativeDevice(autoTargetMac, devName, connectedMacs)
                             } else if (candidates.size == 1) {
                                 Toast.makeText(requireContext(), getString(R.string.searching_phone), Toast.LENGTH_SHORT).show()
                                 val intent = Intent(requireContext(), AapService::class.java).apply {
@@ -567,9 +566,9 @@ class HomeFragment : Fragment() {
                                 showNativeAaDeviceSelector(autoCountdown = false)
                             }
                         } else if (!shouldShow && autoTargetMac != null) {
-                            val targetDev = bonded.firstOrNull { it.address.equals(autoTargetMac, ignoreCase = true) }
+                            val targetDev = cands.deviceFor(autoTargetMac)
                             val devName = targetDev?.name ?: autoTargetMac
-                            connectToNativeDevice(autoTargetMac, devName, connected.map { it.address })
+                            connectToNativeDevice(autoTargetMac, devName, connectedMacs)
                         } else {
                             showNativeAaDeviceSelector(autoCountdown = false)
                         }
@@ -727,14 +726,13 @@ class HomeFragment : Fragment() {
         val adapter = BluetoothHelper.getBluetoothAdapter(requireContext())
         if (adapter == null || !adapter.isEnabled) return
 
-        val bonded = adapter.bondedDevices?.toList() ?: emptyList()
-        val connected = BluetoothHelper.getConnectedBluetoothDevices(requireContext())
-
-        // Filter likely phones so non-phone accessories (speakers, headphones, watches) don't trigger multi-device prompt
-        val likelyPhones = bonded.filter {
-            BluetoothHelper.isLikelyPhone(it, appSettings.nativePreferredDeviceMac, appSettings.lastConnectedNativeMac)
-        }
-        val targetList = if (likelyPhones.isNotEmpty()) likelyPhones else bonded
+        // Only the classified phones count, so a connected watch neither becomes the driver nor
+        // hides the one phone that is unambiguously here.
+        val cands = BluetoothHelper.driverCandidates(
+            requireContext(), appSettings.nativePreferredDeviceMac, appSettings.lastConnectedNativeMac
+        )
+        val targetList = cands.offered
+        val connectedMacs = cands.connectedOffered.map { it.address }
 
         val effectiveLastUsedMac = NativeDriverSelectionPolicy.lastUsedMac(
             appSettings.lastConnectedNativeMac, appSettings.nativePokeBtMacs
@@ -744,24 +742,24 @@ class HomeFragment : Fragment() {
         val shouldShow = NativeDriverSelectionPolicy.shouldShowSelector(
             mode = appSettings.nativeDriverSelectionMode,
             pairedCount = targetList.size,
-            connectedCount = connected.size,
+            connectedCount = connectedMacs.size,
             hasHistory = hasHistory
         )
 
         val autoTargetMac = NativeDriverSelectionPolicy.resolveAutoConnectTarget(
             preferredMac = appSettings.nativePreferredDeviceMac,
             lastUsedMac = effectiveLastUsedMac,
-            connectedMacs = connected.map { it.address },
+            connectedMacs = connectedMacs,
             pairedMacs = targetList.map { it.address }
         )
 
         if (shouldShow) {
             showNativeAaDeviceSelector(autoCountdown = true)
         } else if (appSettings.nativeDriverSelectionMode == NativeDriverSelectionPolicy.Mode.AUTO && autoTargetMac != null) {
-            val targetDev = bonded.firstOrNull { it.address.equals(autoTargetMac, ignoreCase = true) }
+            val targetDev = cands.deviceFor(autoTargetMac)
             val devName = targetDev?.name ?: autoTargetMac
             AppLog.i("HomeFragment: Unambiguous driver ($devName) - auto-connecting directly without prompt")
-            connectToNativeDevice(autoTargetMac, devName, connected.map { it.address })
+            connectToNativeDevice(autoTargetMac, devName, connectedMacs)
         }
     }
 
@@ -774,25 +772,22 @@ class HomeFragment : Fragment() {
             return
         }
 
-        val bondedDevices = adapter.bondedDevices?.toList() ?: emptyList()
+        val appSettings = App.provide(requireContext()).settings
+        val preferredMac = appSettings.nativePreferredDeviceMac
+        val lastUsedMac = appSettings.lastConnectedNativeMac
+        val cands = BluetoothHelper.driverCandidates(requireContext(), preferredMac, lastUsedMac)
+        val bondedDevices = cands.all.map { it.device }
         if (bondedDevices.isEmpty()) {
             Toast.makeText(requireContext(), "No paired Bluetooth devices found", Toast.LENGTH_SHORT).show()
             return
         }
 
-        val appSettings = App.provide(requireContext()).settings
-        val connectedDevices = BluetoothHelper.getConnectedBluetoothDevices(requireContext())
-        val connectedMacs = connectedDevices.map { it.address }
-        // An empty connected set means nothing is connected only if the read works at all. Ask once,
-        // so a stack that cannot answer leaves every row unlabelled instead of calling them all absent.
-        val presenceReadable = bondedDevices.any { BluetoothHelper.deviceConnectionState(it) != null }
-        val preferredMac = appSettings.nativePreferredDeviceMac
-        val lastUsedMac = appSettings.lastConnectedNativeMac
+        // Row labels say who is here, phone or not. The count and the countdown target below ask
+        // only the phones, and an unreadable presence leaves every row unlabelled.
+        val connectedMacs = cands.connectedAll.map { it.address }
+        val presenceReadable = cands.presenceReadable
 
-        // Filter out obvious non-phone accessories (BT speakers, headphones, wearables)
-        val likelyPhones = bondedDevices.filter {
-            BluetoothHelper.isLikelyPhone(it, preferredMac, lastUsedMac)
-        }
+        val likelyPhones = cands.offered
         var showAllDevices = likelyPhones.isEmpty()
         val initialCandidates = if (showAllDevices) bondedDevices else likelyPhones
 
@@ -830,7 +825,7 @@ class HomeFragment : Fragment() {
                 val badgeView = view.findViewById<TextView>(R.id.badgeText)
 
                 val iconView = view.findViewById<ImageView>(R.id.deviceIcon)
-                if (BluetoothHelper.isLikelyPhone(device, preferredMac, lastUsedMac)) {
+                if (cands.verdictOf(device.address) != DriverCandidatePolicy.Verdict.NOT_A_PHONE) {
                     iconView.setImageResource(R.drawable.ic_phone)
                 } else {
                     iconView.setImageResource(R.drawable.ic_headphones)
@@ -955,26 +950,29 @@ class HomeFragment : Fragment() {
             driverCountdownTimer?.cancel()
             driverCountdownTimer = null
             activeDialog = null
-            if (!selectionResolved) {
+            val ctx = context
+            if (!selectionResolved && ctx != null) {
                 // onPause dismisses the dialog, which reaches here and never onCancel. Without
                 // this the prompt flag stayed set and every phone was refused.
-                val dismissIntent = Intent(requireContext(), AapService::class.java).apply {
+                val dismissIntent = Intent(ctx, AapService::class.java).apply {
                     action = AapService.ACTION_NATIVE_AA_PROMPT_DISMISSED
                 }
-                ContextCompat.startForegroundService(requireContext(), dismissIntent)
+                ContextCompat.startForegroundService(ctx, dismissIntent)
             }
         }
 
         val effectiveLastUsed = NativeDriverSelectionPolicy.lastUsedMac(
             lastUsedMac, appSettings.nativePokeBtMacs
         )
+        // Scoped to the phones whatever "Show all" is showing, so widening the list never changes
+        // what the countdown connects to.
         val autoTargetMac = NativeDriverSelectionPolicy.resolveAutoConnectTarget(
             preferredMac = preferredMac,
             lastUsedMac = effectiveLastUsed,
-            connectedMacs = connectedMacs,
-            pairedMacs = currentDevices.map { it.address }
+            connectedMacs = cands.connectedOffered.map { it.address },
+            pairedMacs = likelyPhones.map { it.address }
         )
-        val autoTargetDevice = bondedDevices.firstOrNull { it.address.equals(autoTargetMac, ignoreCase = true) }
+        val autoTargetDevice = cands.deviceFor(autoTargetMac)
         val targetName = autoTargetDevice?.name ?: autoTargetMac ?: ""
 
         deviceListView.setOnItemClickListener { _, _, position, _ ->
@@ -1019,11 +1017,14 @@ class HomeFragment : Fragment() {
         }
 
         dialog.setOnShowListener {
+            // An activity relaunch between show() and this callback leaves it queued against a
+            // destroyed fragment; the fragment that replaced this one opens its own selector.
+            val ctx = context ?: return@setOnShowListener
             (activity as? MainActivity)?.dismissSplashImmediately()
-            val promptIntent = Intent(requireContext(), AapService::class.java).apply {
+            val promptIntent = Intent(ctx, AapService::class.java).apply {
                 action = AapService.ACTION_NATIVE_AA_PROMPT_SHOWN
             }
-            ContextCompat.startForegroundService(requireContext(), promptIntent)
+            ContextCompat.startForegroundService(ctx, promptIntent)
             if (autoCountdown && autoTargetMac != null) {
                 driverCountdownTimer?.start()
             }

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -164,6 +164,10 @@ class SettingsFragment : Fragment() {
     private var pendingScreenOrientation: Settings.ScreenOrientation? = null
     private var pendingAppLanguage: String? = null
     private var pendingFakeSpeed: Boolean? = null
+    private var pendingNarrowBandProfileCap: Boolean? = null
+    private var pendingDebugVideoLowLatency: Boolean? = null
+    private var pendingAllowExternalConfiguration: Boolean? = null
+    private var pendingKeepDummyVpnDuringSession: Boolean? = null
 
     private var pendingWifiConnectionMode: WifiLauncherMode? = null
     private var pendingHelperConnectionStrategy: HelperStrategy? = null
@@ -179,6 +183,7 @@ class SettingsFragment : Fragment() {
     private var pendingNativeDriverSelectionTimeout: Int? = null
     private var pendingNativePreferredDeviceMac: String? = null
     private var pendingWifiDirectBand: Int? = null
+    private var pendingWifiDirectStableIdentity: Boolean? = null
     private var pendingHotspotBand: Int? = null
     private var pendingFiveGhzChannel: Int? = null
     private var pendingHotspotSsid: String? = null
@@ -235,11 +240,14 @@ class SettingsFragment : Fragment() {
     // afterwards, so this dialog is the one moment a Fragment has to be involved. AapService can
     // start the VPN with no Activity once this has run. On the Play Store flavor the toggle that
     // launches this is never rendered, because VpnControl.isVpnAvailable() is false there.
-    private var pendingKeepDummyVpn = false
+    private var vpnConsentRequested = false
     private val vpnConsentLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
         val granted = result.resultCode == android.app.Activity.RESULT_OK
-        settings.keepDummyVpnDuringSession = granted && pendingKeepDummyVpn
-        pendingKeepDummyVpn = false
+        if (vpnConsentRequested) {
+            pendingKeepDummyVpnDuringSession = granted
+            checkChanges()
+        }
+        vpnConsentRequested = false
         if (!granted && VpnControl.consentDeniedRes != 0) {
             Toast.makeText(requireContext(), VpnControl.consentDeniedRes, Toast.LENGTH_LONG).show()
         }
@@ -338,6 +346,10 @@ class SettingsFragment : Fragment() {
         pendingAutoEnableHotspot = settings.autoEnableHotspot
         pendingFakeSpeed = settings.fakeSpeed
         pendingUseLibusb = settings.useLibusb
+        pendingNarrowBandProfileCap = settings.narrowBandProfileCap
+        pendingDebugVideoLowLatency = settings.debugVideoLowLatency
+        pendingAllowExternalConfiguration = settings.allowExternalConfiguration
+        pendingKeepDummyVpnDuringSession = settings.keepDummyVpnDuringSession
 
         pendingWifiConnectionMode = settings.wifiConnectionMode
         pendingHelperConnectionStrategy = settings.helperConnectionStrategy
@@ -352,6 +364,7 @@ class SettingsFragment : Fragment() {
         pendingNativeDriverSelectionTimeout = settings.nativeDriverSelectionTimeoutSec
         pendingNativePreferredDeviceMac = settings.nativePreferredDeviceMac
         pendingWifiDirectBand = settings.wifiDirectBand
+        pendingWifiDirectStableIdentity = settings.wifiDirectStableIdentity
         pendingHotspotBand = settings.hotspotBand
         pendingFiveGhzChannel = settings.fiveGhzChannel
         pendingHotspotSsid = settings.hotspotSsid
@@ -465,6 +478,10 @@ class SettingsFragment : Fragment() {
         pendingAutoEnableHotspot = settings.autoEnableHotspot
         pendingFakeSpeed = settings.fakeSpeed
         pendingUseLibusb = settings.useLibusb
+        pendingNarrowBandProfileCap = settings.narrowBandProfileCap
+        pendingDebugVideoLowLatency = settings.debugVideoLowLatency
+        pendingAllowExternalConfiguration = settings.allowExternalConfiguration
+        pendingKeepDummyVpnDuringSession = settings.keepDummyVpnDuringSession
         pendingWifiConnectionMode = settings.wifiConnectionMode
         pendingHelperConnectionStrategy = settings.helperConnectionStrategy
         pendingWaitForWifi = settings.waitForWifiBeforeWifiDirect
@@ -478,6 +495,7 @@ class SettingsFragment : Fragment() {
         pendingNativeDriverSelectionTimeout = NativeDriverSelectionPolicy.DEFAULT_TIMEOUT_SEC
         pendingNativePreferredDeviceMac = ""
         pendingWifiDirectBand = settings.wifiDirectBand
+        pendingWifiDirectStableIdentity = settings.wifiDirectStableIdentity
         pendingHotspotBand = settings.hotspotBand
         pendingFiveGhzChannel = settings.fiveGhzChannel
         pendingHotspotSsid = settings.hotspotSsid
@@ -623,6 +641,10 @@ class SettingsFragment : Fragment() {
         pendingAutoEnableHotspot?.let { settings.autoEnableHotspot = it }
         pendingFakeSpeed?.let { settings.fakeSpeed = it }
         pendingUseLibusb?.let { settings.useLibusb = it }
+        pendingNarrowBandProfileCap?.let { settings.narrowBandProfileCap = it }
+        pendingDebugVideoLowLatency?.let { settings.debugVideoLowLatency = it }
+        pendingAllowExternalConfiguration?.let { settings.allowExternalConfiguration = it }
+        pendingKeepDummyVpnDuringSession?.let { settings.keepDummyVpnDuringSession = it }
 
         val wirelessConfigBefore = wirelessRearmConfig()
         pendingWifiConnectionMode?.let { settings.wifiConnectionMode = it }
@@ -638,6 +660,7 @@ class SettingsFragment : Fragment() {
         pendingNativeDriverSelectionTimeout?.let { settings.nativeDriverSelectionTimeoutSec = it }
         pendingNativePreferredDeviceMac?.let { settings.nativePreferredDeviceMac = it }
         pendingWifiDirectBand?.let { settings.wifiDirectBand = it }
+        pendingWifiDirectStableIdentity?.let { settings.wifiDirectStableIdentity = it }
         pendingHotspotBand?.let { settings.hotspotBand = it }
         pendingFiveGhzChannel?.let { settings.fiveGhzChannel = it }
         pendingHotspotSsid?.let { settings.hotspotSsid = it }
@@ -764,12 +787,17 @@ class SettingsFragment : Fragment() {
                         pendingNativeDriverSelectionTimeout != settings.nativeDriverSelectionTimeoutSec ||
                         pendingNativePreferredDeviceMac != settings.nativePreferredDeviceMac ||
                         pendingWifiDirectBand != settings.wifiDirectBand ||
+                        pendingWifiDirectStableIdentity != settings.wifiDirectStableIdentity ||
                         pendingHotspotBand != settings.hotspotBand ||
                         pendingFiveGhzChannel != settings.fiveGhzChannel ||
                         pendingHotspotSsid != settings.hotspotSsid ||
                         pendingHotspotPassword != settings.hotspotPassword ||
                         pendingHotspotInterface != settings.hotspotInterface ||
                         pendingUseLibusb != settings.useLibusb ||
+                        pendingNarrowBandProfileCap != settings.narrowBandProfileCap ||
+                        pendingDebugVideoLowLatency != settings.debugVideoLowLatency ||
+                        pendingAllowExternalConfiguration != settings.allowExternalConfiguration ||
+                        pendingKeepDummyVpnDuringSession != settings.keepDummyVpnDuringSession ||
                         pendingHideBatteryLevel != settings.hideBatteryLevel ||
                         pendingHidePhoneSignal != settings.hidePhoneSignal ||
                         pendingHideClock != settings.hideClock
@@ -1281,21 +1309,23 @@ class SettingsFragment : Fragment() {
                     // resources so it is absent from the Play Store build entirely.
                     nameResId = VpnControl.toggleNameRes,
                     descriptionResId = VpnControl.toggleDescriptionRes,
-                    isChecked = settings.keepDummyVpnDuringSession,
+                    isChecked = pendingKeepDummyVpnDuringSession ?: settings.keepDummyVpnDuringSession,
                     searchKeywords = "vpn offline tun stutter dropout audio video 2.4 ghz network scan",
                     onCheckedChanged = { isChecked ->
                         if (!isChecked) {
-                            settings.keepDummyVpnDuringSession = false
+                            pendingKeepDummyVpnDuringSession = false
+                            checkChanges()
                             updateSettingsList()
                         } else {
                             // Null once this app is already the prepared VPN app, which is the
                             // state AapService needs to start it with no Activity.
                             val consent = VpnControl.consentIntent(requireContext())
                             if (consent == null) {
-                                settings.keepDummyVpnDuringSession = true
+                                pendingKeepDummyVpnDuringSession = true
+                                checkChanges()
                                 updateSettingsList()
                             } else {
-                                pendingKeepDummyVpn = true
+                                vpnConsentRequested = true
                                 vpnConsentLauncher.launch(consent)
                             }
                         }
@@ -2023,25 +2053,25 @@ class SettingsFragment : Fragment() {
             stableId = "narrowBandProfileCap",
             nameResId = R.string.narrow_band_profile_cap,
             descriptionResId = R.string.narrow_band_profile_cap_description,
-            isChecked = settings.narrowBandProfileCap,
+            isChecked = pendingNarrowBandProfileCap ?: settings.narrowBandProfileCap,
             searchKeywords = "2.4 GHz band resolution fps limit hotspot wifi direct video",
             onCheckedChanged = { isChecked ->
-                settings.narrowBandProfileCap = isChecked
+                pendingNarrowBandProfileCap = isChecked
+                checkChanges()
                 updateSettingsList()
             }
         ))
 
-        // Applied immediately rather than on confirm, unlike the rows above it: the configure
-        // ladder falls back on its own if the decoder rejects the key, so there is nothing to
-        // weigh up before trying it.
+        // Safe to try: the configure ladder falls back on its own if the decoder rejects the key.
         items.add(SettingItem.ToggleSettingEntry(
             stableId = "debugVideoLowLatency",
             nameResId = R.string.debug_video_low_latency,
             descriptionResId = R.string.debug_video_low_latency_description,
-            isChecked = settings.debugVideoLowLatency,
+            isChecked = pendingDebugVideoLowLatency ?: settings.debugVideoLowLatency,
             searchKeywords = "low latency vendor key decoder mediatek amlogic qualcomm exynos",
             onCheckedChanged = { isChecked ->
-                settings.debugVideoLowLatency = isChecked
+                pendingDebugVideoLowLatency = isChecked
+                checkChanges()
                 updateSettingsList()
             }
         ))
@@ -2530,9 +2560,10 @@ class SettingsFragment : Fragment() {
             stableId = "allowExternalConfiguration",
             nameResId = R.string.allow_external_configuration,
             descriptionResId = R.string.allow_external_configuration_description,
-            isChecked = settings.allowExternalConfiguration,
+            isChecked = pendingAllowExternalConfiguration ?: settings.allowExternalConfiguration,
             onCheckedChanged = { isChecked ->
-                settings.allowExternalConfiguration = isChecked
+                pendingAllowExternalConfiguration = isChecked
+                checkChanges()
                 updateSettingsList()
             }
         ))
@@ -4004,9 +4035,8 @@ class SettingsFragment : Fragment() {
      * Whether the group keeps its name and passphrase between bring-ups, and a way to draw new ones.
      *
      * Only where the group is ours to name: the hotspot's identity is the access point's own. The
-     * switch writes straight through rather than through the pending/apply pattern, because it is
-     * read at the next create and nothing needs re-arming for it. The "new identity" action replaces both halves
-     * together, which is the one rotation a phone's saved profile survives.
+     * switch is read at the next create, so Save needs no re-arm for it. The "new identity" action
+     * replaces both halves together, which is the one rotation a phone's saved profile survives.
      */
     private fun addWifiDirectIdentitySettings(items: MutableList<SettingItem>) {
         // Below API 29 the app cannot name the group at all: the platform picks the name and keeps
@@ -4017,14 +4047,15 @@ class SettingsFragment : Fragment() {
             nameResId = R.string.wifi_direct_stable_identity,
             descriptionResId = if (appNamesGroup) R.string.wifi_direct_stable_identity_description
                 else R.string.wifi_direct_stable_identity_description_legacy,
-            isChecked = settings.wifiDirectStableIdentity,
+            isChecked = pendingWifiDirectStableIdentity ?: settings.wifiDirectStableIdentity,
             searchKeywords = "persistent group ssid passphrase password same network reconnect faster",
             onCheckedChanged = { isChecked ->
-                settings.wifiDirectStableIdentity = isChecked
+                pendingWifiDirectStableIdentity = isChecked
+                checkChanges()
                 updateSettingsList()
             }
         ))
-        if (!settings.wifiDirectStableIdentity) return
+        if (pendingWifiDirectStableIdentity == false) return
         items.add(SettingItem.SettingEntry(
             stableId = "wifiDirectNewIdentity",
             nameResId = R.string.wifi_direct_new_identity,

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -1198,20 +1198,17 @@ class SettingsFragment : Fragment() {
                     nameResId = R.string.native_driver_preferred_device,
                     value = prefDeviceName,
                     onClick = { _ ->
+                        // Only a phone can be the preferred phone: a watch chosen here used to
+                        // count as one everywhere. A stored non-phone is cleared with None.
                         val likelyPhones = bonded.filter {
                             BluetoothHelper.isLikelyPhone(it, preferredMac = currentPrefMac)
                         }
-                        val otherDevices = bonded.filter { it !in likelyPhones }
 
                         val options = mutableListOf<Pair<String, String>>()
                         options.add("" to getString(R.string.driver_none))
                         likelyPhones.forEach { dev ->
                             val name = dev.name ?: "Unknown"
                             options.add(dev.address to "$name (${dev.address})")
-                        }
-                        otherDevices.forEach { dev ->
-                            val name = dev.name ?: "Unknown"
-                            options.add(dev.address to "🎧 $name (${dev.address})")
                         }
                         val labels = options.map { it.second }.toTypedArray()
                         val selectedIdx = options.indexOfFirst { it.first.equals(currentPrefMac, ignoreCase = true) }.coerceAtLeast(0)

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -28,6 +28,7 @@ import com.andrerinas.openheadunit.aap.AapService
 import com.andrerinas.openheadunit.connection.wifi.modes.nativeaa.CredentialField
 import com.andrerinas.openheadunit.input.MediaKeyRoutingPolicy
 import com.andrerinas.openheadunit.connection.wifi.direct.P2pGroupIdentityPolicy
+import com.andrerinas.openheadunit.connection.wifi.direct.P2pIdentityRotationPolicy
 import com.andrerinas.openheadunit.connection.wifi.modes.nativeaa.NativeCredentialsPreflightPolicy
 import com.andrerinas.openheadunit.connection.wifi.modes.nativeaa.NativeDriverSelectionPolicy
 import com.andrerinas.openheadunit.aap.NativeTransport
@@ -4008,10 +4009,14 @@ class SettingsFragment : Fragment() {
      * together, which is the one rotation a phone's saved profile survives.
      */
     private fun addWifiDirectIdentitySettings(items: MutableList<SettingItem>) {
+        // Below API 29 the app cannot name the group at all: the platform picks the name and keeps
+        // its own profile, so the toggle and the row describe that arrangement instead of this one.
+        val appNamesGroup = Build.VERSION.SDK_INT >= P2pIdentityRotationPolicy.NAMED_CREATE_SDK
         items.add(SettingItem.ToggleSettingEntry(
             stableId = "wifiDirectStableIdentity",
             nameResId = R.string.wifi_direct_stable_identity,
-            descriptionResId = R.string.wifi_direct_stable_identity_description,
+            descriptionResId = if (appNamesGroup) R.string.wifi_direct_stable_identity_description
+                else R.string.wifi_direct_stable_identity_description_legacy,
             isChecked = settings.wifiDirectStableIdentity,
             searchKeywords = "persistent group ssid passphrase password same network reconnect faster",
             onCheckedChanged = { isChecked ->
@@ -4023,7 +4028,10 @@ class SettingsFragment : Fragment() {
         items.add(SettingItem.SettingEntry(
             stableId = "wifiDirectNewIdentity",
             nameResId = R.string.wifi_direct_new_identity,
-            value = settings.wifiDirectGroupIdentity?.networkName
+            // The name the app asked for where it names the group, and the one the last group
+            // actually came up under where the platform does.
+            value = (if (appNamesGroup) settings.wifiDirectGroupIdentity?.networkName
+                else settings.wifiDirectLastGroup?.ssid)
                 ?: getString(R.string.wifi_direct_new_identity_none),
             searchKeywords = "forget reset ssid passphrase password group name",
             onClick = { _ ->
@@ -4031,9 +4039,32 @@ class SettingsFragment : Fragment() {
                     .setTitle(R.string.wifi_direct_new_identity)
                     .setMessage(R.string.wifi_direct_new_identity_confirm)
                     .setPositiveButton(android.R.string.ok) { _, _ ->
-                        settings.wifiDirectGroupIdentity =
-                            P2pGroupIdentityPolicy.mint(AapService.wifiDirectName.value)
-                        Toast.makeText(requireContext(), R.string.wifi_direct_new_identity_done, Toast.LENGTH_LONG).show()
+                        if (appNamesGroup) {
+                            settings.wifiDirectGroupIdentity =
+                                P2pGroupIdentityPolicy.mint(AapService.wifiDirectName.value)
+                        } else {
+                            settings.wifiDirectRotationPending = true
+                        }
+                        requireContext().startService(
+                            Intent(requireContext(), AapService::class.java).apply {
+                                action = AapService.ACTION_ROTATE_WIFI_DIRECT_IDENTITY
+                            }
+                        )
+                        // The saved mode, not the pending one: the running launcher is what the
+                        // service asks, and it is still the authority on whether this applies now.
+                        // A handshake is invisible from here, so the toast can only be hopeful.
+                        val appliesNow = P2pIdentityRotationPolicy.applyNow(
+                            sessionLive = App.provide(requireContext()).commManager.isConnected,
+                            handshakeInFlight = false,
+                            nativeWifiDirectActive = settings.wifiConnectionMode == WifiLauncherMode.NATIVE &&
+                                settings.nativeApStrategy == NativeStrategy.WIFI_DIRECT,
+                        )
+                        Toast.makeText(
+                            requireContext(),
+                            if (appliesNow) R.string.wifi_direct_new_identity_applied
+                            else R.string.wifi_direct_new_identity_done,
+                            Toast.LENGTH_LONG
+                        ).show()
                         updateSettingsList()
                     }
                     .setNegativeButton(android.R.string.cancel, null)

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.os.Build
 import android.os.IBinder
 import com.andrerinas.openheadunit.App
+import com.andrerinas.openheadunit.connection.wifi.modes.nativeaa.DriverCandidatePolicy
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 
@@ -247,70 +248,123 @@ object BluetoothHelper {
      */
     fun isDeviceConnected(device: BluetoothDevice): Boolean = deviceConnectionState(device) == true
 
+    /** One bonded device with the policy's verdict on it. */
+    data class DriverCandidate(
+        val device: BluetoothDevice,
+        val classification: DriverCandidatePolicy.Classification,
+        val connected: Boolean
+    ) {
+        val verdict: DriverCandidatePolicy.Verdict get() = classification.verdict
+    }
+
     /**
-     * Determines whether a Bluetooth device is likely to be a smartphone / Android Auto candidate,
-     * as opposed to dedicated audio accessories (Bluetooth speakers, headphones, headsets),
-     * wearables (watches), or peripherals (keyboards, mice).
-     *
-     * Never filters out a device that the user previously connected to or designated as preferred.
-     * Safe on all Android versions (SDK 16+).
+     * Every bonded device classified, and the tier offered as a driver: the phones, else the
+     * devices nothing could classify, never the ones ruled out. Those stay reachable by a
+     * deliberate tap under "Show all"; nothing automatic reaches for them.
+     */
+    class DriverCandidates(val all: List<DriverCandidate>, val presenceReadable: Boolean) {
+        val offeredVerdict: DriverCandidatePolicy.Verdict =
+            DriverCandidatePolicy.offeredVerdict(all.map { it.verdict })
+        val offered: List<BluetoothDevice> =
+            if (offeredVerdict == DriverCandidatePolicy.Verdict.NOT_A_PHONE) emptyList()
+            else all.filter { it.verdict == offeredVerdict }.map { it.device }
+        val hidden: List<DriverCandidate> = all.filter { it.verdict != offeredVerdict || offered.isEmpty() }
+        val connectedAll: List<BluetoothDevice> = all.filter { it.connected }.map { it.device }
+        val connectedOffered: List<BluetoothDevice> =
+            connectedAll.filter { device -> offered.any { it.address == device.address } }
+
+        fun verdictOf(mac: String): DriverCandidatePolicy.Verdict =
+            all.firstOrNull { it.device.address.equals(mac, ignoreCase = true) }?.verdict
+                ?: DriverCandidatePolicy.Verdict.UNKNOWN
+
+        fun deviceFor(mac: String?): BluetoothDevice? =
+            mac?.let { m -> all.firstOrNull { it.device.address.equals(m, ignoreCase = true) }?.device }
+    }
+
+    @Volatile
+    private var lastCandidateSummary: String? = null
+
+    /**
+     * The bonded devices classified for driver selection and the wake poke. Enumerated every poke
+     * round and every resume, so the roll-up is INFO only when its composition changes.
+     */
+    @SuppressLint("MissingPermission")
+    fun driverCandidates(context: Context, preferredMac: String, lastConnectedMac: String): DriverCandidates {
+        val adapter = try { getBluetoothAdapter(context) } catch (e: Exception) { null }
+        val bonded = try { adapter?.bondedDevices?.toList() ?: emptyList() } catch (e: Exception) { emptyList() }
+        var presenceReadable = false
+        val all = bonded.map { device ->
+            val state = deviceConnectionState(device)
+            if (state != null) presenceReadable = true
+            val classification = classifyDevice(device, pinFor(device, preferredMac, lastConnectedMac))
+            AppLog.d(
+                "BluetoothHelper: driver candidate ${device.name} (${device.address}) -> " +
+                    "${classification.verdict}, ${DriverCandidatePolicy.reasonText(classification, deviceClassOf(device))}"
+            )
+            DriverCandidate(device, classification, state == true)
+        }
+        val candidates = DriverCandidates(all, presenceReadable)
+        val counts = DriverCandidatePolicy.Verdict.entries.joinToString(", ") { verdict ->
+            "${all.count { it.verdict == verdict }} ${verdict.name.lowercase().replace('_', ' ')}"
+        }
+        val hidden = candidates.hidden.joinToString {
+            "${it.device.name} (${it.classification.reason.name.lowercase().replace('_', ' ')})"
+        }
+        val summary = "BluetoothHelper: driver candidates: $counts" +
+            if (hidden.isEmpty()) "" else " - hidden: $hidden"
+        if (summary != lastCandidateSummary) {
+            lastCandidateSummary = summary
+            AppLog.i(summary)
+        } else {
+            AppLog.d(summary)
+        }
+        return candidates
+    }
+
+    /** The policy's verdict on one device, read from what the bond cached: records, class, type. */
+    @SuppressLint("MissingPermission")
+    fun classifyDevice(device: BluetoothDevice, pin: DriverCandidatePolicy.Pin): DriverCandidatePolicy.Classification {
+        val uuids = try { device.uuids?.map { it.uuid.toString() } } catch (e: Exception) { null }
+        val btClass = try { device.bluetoothClass } catch (e: Exception) { null }
+        val type = if (Build.VERSION.SDK_INT >= 18) {
+            try { device.type } catch (e: Exception) { DriverCandidatePolicy.DEVICE_TYPE_UNKNOWN }
+        } else {
+            DriverCandidatePolicy.DEVICE_TYPE_UNKNOWN
+        }
+        return DriverCandidatePolicy.classify(
+            uuids = uuids,
+            hasDeviceClass = btClass != null,
+            majorDeviceClass = btClass?.majorDeviceClass ?: 0,
+            deviceClass = btClass?.deviceClass ?: 0,
+            deviceType = type,
+            pin = pin
+        )
+    }
+
+    /** The last-connected MAC was written by a completed handshake; the preferred one was typed. */
+    fun pinFor(device: BluetoothDevice, preferredMac: String, lastConnectedMac: String): DriverCandidatePolicy.Pin {
+        val address = try { device.address } catch (_: Exception) { "" }
+        return when {
+            address.isEmpty() -> DriverCandidatePolicy.Pin.NONE
+            address.equals(lastConnectedMac, ignoreCase = true) -> DriverCandidatePolicy.Pin.PROVEN
+            address.equals(preferredMac, ignoreCase = true) -> DriverCandidatePolicy.Pin.USER
+            else -> DriverCandidatePolicy.Pin.NONE
+        }
+    }
+
+    private fun deviceClassOf(device: BluetoothDevice): Int =
+        try { device.bluetoothClass?.deviceClass ?: 0 } catch (e: Exception) { 0 }
+
+    /**
+     * Whether one device may stand as a phone, meaning it was not ruled out. Lists go through
+     * [driverCandidates]; this serves the pickers that ask about one device at a time.
      */
     fun isLikelyPhone(
         device: BluetoothDevice,
         preferredMac: String = "",
-        lastUsedMac: String = ""
-    ): Boolean {
-        val address = try { device.address } catch (_: Exception) { "" }
-        if (address.isNotEmpty()) {
-            if (address.equals(preferredMac, ignoreCase = true) || address.equals(lastUsedMac, ignoreCase = true)) {
-                return true
-            }
-        }
-
-        val btClass = try { device.bluetoothClass } catch (_: Exception) { null } ?: return true
-        val major = btClass.majorDeviceClass
-
-        // Definite non-phone peripherals: mice, keyboards, watches, printers
-        if (major == android.bluetooth.BluetoothClass.Device.Major.PERIPHERAL ||
-            major == android.bluetooth.BluetoothClass.Device.Major.WEARABLE ||
-            major == android.bluetooth.BluetoothClass.Device.Major.IMAGING) {
-            return false
-        }
-
-        // Filter out dedicated audio output accessories (speakers, headphones, headsets)
-        if (major == android.bluetooth.BluetoothClass.Device.Major.AUDIO_VIDEO) {
-            return when (btClass.deviceClass) {
-                android.bluetooth.BluetoothClass.Device.AUDIO_VIDEO_LOUDSPEAKER,
-                android.bluetooth.BluetoothClass.Device.AUDIO_VIDEO_HEADPHONES,
-                android.bluetooth.BluetoothClass.Device.AUDIO_VIDEO_WEARABLE_HEADSET,
-                android.bluetooth.BluetoothClass.Device.AUDIO_VIDEO_PORTABLE_AUDIO,
-                android.bluetooth.BluetoothClass.Device.AUDIO_VIDEO_HIFI_AUDIO -> false
-                else -> true
-            }
-        }
-
-        return true
-    }
-
-    /**
-     * Returns the list of bonded Bluetooth devices that are confirmed to be currently connected.
-     * Safe on all Android versions (SDK 16+).
-     */
-    fun getConnectedBluetoothDevices(context: Context): List<BluetoothDevice> {
-        val adapter = try {
-            getBluetoothAdapter(context)
-        } catch (e: Exception) {
-            null
-        } ?: return emptyList()
-
-        val bonded = try {
-            adapter.bondedDevices?.toList() ?: emptyList()
-        } catch (e: Exception) {
-            emptyList()
-        }
-
-        return bonded.filter { isDeviceConnected(it) }
-    }
+        lastConnectedMac: String = ""
+    ): Boolean = classifyDevice(device, pinFor(device, preferredMac, lastConnectedMac)).verdict !=
+        DriverCandidatePolicy.Verdict.NOT_A_PHONE
 
 
     /**

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -569,6 +569,14 @@ class Settings(private val context: Context) {
         set(value) { prefs.edit().putBoolean("wifi-direct-stable-identity", value).apply() }
 
     /**
+     * Below API 29 the platform names the group, so a "new identity" is a request to forget its
+     * stored profile at the next create. Persisted so a tap outlives the service and a reboot.
+     */
+    var wifiDirectRotationPending: Boolean
+        get() = prefs.getBoolean("wifi-direct-rotation-pending", false)
+        set(value) { prefs.edit().putBoolean("wifi-direct-rotation-pending", value).apply() }
+
+    /**
      * The kept pair, or null before the first bring-up draws one.
      *
      * Written by WifiDirectManager when the policy draws it, and by the settings screen's "new

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1087,6 +1087,8 @@
     <string name="wifi_direct_new_identity_none">سيتم الاختيار عند الاتصال التالي</string>
     <string name="wifi_direct_new_identity_confirm">يختار اسماً وكلمة مرور جديدة للمجموعة بدءاً من الاتصال التالي. سيتم إعداد هاتفك عبر البلوتوث وكأنها وحدة جديدة.</string>
     <string name="wifi_direct_new_identity_done">سيتم استخدام هوية شبكة جديدة بدءاً من الاتصال التالي.</string>
+    <string name="wifi_direct_new_identity_applied">يتم الآن إعداد هوية شبكة جديدة. سيُطلب من هاتفك الانضمام إليها عند الاتصال التالي.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">في هذا الإصدار من أندرويد يأتي اسم الشبكة من النظام، الذي يحتفظ بالاسم نفسه ما دام ذلك ممكناً. اترك هذا الخيار مفعّلاً ليعاود هاتفك الاتصال بشبكة يعرفها، واستخدم هوية جديدة أدناه إذا استمر في رفض الشبكة المحفوظة. عطّله لينسى النظام الشبكة قبل كل اتصال.</string>
     <string name="debug_video_low_latency">طلب وضع زمن الوصول المنخفض لمفكك التشفير</string>
     <string name="debug_video_low_latency_description">يضبط مفتاح MediaFormat المخصص للكمون المنخفض عند تكوين مفكك تشفير الفيديو.</string>
     <string name="debug_video_feed_hold">محاكاة مفكك تشفير بطيء</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1089,6 +1089,8 @@
     <string name="wifi_direct_new_identity_none">Bude vybráno při příštím připojení</string>
     <string name="wifi_direct_new_identity_confirm">Zvolí nový název a heslo pro skupinu od příštího připojení. Telefon se nastaví přes Bluetooth jako pro novou hlavní jednotku.</string>
     <string name="wifi_direct_new_identity_done">Od příštího připojení bude použita nová identita sítě.</string>
+    <string name="wifi_direct_new_identity_applied">Nová identita sítě se právě nastavuje. Telefon bude vyzván, aby se k ní připojil při příštím připojení.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">V této verzi Androidu určuje název sítě systém, který jej zachovává, dokud to jde. Nechte zapnuté, aby se telefon připojoval ke známé síti, a použijte novou identitu níže, pokud uloženou síť stále odmítá. Vypnutím systém zapomene síť před každým připojením.</string>
     <string name="debug_video_low_latency">Požádat o režim nízké latence dekodéru</string>
     <string name="debug_video_low_latency_description">Nastaví klíč MediaFormat nízké latence výrobce při konfiguraci videodekodéru.</string>
     <string name="debug_video_feed_hold">Simulovat pomalý dekodér</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1090,6 +1090,8 @@
     <string name="wifi_direct_new_identity_none">Wird bei der nächsten Verbindung festgelegt</string>
     <string name="wifi_direct_new_identity_confirm">Wählt einen neuen Namen und ein neues Passwort für die Gruppe, gültig ab der nächsten Verbindung. Dein Smartphone wird dafür über Bluetooth eingerichtet, als wäre dies ein neues Headunit. Nutze dies, wenn das Smartphone versucht, sich mit einem nicht mehr erreichbaren Netzwerk zu verbinden.</string>
     <string name="wifi_direct_new_identity_done">Ab der nächsten Verbindung wird eine neue Netzwerkidentität verwendet.</string>
+    <string name="wifi_direct_new_identity_applied">Eine neue Netzwerkidentität wird jetzt eingerichtet. Dein Smartphone wird bei der nächsten Verbindung aufgefordert, ihr beizutreten.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">In dieser Android-Version stammt der Netzwerkname vom System, das ihn so lange wie möglich beibehält. Lass die Option aktiviert, damit sich dein Smartphone wieder mit einem bekannten Netzwerk verbindet, und wähle unten eine neue Identität, falls es das gespeicherte Netzwerk weiterhin ablehnt. Deaktiviere sie, damit das System das Netzwerk vor jeder Verbindung vergisst.</string>
     <string name="debug_video_low_latency">Low-Latency-Modus für Decoder anfordern</string>
     <string name="debug_video_low_latency_description">Setzt beim Konfigurieren des Videodecoders den herstellerspezifischen Low-Latency-MediaFormat-Schlüssel. Fällt automatisch zurück, wenn der Decoder ihn ablehnt.</string>
     <string name="debug_video_feed_hold">Langsamen Decoder simulieren</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -1098,6 +1098,8 @@
     <string name="wifi_direct_new_identity_none">Se elegirá en la próxima conexión</string>
     <string name="wifi_direct_new_identity_confirm">Elige un nuevo nombre y contraseña para el grupo a partir de la próxima conexión. El teléfono se configurará por Bluetooth como si fuera una nueva unidad principal. Usa esto si el teléfono sigue intentando unirse a una red inaccesible.</string>
     <string name="wifi_direct_new_identity_done">Se utilizará una nueva identidad de red a partir de la próxima conexión.</string>
+    <string name="wifi_direct_new_identity_applied">Se está configurando una nueva identidad de red. Se pedirá al teléfono que se una a ella en la próxima conexión.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">En esta versión de Android el nombre de la red lo decide el sistema, que lo mantiene mientras puede. Déjalo activado para que el teléfono vuelva a conectarse a una red conocida, y usa una nueva identidad abajo si sigue rechazando la guardada. Desactívalo para que el sistema olvide la red antes de cada conexión.</string>
     <string name="debug_video_low_latency">Solicitar modo de baja latencia del decodificador</string>
     <string name="debug_video_low_latency_description">Establece la clave MediaFormat de baja latencia del fabricante al configurar el decodificador de vídeo. Vuelve atrás automáticamente si el decodificador la rechaza.</string>
     <string name="debug_video_feed_hold">Simular decodificador lento</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1097,6 +1097,8 @@
     <string name="wifi_direct_new_identity_none">Se elegirá en la próxima conexión</string>
     <string name="wifi_direct_new_identity_confirm">Elige un nuevo nombre y contraseña para el grupo a partir de la próxima conexión. El teléfono se configurará por Bluetooth como si fuera una nueva unidad principal. Usa esto si el teléfono sigue intentando unirse a una red inaccesible.</string>
     <string name="wifi_direct_new_identity_done">Se utilizará una nueva identidad de red a partir de la próxima conexión.</string>
+    <string name="wifi_direct_new_identity_applied">Se está configurando una nueva identidad de red. Se pedirá al teléfono que se una a ella en la próxima conexión.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">En esta versión de Android el nombre de la red lo decide el sistema, que lo mantiene mientras puede. Déjalo activado para que el teléfono vuelva a conectarse a una red conocida, y usa una nueva identidad abajo si sigue rechazando la guardada. Desactívalo para que el sistema olvide la red antes de cada conexión.</string>
     <string name="debug_video_low_latency">Solicitar modo de baja latencia del decodificador</string>
     <string name="debug_video_low_latency_description">Establece la clave MediaFormat de baja latencia del fabricante al configurar el decodificador de vídeo. Vuelve atrás automáticamente si el decodificador la rechaza.</string>
     <string name="debug_video_feed_hold">Simular decodificador lento</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1132,5 +1132,7 @@
     <string name="wifi_direct_new_identity_none">Choisie lors de la prochaine connexion</string>
     <string name="wifi_direct_new_identity_confirm">Choisit un nouveau nom et mot de passe pour le groupe, appliqués dès la prochaine connexion. Votre téléphone sera configuré via Bluetooth comme s\'il s\'agissait d\'un nouvel autoradio. Utilisez cette option si le téléphone persiste à essayer un réseau inaccessible.</string>
     <string name="wifi_direct_new_identity_done">Une nouvelle identité réseau sera utilisée dès la prochaine connexion.</string>
+    <string name="wifi_direct_new_identity_applied">Une nouvelle identité réseau est en cours de configuration. Votre téléphone sera invité à la rejoindre lors de la prochaine connexion.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">Sur cette version d\'Android, le nom du réseau vient du système, qui le conserve aussi longtemps que possible. Laissez cette option activée pour que votre téléphone rejoigne un réseau connu, et essayez une nouvelle identité ci-dessous s\'il refuse toujours le réseau enregistré. Désactivez-la pour que le système oublie le réseau avant chaque connexion.</string>
     <string name="debug_video_feed_hold">Simuler un décodeur lent</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1085,6 +1085,8 @@
     <string name="wifi_direct_new_identity_none">A következő csatlakozáskor lesz kiválasztva</string>
     <string name="wifi_direct_new_identity_confirm">Új nevet és jelszót választ a csoportnak a következő csatlakozástól kezdve.</string>
     <string name="wifi_direct_new_identity_done">A következő csatlakozástól új hálózati identitás lesz használatban.</string>
+    <string name="wifi_direct_new_identity_applied">Új hálózati identitás beállítása folyamatban. A telefon a következő csatlakozáskor kapja meg.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">Ezen az Android-verzión a hálózat nevét a rendszer adja, és ameddig lehet, meg is tartja. Hagyd bekapcsolva, hogy a telefon ismert hálózathoz csatlakozzon, és próbálj lent új identitást, ha továbbra is elutasítja a mentettet. Kikapcsolva a rendszer minden csatlakozás előtt elfelejti a hálózatot.</string>
     <string name="debug_video_low_latency">Dekóder alacsony késleltetésű mód kérése</string>
     <string name="debug_video_low_latency_description">Beállítja a gyártói alacsony késleltetésű MediaFormat kulcsot a videódekóder konfigurálásakor.</string>
     <string name="debug_video_feed_hold">Lassú dekóder szimulálása</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1092,6 +1092,8 @@
     <string name="wifi_direct_new_identity_none">Scelta alla prossima connessione</string>
     <string name="wifi_direct_new_identity_confirm">Sceglie un nuovo nome e password per il gruppo, applicati dalla prossima connessione. Il telefono verrà configurato via Bluetooth come se fosse una nuova unità.</string>
     <string name="wifi_direct_new_identity_done">Una nuova identità di rete verrà utilizzata dalla prossima connessione.</string>
+    <string name="wifi_direct_new_identity_applied">È in corso la configurazione di una nuova identità di rete. Al telefono verrà chiesto di collegarsi alla prossima connessione.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">In questa versione di Android il nome della rete lo sceglie il sistema, che lo mantiene finché può. Lascia attiva questa opzione perché il telefono si ricolleghi a una rete già nota, e prova una nuova identità qui sotto se continua a rifiutare quella salvata. Disattivala per far dimenticare la rete al sistema prima di ogni connessione.</string>
     <string name="debug_video_low_latency">Richiedi modalità a bassa latenza del decoder</string>
     <string name="debug_video_low_latency_description">Imposta la chiave proprietaria MediaFormat a bassa latenza durante la configurazione del decoder video.</string>
     <string name="debug_video_feed_hold">Simula un decoder lento</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1093,6 +1093,8 @@
     <string name="wifi_direct_new_identity_none">次回の接続時に決定されます</string>
     <string name="wifi_direct_new_identity_confirm">次回の接続から使用するグループの新しい名前とパスワードを選択します。新しいヘッドユニットであるかのようにBluetooth経由で設定されます。</string>
     <string name="wifi_direct_new_identity_done">次回の接続から新しいネットワークIDが使用されます。</string>
+    <string name="wifi_direct_new_identity_applied">新しいネットワークIDを設定しています。次回の接続時にスマートフォンへ通知されます。</string>
+    <string name="wifi_direct_stable_identity_description_legacy">このAndroidバージョンではネットワーク名をシステムが決め、可能な限り同じ名前を維持します。スマートフォンが既知のネットワークに再接続できるようオンのままにし、保存済みのネットワークを拒否し続ける場合は下で新しいIDをお試しください。オフにすると、接続のたびにシステムがネットワークを忘れます。</string>
     <string name="debug_video_low_latency">デコーダーの低遅延モードを要求</string>
     <string name="debug_video_low_latency_description">ビデオデコーダー設定時にベンダー独自の低遅延MediaFormatキーを設定します。</string>
     <string name="debug_video_feed_hold">低速デコーダーをシミュレート</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -1070,6 +1070,8 @@
     <string name="wifi_direct_new_identity_none">შეირჩევა შემდეგი დაკავშირებისას</string>
     <string name="wifi_direct_new_identity_confirm">ირჩევს ახალ სახელსა და პაროლს შემდეგი დაკავშირებისთვის.</string>
     <string name="wifi_direct_new_identity_done">ახალი ქსელის იდენტიფიკატორი გამოყენებული იქნება შემდეგი დაკავშირებისას.</string>
+    <string name="wifi_direct_new_identity_applied">ახალი ქსელის იდენტიფიკატორი ახლა კონფიგურირდება. ტელეფონი მას შემდეგი დაკავშირებისას მიიღებს.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">Android-ის ამ ვერსიაში ქსელის სახელს სისტემა ირჩევს და ინახავს მას რამდენადაც შესაძლებელია. დატოვეთ ჩართული, რომ ტელეფონი ნაცნობ ქსელს დაუკავშირდეს, და სცადეთ ახალი იდენტიფიკატორი ქვემოთ, თუ ის შენახულ ქსელს კვლავ უარყოფს. გამორთვისას სისტემა ქსელს ყოველ დაკავშირებამდე დაივიწყებს.</string>
     <string name="debug_video_low_latency">დეკოდერის დაბალი დაყოვნების რეჟიმის მოთხოვნა</string>
     <string name="debug_video_low_latency_description">აყენებს მწარმოებლის დაბალი დაყოვნების MediaFormat გასაღებს ვიდეო დეკოდერის კონფიგურაციისას.</string>
     <string name="debug_video_feed_hold">ნელი დეკოდერის სიმულაცია</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1086,6 +1086,8 @@
     <string name="wifi_direct_new_identity_none">다음 연결 시 선택됨</string>
     <string name="wifi_direct_new_identity_confirm">다음 연결부터 적용될 새 그룹 이름과 비밀번호를 선택합니다. 새 헤드유닛처럼 블루투스를 통해 설정됩니다.</string>
     <string name="wifi_direct_new_identity_done">다음 연결부터 새 네트워크 식별자가 사용됩니다.</string>
+    <string name="wifi_direct_new_identity_applied">새 네트워크 식별자를 설정하는 중입니다. 다음 연결 때 휴대폰에 전달됩니다.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">이 Android 버전에서는 네트워크 이름을 시스템이 정하며 가능한 한 같은 이름을 유지합니다. 휴대폰이 이미 아는 네트워크에 다시 연결되도록 켜 두고, 저장된 네트워크를 계속 거부하면 아래에서 새 식별자를 사용하세요. 끄면 연결할 때마다 시스템이 네트워크를 잊습니다.</string>
     <string name="debug_video_low_latency">디코더 저지연 모드 요청</string>
     <string name="debug_video_low_latency_description">비디오 디코더 설정 시 벤더 저지연 MediaFormat 키를 적용합니다.</string>
     <string name="debug_video_feed_hold">느린 디코더 시뮬레이션</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1089,6 +1089,8 @@
     <string name="wifi_direct_new_identity_none">Gekozen bij de volgende verbinding</string>
     <string name="wifi_direct_new_identity_confirm">Kiest een nieuwe naam en wachtwoord voor de groep vanaf de volgende verbinding. Je telefoon wordt via Bluetooth ingesteld alsof dit een nieuwe head-unit is.</string>
     <string name="wifi_direct_new_identity_done">Vanaf de volgende verbinding wordt een nieuwe netwerkidentiteit gebruikt.</string>
+    <string name="wifi_direct_new_identity_applied">Er wordt nu een nieuwe netwerkidentiteit ingesteld. Je telefoon krijgt bij de volgende verbinding het verzoek om er verbinding mee te maken.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">In deze Android-versie bepaalt het systeem de netwerknaam en houdt die zo lang mogelijk aan. Laat dit aan staan zodat je telefoon opnieuw verbindt met een bekend netwerk, en probeer hieronder een nieuwe identiteit als hij het opgeslagen netwerk blijft weigeren. Zet het uit om het systeem het netwerk voor elke verbinding te laten vergeten.</string>
     <string name="debug_video_low_latency">Lage-latentiemodus van decoder aanvragen</string>
     <string name="debug_video_low_latency_description">Stelt de propriëtaire MediaFormat-sleutel voor lage latentie in bij het configureren van de videodecoder.</string>
     <string name="debug_video_feed_hold">Trage decoder simuleren</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1088,6 +1088,8 @@
     <string name="wifi_direct_new_identity_none">Zostanie wybrana przy następnym połączeniu</string>
     <string name="wifi_direct_new_identity_confirm">Wybiera nową nazwę i hasło dla grupy od następnego połączenia. Telefon zostanie skonfigurowany przez Bluetooth jak dla nowej stacji.</string>
     <string name="wifi_direct_new_identity_done">Nowa tożsamość sieci zostanie użyta od następnego połączenia.</string>
+    <string name="wifi_direct_new_identity_applied">Trwa konfigurowanie nowej tożsamości sieci. Telefon otrzyma ją przy następnym połączeniu.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">W tej wersji Androida nazwę sieci ustala system i zachowuje ją tak długo, jak to możliwe. Zostaw tę opcję włączoną, aby telefon łączył się ze znaną siecią, a jeśli nadal odrzuca zapisaną, wypróbuj nową tożsamość poniżej. Wyłączenie sprawia, że system zapomina sieć przed każdym połączeniem.</string>
     <string name="debug_video_low_latency">Żądaj trybu niskiego opóźnienia dekodera</string>
     <string name="debug_video_low_latency_description">Ustawia klucz MediaFormat niskiego opóźnienia producenta podczas konfiguracji dekodera wideo.</string>
     <string name="debug_video_feed_hold">Symuluj wolny dekoder</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1090,6 +1090,8 @@
     <string name="wifi_direct_new_identity_none">Escolhida na próxima conexão</string>
     <string name="wifi_direct_new_identity_confirm">Escolhe um novo nome e senha para o grupo a partir da próxima conexão. O telefone será configurado por Bluetooth como se fosse uma nova central multimídia.</string>
     <string name="wifi_direct_new_identity_done">Uma nova identidade de rede será usada a partir da próxima conexão.</string>
+    <string name="wifi_direct_new_identity_applied">Uma nova identidade de rede está sendo configurada agora. O telefone será solicitado a entrar nela na próxima conexão.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">Nesta versão do Android o nome da rede vem do sistema, que o mantém enquanto pode. Deixe ativado para que o telefone se reconecte a uma rede conhecida, e use uma nova identidade abaixo se ele continuar recusando a rede salva. Desative para que o sistema esqueça a rede antes de cada conexão.</string>
     <string name="debug_video_low_latency">Solicitar modo de baixa latência do decodificador</string>
     <string name="debug_video_low_latency_description">Define a chave proprietária MediaFormat de baixa latência ao configurar o decodificador de vídeo.</string>
     <string name="debug_video_feed_hold">Simular decodificador lento</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1086,6 +1086,8 @@
     <string name="wifi_direct_new_identity_none">Se va alege la următoarea conexiune</string>
     <string name="wifi_direct_new_identity_confirm">Alege un nume și o parolă noi pentru grup începând cu următoarea conexiune.</string>
     <string name="wifi_direct_new_identity_done">O nouă identitate de rețea va fi utilizată de la următoarea conexiune.</string>
+    <string name="wifi_direct_new_identity_applied">O nouă identitate de rețea se configurează acum. Telefonului i se va cere să se conecteze la ea la următoarea conexiune.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">Pe această versiune de Android numele rețelei este stabilit de sistem, care îl păstrează cât timp poate. Lasă opțiunea activată pentru ca telefonul să se reconecteze la o rețea cunoscută și încearcă o identitate nouă mai jos dacă refuză în continuare rețeaua salvată. Dezactiveaz-o pentru ca sistemul să uite rețeaua înainte de fiecare conexiune.</string>
     <string name="debug_video_low_latency">Solicită mod de latență redusă a decodorului</string>
     <string name="debug_video_low_latency_description">Setează cheia MediaFormat proprietară de latență redusă la configurarea decodorului video.</string>
     <string name="debug_video_feed_hold">Simulează un decodor lent</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1088,6 +1088,8 @@
     <string name="wifi_direct_new_identity_none">Будет выбрано при следующем подключении</string>
     <string name="wifi_direct_new_identity_confirm">Выбирает новое имя и пароль для группы начиная со следующего подключения. Телефон настроится по Bluetooth как для новой магнитолы.</string>
     <string name="wifi_direct_new_identity_done">Новые параметры сети будут применены со следующего подключения.</string>
+    <string name="wifi_direct_new_identity_applied">Новые параметры сети настраиваются сейчас. Телефону будет предложено подключиться к этой сети при следующем подключении.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">В этой версии Android имя сети выбирает система и сохраняет его так долго, как может. Оставьте параметр включённым, чтобы телефон подключался к уже известной сети, и попробуйте новые параметры ниже, если он продолжает отклонять сохранённую. Выключите, чтобы система забывала сеть перед каждым подключением.</string>
     <string name="debug_video_low_latency">Запросить режим низкой задержки декодера</string>
     <string name="debug_video_low_latency_description">Устанавливает ключ MediaFormat низкой задержки производителя при настройке видеодекодера.</string>
     <string name="debug_video_feed_hold">Имитировать медленный декодер</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1084,6 +1084,8 @@
     <string name="wifi_direct_new_identity_none">Sonraki bağlantıda belirlenecek</string>
     <string name="wifi_direct_new_identity_confirm">Sonraki bağlantıdan itibaren grup için yeni bir ad ve şifre belirler. Telefonunuz yeni bir ana üniteymiş gibi Bluetooth üzerinden ayarlanacaktır.</string>
     <string name="wifi_direct_new_identity_done">Bir sonraki bağlantıdan itibaren yeni ağ kimliği kullanılacaktır.</string>
+    <string name="wifi_direct_new_identity_applied">Yeni bir ağ kimliği şimdi hazırlanıyor. Telefonunuzdan bir sonraki bağlantıda bu ağa katılması istenecek.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">Bu Android sürümünde ağ adını sistem belirler ve mümkün olduğu sürece aynı adı korur. Telefonunuzun bildiği bir ağa yeniden bağlanması için bunu açık bırakın; kaydedilmiş ağı reddetmeye devam ederse aşağıdan yeni bir kimlik deneyin. Kapatırsanız sistem her bağlantıdan önce ağı unutur.</string>
     <string name="debug_video_low_latency">Kod çözücü düşük gecikme modunu iste</string>
     <string name="debug_video_low_latency_description">Video kod çözücüyü yapılandırırken üreticinin düşük gecikmeli MediaFormat anahtarını ayarlar.</string>
     <string name="debug_video_feed_hold">Yavaş kod çözücüyü simüle et</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1090,6 +1090,8 @@
     <string name="wifi_direct_new_identity_none">Буде вибрано при наступному підключенні</string>
     <string name="wifi_direct_new_identity_confirm">Вибирає нове ім\'я та пароль для групи з наступного підключення.</string>
     <string name="wifi_direct_new_identity_done">Нова ідентичність мережі використовуватиметься з наступного підключення.</string>
+    <string name="wifi_direct_new_identity_applied">Нова ідентичність мережі налаштовується зараз. Телефон отримає її під час наступного підключення.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">У цій версії Android ім\'я мережі визначає система і зберігає його якомога довше. Залиште увімкненим, щоб телефон підключався до вже відомої мережі, і спробуйте нову ідентичність нижче, якщо він і далі відхиляє збережену. Вимкніть, щоб система забувала мережу перед кожним підключенням.</string>
     <string name="debug_video_low_latency">Запитати режим низької затримки декодера</string>
     <string name="debug_video_low_latency_description">Встановлює ключ MediaFormat низької затримки виробника під час налаштування відеодекодера.</string>
     <string name="debug_video_feed_hold">Імітувати повільний декодер</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1092,6 +1092,8 @@
     <string name="wifi_direct_new_identity_none">Được chọn ở lần kết nối tiếp theo</string>
     <string name="wifi_direct_new_identity_confirm">Chọn tên và mật khẩu mới cho nhóm áp dụng từ lần kết nối tiếp theo.</string>
     <string name="wifi_direct_new_identity_done">Danh tính mạng mới sẽ được sử dụng từ lần kết nối tiếp theo.</string>
+    <string name="wifi_direct_new_identity_applied">Danh tính mạng mới đang được thiết lập. Điện thoại sẽ được yêu cầu tham gia mạng này ở lần kết nối tiếp theo.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">Trên phiên bản Android này, tên mạng do hệ thống đặt và được giữ nguyên lâu nhất có thể. Hãy bật tùy chọn này để điện thoại kết nối lại với mạng đã biết, và thử một danh tính mới bên dưới nếu điện thoại vẫn từ chối mạng đã lưu. Tắt để hệ thống quên mạng trước mỗi lần kết nối.</string>
     <string name="debug_video_low_latency">Yêu cầu chế độ độ trễ thấp của bộ giải mã</string>
     <string name="debug_video_low_latency_description">Đặt khóa MediaFormat độ trễ thấp của nhà sản xuất khi định cấu hình bộ giải mã video.</string>
     <string name="debug_video_feed_hold">Mô phỏng bộ giải mã chậm</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1088,6 +1088,8 @@
     <string name="wifi_direct_new_identity_none">將於下次連線時選擇</string>
     <string name="wifi_direct_new_identity_confirm">為群組選擇新的名稱和密碼，並於下次連線時生效。手機將透過藍牙重新設定，猶如連至全新車機。</string>
     <string name="wifi_direct_new_identity_done">下次連線時將使用新的網路識別碼。</string>
+    <string name="wifi_direct_new_identity_applied">正在設定新的網路識別碼。下次連線時將要求您的手機加入該網路。</string>
+    <string name="wifi_direct_stable_identity_description_legacy">在此 Android 版本中，網路名稱由系統決定，並會盡可能維持不變。請保持開啟，讓手機重新連接已知的網路；若手機持續拒絕已儲存的網路，請在下方改用新的識別碼。關閉後，系統會在每次連線前忘記該網路。</string>
     <string name="debug_video_low_latency">請求解碼器低延遲模式</string>
     <string name="debug_video_low_latency_description">在設定視訊解碼器時設定廠商低延遲 MediaFormat 金鑰。</string>
     <string name="debug_video_feed_hold">模擬慢速解碼器</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -823,6 +823,8 @@
     <string name="wifi_direct_new_identity_none">Chosen at the next connection</string>
     <string name="wifi_direct_new_identity_confirm">Picks a new name and password for the group, used from the next connection on. Your phone will be set up for it over Bluetooth as if this were a new head unit. Do this if the phone keeps trying a network it can no longer join.</string>
     <string name="wifi_direct_new_identity_done">A new network identity will be used from the next connection.</string>
+    <string name="wifi_direct_new_identity_applied">A new network identity is being set up now. Your phone will be asked to join it on the next connection.</string>
+    <string name="wifi_direct_stable_identity_description_legacy">On this Android version the network name comes from the system, which keeps the same one for as long as it can. Leave this on so your phone rejoins a network it already knows, and use a new identity below if it keeps refusing the saved one. Turn it off to make the system forget the network before every connection.</string>
     <string name="debug_video_low_latency">Request decoder low-latency mode</string>
     <string name="debug_video_low_latency_description">Sets the vendor low-latency MediaFormat key when configuring the video decoder. Falls back automatically if the decoder rejects it.</string>
     <string name="debug_video_feed_hold">Simulate a slow decoder</string>

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/GroupIpResolutionPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/GroupIpResolutionPolicyTest.kt
@@ -1,0 +1,36 @@
+package com.andrerinas.openheadunit.connection.wifi.direct
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GroupIpResolutionPolicyTest {
+
+    @Test
+    fun `group owner reads the interface once and does not retry`() {
+        assertEquals(0, GroupIpResolutionPolicy.retriesAfterFirstRead(isGroupOwner = true))
+    }
+
+    @Test
+    fun `a client still waits out its lease, unchanged`() {
+        assertEquals(
+            GroupIpResolutionPolicy.CLIENT_RETRIES,
+            GroupIpResolutionPolicy.retriesAfterFirstRead(isGroupOwner = false)
+        )
+    }
+
+    @Test
+    fun `a readable address is used whoever we are`() {
+        assertEquals("192.168.49.37", GroupIpResolutionPolicy.resolve("192.168.49.37", isGroupOwner = true))
+        assertEquals("192.168.49.37", GroupIpResolutionPolicy.resolve("192.168.49.37", isGroupOwner = false))
+    }
+
+    @Test
+    fun `an unreadable interface falls back to the fixed address only for the owner`() {
+        assertEquals(
+            GroupIpResolutionPolicy.GROUP_OWNER_IP,
+            GroupIpResolutionPolicy.resolve(null, isGroupOwner = true)
+        )
+        assertNull(GroupIpResolutionPolicy.resolve(null, isGroupOwner = false))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/NativeRefreshPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/NativeRefreshPolicyTest.kt
@@ -44,4 +44,41 @@ class NativeRefreshPolicyTest {
     fun `a group we are only a client of is not ours to hand out`() {
         assertEquals(Action.RECREATE, NativeRefreshPolicy.decide(groupExists = true, isGroupOwner = false, createInFlightForMs = null))
     }
+
+    // --- an accepted create is left alone for the whole group-info window ---
+
+    @Test
+    fun `a create the platform accepted is not remade while it is still being read for`() {
+        // Past the grace, which is where the refresh used to remake the group under the reads.
+        assertEquals(
+            Action.WAIT,
+            NativeRefreshPolicy.decide(groupExists = false, isGroupOwner = false, createInFlightForMs = 16_000L, acceptedCreatePendingForMs = 16_000L)
+        )
+        assertEquals(
+            Action.WAIT,
+            NativeRefreshPolicy.decide(groupExists = false, isGroupOwner = false, createInFlightForMs = null, acceptedCreatePendingForMs = NativeRefreshPolicy.GROUP_INFO_WINDOW_MS - 1)
+        )
+    }
+
+    @Test
+    fun `an accepted create that outlived the group-info window is remade`() {
+        assertEquals(
+            Action.RECREATE,
+            NativeRefreshPolicy.decide(groupExists = false, isGroupOwner = false, createInFlightForMs = null, acceptedCreatePendingForMs = NativeRefreshPolicy.GROUP_INFO_WINDOW_MS)
+        )
+    }
+
+    @Test
+    fun `the group-info window covers the twenty one-second reads`() {
+        assertTrue(NativeRefreshPolicy.GROUP_INFO_WINDOW_MS > 20_000L)
+        assertTrue(NativeRefreshPolicy.GROUP_INFO_WINDOW_MS > NativeRefreshPolicy.CREATE_GRACE_MS)
+    }
+
+    @Test
+    fun `the recheck waits for the longer of the two windows`() {
+        assertEquals(NativeRefreshPolicy.CREATE_GRACE_MS - 1_000L + 500L, NativeRefreshPolicy.recheckDelayMs(1_000L, null))
+        assertEquals(NativeRefreshPolicy.GROUP_INFO_WINDOW_MS - 16_000L + 500L, NativeRefreshPolicy.recheckDelayMs(16_000L, 16_000L))
+        assertEquals(NativeRefreshPolicy.GROUP_INFO_WINDOW_MS - 2_000L + 500L, NativeRefreshPolicy.recheckDelayMs(2_000L, 2_000L))
+        assertEquals(500L, NativeRefreshPolicy.recheckDelayMs(null, null))
+    }
 }

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pCreateWedgePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pCreateWedgePolicyTest.kt
@@ -1,8 +1,10 @@
 package com.andrerinas.openheadunit.connection.wifi.direct
 
 import com.andrerinas.openheadunit.connection.wifi.direct.P2pCreateWedgePolicy.Step
+import com.andrerinas.openheadunit.connection.wifi.direct.P2pCreateWedgePolicy.Variant
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -64,5 +66,48 @@ class P2pCreateWedgePolicyTest {
     @Test
     fun `a refusal below the stall floor is still a pending create, not a refusal`() {
         assertFalse(P2pCreateWedgePolicy.isRefusalHonest(P2pCreateWedgePolicy.BUSY, 1_000L))
+    }
+
+    // --- the group-info loop running out is the stall, with no BUSY needed ---
+
+    @Test
+    fun `twenty empty group reads on an accepted create is a stall`() {
+        assertEquals(Step.CANCEL_FIRST, P2pCreateWedgePolicy.stepAfterGroupInfoExhausted(21_000L, cancelAlreadySpent = false))
+    }
+
+    @Test
+    fun `an exhausted loop with no accepted create, or a cancel already spent, cancels nothing`() {
+        assertEquals(Step.RETRY, P2pCreateWedgePolicy.stepAfterGroupInfoExhausted(null, cancelAlreadySpent = false))
+        assertEquals(Step.RETRY, P2pCreateWedgePolicy.stepAfterGroupInfoExhausted(21_000L, cancelAlreadySpent = true))
+        assertEquals(Step.RETRY, P2pCreateWedgePolicy.stepAfterGroupInfoExhausted(P2pCreateWedgePolicy.FRAMEWORK_CREATE_TIMEOUT_MS, cancelAlreadySpent = false))
+    }
+
+    // --- what is asked for after a cancel: the same request goes back accepted and hanging ---
+
+    @Test
+    fun `each cancel drops something the stuck create asked for`() {
+        assertEquals(Variant.NAMED_NO_BAND, P2pCreateWedgePolicy.nextAfterCancel(Variant.BANDED, cancelsSpent = 1))
+        assertEquals(Variant.FRAMEWORK_PROFILE, P2pCreateWedgePolicy.nextAfterCancel(Variant.NAMED_NO_BAND, cancelsSpent = 2))
+    }
+
+    @Test
+    fun `the framework profile is the last thing to try`() {
+        assertNull(P2pCreateWedgePolicy.nextAfterCancel(Variant.FRAMEWORK_PROFILE, cancelsSpent = 1))
+        assertNull(P2pCreateWedgePolicy.nextAfterCancel(Variant.FRAMEWORK_PROFILE, cancelsSpent = 3))
+    }
+
+    @Test
+    fun `the cancel budget is one per variant and nothing more`() {
+        assertEquals(3, P2pCreateWedgePolicy.MAX_CANCELS_PER_BRING_UP)
+        assertNull(P2pCreateWedgePolicy.nextAfterCancel(Variant.BANDED, cancelsSpent = P2pCreateWedgePolicy.MAX_CANCELS_PER_BRING_UP))
+        assertNull(P2pCreateWedgePolicy.nextAfterCancel(Variant.NAMED_NO_BAND, cancelsSpent = P2pCreateWedgePolicy.MAX_CANCELS_PER_BRING_UP))
+    }
+
+    @Test
+    fun `a banded create refused twice still has the profile left after the name`() {
+        // The banded rung was stuck, cancelled, then the named rung was stuck and cancelled.
+        assertEquals(Variant.FRAMEWORK_PROFILE, P2pCreateWedgePolicy.nextAfterCancel(Variant.NAMED_NO_BAND, cancelsSpent = 2))
+        // And the profile itself stuck: that is the end.
+        assertNull(P2pCreateWedgePolicy.nextAfterCancel(Variant.FRAMEWORK_PROFILE, cancelsSpent = 3))
     }
 }

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pCreateWedgePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pCreateWedgePolicyTest.kt
@@ -1,0 +1,68 @@
+package com.andrerinas.openheadunit.connection.wifi.direct
+
+import com.andrerinas.openheadunit.connection.wifi.direct.P2pCreateWedgePolicy.Step
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The ages are the ones #952's log measured: a create accepted at 14:16:42.69 that never formed a
+ * group, and the first rung after 120 s that was finally allowed through.
+ */
+class P2pCreateWedgePolicyTest {
+
+    private fun step(
+        reason: Int = P2pCreateWedgePolicy.BUSY,
+        age: Long? = 30_000L,
+        spent: Boolean = false,
+    ) = P2pCreateWedgePolicy.stepAfterBusy(reason, age, spent)
+
+    @Test
+    fun `a stuck create of ours is cancelled rather than retried`() {
+        assertEquals(Step.CANCEL_FIRST, step(age = 30_000L))
+        assertEquals(Step.CANCEL_FIRST, step(age = P2pCreateWedgePolicy.CREATE_STALL_FLOOR_MS))
+        assertEquals(Step.CANCEL_FIRST, step(age = P2pCreateWedgePolicy.FRAMEWORK_CREATE_TIMEOUT_MS - 1))
+    }
+
+    @Test
+    fun `a create that could still land is left alone`() {
+        assertEquals(Step.RETRY, step(age = 0L))
+        assertEquals(Step.RETRY, step(age = P2pCreateWedgePolicy.CREATE_STALL_FLOOR_MS - 1))
+    }
+
+    @Test
+    fun `nothing is cancelled once the platform has timed the create out itself`() {
+        assertEquals(Step.RETRY, step(age = P2pCreateWedgePolicy.FRAMEWORK_CREATE_TIMEOUT_MS))
+        assertEquals(Step.RETRY, step(age = 200_000L))
+    }
+
+    @Test
+    fun `a BUSY with no create of ours outstanding belongs to somebody else`() {
+        assertEquals(Step.RETRY, step(age = null))
+    }
+
+    @Test
+    fun `only BUSY means the platform is holding a creation`() {
+        assertEquals(Step.RETRY, step(reason = 0))
+        assertEquals(Step.RETRY, step(reason = 1))
+    }
+
+    @Test
+    fun `the cancel is spent once per stuck create`() {
+        assertEquals(Step.RETRY, step(spent = true))
+    }
+
+    @Test
+    fun `a refusal is honest unless our own create is still pending`() {
+        assertFalse(P2pCreateWedgePolicy.isRefusalHonest(P2pCreateWedgePolicy.BUSY, 30_000L))
+        assertTrue(P2pCreateWedgePolicy.isRefusalHonest(P2pCreateWedgePolicy.BUSY, null))
+        assertTrue(P2pCreateWedgePolicy.isRefusalHonest(P2pCreateWedgePolicy.BUSY, 200_000L))
+        assertTrue(P2pCreateWedgePolicy.isRefusalHonest(0, 30_000L))
+    }
+
+    @Test
+    fun `a refusal below the stall floor is still a pending create, not a refusal`() {
+        assertFalse(P2pCreateWedgePolicy.isRefusalHonest(P2pCreateWedgePolicy.BUSY, 1_000L))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pIdentityRotationPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pIdentityRotationPolicyTest.kt
@@ -1,0 +1,140 @@
+package com.andrerinas.openheadunit.connection.wifi.direct
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class P2pIdentityRotationPolicyTest {
+
+    // --- mechanism ---
+
+    @Test
+    fun `from API 29 the app names the group itself`() {
+        assertEquals(
+            P2pIdentityRotationPolicy.Mechanism.NAMED_RECREATE,
+            P2pIdentityRotationPolicy.mechanism(29)
+        )
+        assertEquals(
+            P2pIdentityRotationPolicy.Mechanism.NAMED_RECREATE,
+            P2pIdentityRotationPolicy.mechanism(36)
+        )
+    }
+
+    @Test
+    fun `below API 29 the stored profile is what has to go`() {
+        assertEquals(
+            P2pIdentityRotationPolicy.Mechanism.PURGE_PROFILE_THEN_RECREATE,
+            P2pIdentityRotationPolicy.mechanism(17)
+        )
+        assertEquals(
+            P2pIdentityRotationPolicy.Mechanism.PURGE_PROFILE_THEN_RECREATE,
+            P2pIdentityRotationPolicy.mechanism(28)
+        )
+    }
+
+    // --- applyNow ---
+
+    @Test
+    fun `an idle native WiFi Direct group is rotated now`() {
+        assertTrue(
+            P2pIdentityRotationPolicy.applyNow(
+                sessionLive = false,
+                handshakeInFlight = false,
+                nativeWifiDirectActive = true,
+            )
+        )
+        assertNull(
+            P2pIdentityRotationPolicy.deferralReason(
+                sessionLive = false,
+                handshakeInFlight = false,
+                nativeWifiDirectActive = true,
+            )
+        )
+    }
+
+    @Test
+    fun `a projecting session keeps its group`() {
+        assertFalse(
+            P2pIdentityRotationPolicy.applyNow(
+                sessionLive = true,
+                handshakeInFlight = false,
+                nativeWifiDirectActive = true,
+            )
+        )
+        assertTrue(
+            P2pIdentityRotationPolicy.deferralReason(
+                sessionLive = true,
+                handshakeInFlight = false,
+                nativeWifiDirectActive = true,
+            )!!.contains("projecting")
+        )
+    }
+
+    @Test
+    fun `a handshake mid-exchange keeps its group`() {
+        assertFalse(
+            P2pIdentityRotationPolicy.applyNow(
+                sessionLive = false,
+                handshakeInFlight = true,
+                nativeWifiDirectActive = true,
+            )
+        )
+    }
+
+    @Test
+    fun `nothing is rotated when this mode hosts no group`() {
+        assertFalse(
+            P2pIdentityRotationPolicy.applyNow(
+                sessionLive = false,
+                handshakeInFlight = false,
+                nativeWifiDirectActive = false,
+            )
+        )
+        assertNotNull(
+            P2pIdentityRotationPolicy.deferralReason(
+                sessionLive = false,
+                handshakeInFlight = false,
+                nativeWifiDirectActive = false,
+            )
+        )
+    }
+
+    // --- purgeBeforeCreate ---
+
+    @Test
+    fun `a pending rotation purges the stored profile below API 29`() {
+        assertTrue(
+            P2pIdentityRotationPolicy.purgeBeforeCreate(17, keepIdentity = true, rotationPending = true)
+        )
+    }
+
+    @Test
+    fun `a new network on every connection purges every create below API 29`() {
+        assertTrue(
+            P2pIdentityRotationPolicy.purgeBeforeCreate(17, keepIdentity = false, rotationPending = false)
+        )
+    }
+
+    @Test
+    fun `an ordinary create below API 29 keeps the profile the setting asks it to keep`() {
+        assertFalse(
+            P2pIdentityRotationPolicy.purgeBeforeCreate(17, keepIdentity = true, rotationPending = false)
+        )
+    }
+
+    @Test
+    fun `nothing is ever purged from API 29`() {
+        assertFalse(
+            P2pIdentityRotationPolicy.purgeBeforeCreate(29, keepIdentity = true, rotationPending = true)
+        )
+        assertFalse(
+            P2pIdentityRotationPolicy.purgeBeforeCreate(29, keepIdentity = false, rotationPending = true)
+        )
+        assertFalse(
+            P2pIdentityRotationPolicy.purgeBeforeCreate(36, keepIdentity = false, rotationPending = false)
+        )
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pIdentityRotationPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/P2pIdentityRotationPolicyTest.kt
@@ -56,6 +56,26 @@ class P2pIdentityRotationPolicyTest {
     }
 
     @Test
+    fun `a create still being answered is not built over`() {
+        assertFalse(
+            P2pIdentityRotationPolicy.applyNow(
+                sessionLive = false,
+                handshakeInFlight = false,
+                nativeWifiDirectActive = true,
+                createOutstanding = true,
+            )
+        )
+        assertNotNull(
+            P2pIdentityRotationPolicy.deferralReason(
+                sessionLive = false,
+                handshakeInFlight = false,
+                nativeWifiDirectActive = true,
+                createOutstanding = true,
+            )
+        )
+    }
+
+    @Test
     fun `a projecting session keeps its group`() {
         assertFalse(
             P2pIdentityRotationPolicy.applyNow(

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/StationStandDownSettlePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/direct/StationStandDownSettlePolicyTest.kt
@@ -1,0 +1,47 @@
+package com.andrerinas.openheadunit.connection.wifi.direct
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StationStandDownSettlePolicyTest {
+
+    @Test
+    fun `still associated inside the ceiling waits`() {
+        assertEquals(
+            StationStandDownSettlePolicy.Step.WAIT,
+            StationStandDownSettlePolicy.step(stillAssociated = true, waitedMs = 0)
+        )
+    }
+
+    @Test
+    fun `having left creates immediately`() {
+        assertEquals(
+            StationStandDownSettlePolicy.Step.CREATE,
+            StationStandDownSettlePolicy.step(stillAssociated = false, waitedMs = 0)
+        )
+    }
+
+    @Test
+    fun `the ceiling creates even while still associated`() {
+        assertEquals(
+            StationStandDownSettlePolicy.Step.CREATE,
+            StationStandDownSettlePolicy.step(
+                stillAssociated = true,
+                waitedMs = StationStandDownSettlePolicy.CEILING_MS
+            )
+        )
+    }
+
+    @Test
+    fun `an unreadable station does not hold the group up`() {
+        assertEquals(
+            StationStandDownSettlePolicy.Step.CREATE,
+            StationStandDownSettlePolicy.step(stillAssociated = null, waitedMs = 0)
+        )
+    }
+
+    @Test
+    fun `the ceiling is the verify delay it replaces`() {
+        assertEquals(StationStandDown.VERIFY_DELAY_MS, StationStandDownSettlePolicy.CEILING_MS)
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/DriverCandidatePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/DriverCandidatePolicyTest.kt
@@ -1,0 +1,206 @@
+package com.andrerinas.openheadunit.connection.wifi.modes.nativeaa
+
+import com.andrerinas.openheadunit.connection.wifi.modes.nativeaa.DriverCandidatePolicy.Pin
+import com.andrerinas.openheadunit.connection.wifi.modes.nativeaa.DriverCandidatePolicy.Reason
+import com.andrerinas.openheadunit.connection.wifi.modes.nativeaa.DriverCandidatePolicy.Verdict
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DriverCandidatePolicyTest {
+
+    private val audioGateway = DriverCandidatePolicy.HFP_AG_UUID
+    private val headsetGateway = DriverCandidatePolicy.HSP_AG_UUID
+    private val handsFree = DriverCandidatePolicy.HFP_HF_UUID
+    private val a2dpSink = DriverCandidatePolicy.A2DP_SINK_UUID
+    private val classic = 1
+
+    private fun classify(
+        uuids: List<String>? = null,
+        hasClass: Boolean = true,
+        major: Int = 0,
+        deviceClass: Int = 0,
+        type: Int = classic,
+        pin: Pin = Pin.NONE
+    ) = DriverCandidatePolicy.classify(uuids, hasClass, major, deviceClass, type, pin)
+
+    private fun assertVerdict(verdict: Verdict, reason: Reason, actual: DriverCandidatePolicy.Classification) {
+        assertEquals(DriverCandidatePolicy.Classification(verdict, reason), actual)
+    }
+
+    @Test
+    fun `the audio gateway record is a phone when the class does not rule it out`() {
+        assertVerdict(Verdict.PHONE, Reason.AUDIO_GATEWAY, classify(uuids = listOf(audioGateway), hasClass = false))
+        assertVerdict(Verdict.PHONE, Reason.AUDIO_GATEWAY, classify(uuids = listOf(headsetGateway)))
+        assertVerdict(
+            Verdict.PHONE, Reason.AUDIO_GATEWAY,
+            classify(uuids = listOf(audioGateway), major = DriverCandidatePolicy.MAJOR_PHONE, deviceClass = 0x020c)
+        )
+        assertVerdict(Verdict.PHONE, Reason.AUDIO_GATEWAY, classify(uuids = listOf(audioGateway), major = 0x0100))
+    }
+
+    @Test
+    fun `a head unit with its own dialer is not a phone despite its audio gateway record`() {
+        assertVerdict(
+            Verdict.NOT_A_PHONE, Reason.GATEWAY_BUT_CLASS_NOT_PHONE,
+            classify(uuids = listOf(audioGateway, handsFree), major = DriverCandidatePolicy.MAJOR_AUDIO_VIDEO, deviceClass = DriverCandidatePolicy.AV_HANDSFREE)
+        )
+        assertVerdict(
+            Verdict.NOT_A_PHONE, Reason.GATEWAY_BUT_CLASS_NOT_PHONE,
+            classify(uuids = listOf(headsetGateway), major = DriverCandidatePolicy.MAJOR_AUDIO_VIDEO, deviceClass = DriverCandidatePolicy.AV_CAR_AUDIO)
+        )
+        assertVerdict(
+            Verdict.NOT_A_PHONE, Reason.GATEWAY_BUT_CLASS_NOT_PHONE,
+            classify(uuids = listOf(audioGateway), major = DriverCandidatePolicy.MAJOR_WEARABLE, deviceClass = 0x0704)
+        )
+    }
+
+    @Test
+    fun `the reason names both the record and the class that overruled it`() {
+        val nav = classify(uuids = listOf(audioGateway), major = DriverCandidatePolicy.MAJOR_AUDIO_VIDEO, deviceClass = DriverCandidatePolicy.AV_HANDSFREE)
+        assertEquals(
+            "advertises the Audio Gateway record but device class 0x0408 is not a phone",
+            DriverCandidatePolicy.reasonText(nav, DriverCandidatePolicy.AV_HANDSFREE)
+        )
+    }
+
+    @Test
+    fun `a device carrying both halves of hands-free is a phone`() {
+        assertVerdict(Verdict.PHONE, Reason.AUDIO_GATEWAY, classify(uuids = listOf(handsFree, audioGateway)))
+    }
+
+    @Test
+    fun `a wireless dongle advertising only the hands-free unit is not a phone`() {
+        assertVerdict(
+            Verdict.NOT_A_PHONE, Reason.HANDS_FREE_UNIT,
+            classify(uuids = listOf(handsFree), major = DriverCandidatePolicy.MAJOR_AUDIO_VIDEO, deviceClass = DriverCandidatePolicy.AV_HANDSFREE)
+        )
+    }
+
+    @Test
+    fun `a car radio advertising hands-free unit and a2dp sink is not a phone`() {
+        assertVerdict(
+            Verdict.NOT_A_PHONE, Reason.HANDS_FREE_UNIT,
+            classify(uuids = listOf(handsFree, a2dpSink), major = DriverCandidatePolicy.MAJOR_AUDIO_VIDEO, deviceClass = DriverCandidatePolicy.AV_CAR_AUDIO)
+        )
+    }
+
+    @Test
+    fun `a headset advertising only a2dp sink is not a phone`() {
+        assertVerdict(
+            Verdict.NOT_A_PHONE, Reason.HANDS_FREE_UNIT,
+            classify(uuids = listOf(a2dpSink), major = DriverCandidatePolicy.MAJOR_AUDIO_VIDEO, deviceClass = DriverCandidatePolicy.AV_HEADPHONES)
+        )
+    }
+
+    @Test
+    fun `a watch bonded over low energy with no class is not a phone`() {
+        assertVerdict(
+            Verdict.NOT_A_PHONE, Reason.LOW_ENERGY_ONLY,
+            classify(uuids = null, hasClass = false, type = DriverCandidatePolicy.DEVICE_TYPE_LE)
+        )
+    }
+
+    @Test
+    fun `a classic watch is ruled out by its class`() {
+        assertVerdict(
+            Verdict.NOT_A_PHONE, Reason.CLASS_NOT_PHONE,
+            classify(major = DriverCandidatePolicy.MAJOR_WEARABLE, deviceClass = 0x0704)
+        )
+    }
+
+    @Test
+    fun `a phone whose records were never fetched is a phone by class`() {
+        assertVerdict(
+            Verdict.PHONE, Reason.CLASS_PHONE,
+            classify(uuids = null, major = DriverCandidatePolicy.MAJOR_PHONE, deviceClass = 0x020c)
+        )
+    }
+
+    @Test
+    fun `an unreadable class with no records is unknown, not a phone`() {
+        assertVerdict(Verdict.UNKNOWN, Reason.NO_SIGNAL, classify(uuids = null, hasClass = false))
+    }
+
+    @Test
+    fun `a computer class is unknown, never a phone`() {
+        assertVerdict(Verdict.UNKNOWN, Reason.NO_SIGNAL, classify(major = 0x0100, deviceClass = 0x010c))
+    }
+
+    @Test
+    fun `an audio device of an unlisted subclass is unknown, never a phone`() {
+        assertVerdict(
+            Verdict.UNKNOWN, Reason.NO_SIGNAL,
+            classify(major = DriverCandidatePolicy.MAJOR_AUDIO_VIDEO, deviceClass = 0x0430)
+        )
+    }
+
+    @Test
+    fun `an audio output class is not a phone`() {
+        for (subclass in listOf(
+            DriverCandidatePolicy.AV_LOUDSPEAKER, DriverCandidatePolicy.AV_HEADPHONES,
+            DriverCandidatePolicy.AV_WEARABLE_HEADSET, DriverCandidatePolicy.AV_PORTABLE_AUDIO,
+            DriverCandidatePolicy.AV_HIFI_AUDIO, DriverCandidatePolicy.AV_CAR_AUDIO,
+            DriverCandidatePolicy.AV_HANDSFREE, DriverCandidatePolicy.AV_MICROPHONE
+        )) {
+            assertVerdict(
+                Verdict.NOT_A_PHONE, Reason.CLASS_NOT_PHONE,
+                classify(major = DriverCandidatePolicy.MAJOR_AUDIO_VIDEO, deviceClass = subclass)
+            )
+        }
+    }
+
+    @Test
+    fun `record matching ignores case and an empty list reads as unfetched`() {
+        assertVerdict(Verdict.PHONE, Reason.AUDIO_GATEWAY, classify(uuids = listOf(audioGateway.uppercase())))
+        assertVerdict(
+            Verdict.PHONE, Reason.CLASS_PHONE,
+            classify(uuids = emptyList(), major = DriverCandidatePolicy.MAJOR_PHONE, deviceClass = 0x020c)
+        )
+    }
+
+    @Test
+    fun `a preferred pin never lifts a device that was ruled out`() {
+        assertVerdict(
+            Verdict.NOT_A_PHONE, Reason.LOW_ENERGY_ONLY,
+            classify(hasClass = false, type = DriverCandidatePolicy.DEVICE_TYPE_LE, pin = Pin.USER)
+        )
+        assertVerdict(
+            Verdict.NOT_A_PHONE, Reason.CLASS_NOT_PHONE,
+            classify(major = DriverCandidatePolicy.MAJOR_WEARABLE, deviceClass = 0x0704, pin = Pin.USER)
+        )
+        assertVerdict(
+            Verdict.NOT_A_PHONE, Reason.HANDS_FREE_UNIT,
+            classify(uuids = listOf(handsFree), pin = Pin.USER)
+        )
+        assertVerdict(
+            Verdict.NOT_A_PHONE, Reason.GATEWAY_BUT_CLASS_NOT_PHONE,
+            classify(uuids = listOf(audioGateway), major = DriverCandidatePolicy.MAJOR_AUDIO_VIDEO, deviceClass = DriverCandidatePolicy.AV_HANDSFREE, pin = Pin.USER)
+        )
+    }
+
+    @Test
+    fun `a preferred pin lifts only an unknown device`() {
+        assertVerdict(Verdict.PHONE, Reason.PINNED, classify(hasClass = false, pin = Pin.USER))
+        assertVerdict(Verdict.PHONE, Reason.PINNED, classify(major = 0x0100, pin = Pin.USER))
+    }
+
+    @Test
+    fun `a proven pin is a phone whatever the records and class say`() {
+        assertVerdict(
+            Verdict.PHONE, Reason.PINNED,
+            classify(uuids = listOf(handsFree), major = DriverCandidatePolicy.MAJOR_WEARABLE, type = DriverCandidatePolicy.DEVICE_TYPE_LE, pin = Pin.PROVEN)
+        )
+        assertVerdict(
+            Verdict.PHONE, Reason.PINNED,
+            classify(uuids = listOf(audioGateway), major = DriverCandidatePolicy.MAJOR_AUDIO_VIDEO, deviceClass = DriverCandidatePolicy.AV_HANDSFREE, pin = Pin.PROVEN)
+        )
+    }
+
+    @Test
+    fun `the offered tier is phones, else the unclassified, else nothing`() {
+        assertEquals(Verdict.PHONE, DriverCandidatePolicy.offeredVerdict(listOf(Verdict.NOT_A_PHONE, Verdict.UNKNOWN, Verdict.PHONE)))
+        assertEquals(Verdict.UNKNOWN, DriverCandidatePolicy.offeredVerdict(listOf(Verdict.NOT_A_PHONE, Verdict.UNKNOWN)))
+        assertEquals(Verdict.NOT_A_PHONE, DriverCandidatePolicy.offeredVerdict(listOf(Verdict.NOT_A_PHONE)))
+        assertEquals(Verdict.NOT_A_PHONE, DriverCandidatePolicy.offeredVerdict(emptyList()))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/EarlyWakePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/EarlyWakePolicyTest.kt
@@ -81,4 +81,35 @@ class EarlyWakePolicyTest {
     fun `credentials going away restarts the loop`() {
         assertTrue(EarlyWakePolicy.shouldRestartLoop(loopActive = true, previousKey = real, newKey = none))
     }
+
+    // --- a wake that brought the phone back to nothing is not repeated ---
+
+    @Test
+    fun `an early loop stops once its handshake ended for lack of credentials`() {
+        assertTrue(EarlyWakePolicy.stopAfterCredentialsFailure(loopStartedEmpty = true, credentialsPresent = false))
+    }
+
+    @Test
+    fun `a credentialed loop, or one whose credentials exist now, keeps going`() {
+        assertFalse(EarlyWakePolicy.stopAfterCredentialsFailure(loopStartedEmpty = false, credentialsPresent = false))
+        assertFalse(EarlyWakePolicy.stopAfterCredentialsFailure(loopStartedEmpty = true, credentialsPresent = true))
+    }
+
+    @Test
+    fun `a second empty wake waits for the credentials`() {
+        assertFalse(EarlyWakePolicy.mayStartWithoutCredentials(keyIsEmpty = true, earlyWakeSpent = true))
+        assertTrue(EarlyWakePolicy.mayStartWithoutCredentials(keyIsEmpty = true, earlyWakeSpent = false))
+    }
+
+    @Test
+    fun `a credentialed wake is never held by a spent early one`() {
+        assertTrue(EarlyWakePolicy.mayStartWithoutCredentials(keyIsEmpty = false, earlyWakeSpent = true))
+    }
+
+    @Test
+    fun `an empty key is all three fields empty`() {
+        assertTrue(EarlyWakePolicy.isEmptyKey(none))
+        assertFalse(EarlyWakePolicy.isEmptyKey(real))
+        assertFalse(EarlyWakePolicy.isEmptyKey(Triple("DIRECT-ab", "", "")))
+    }
 }

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/EarlyWakePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/EarlyWakePolicyTest.kt
@@ -1,0 +1,84 @@
+package com.andrerinas.openheadunit.connection.wifi.modes.nativeaa
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EarlyWakePolicyTest {
+
+    private val none = Triple("", "", "")
+    private val real = Triple("DIRECT-ab", "192.168.49.1", "aa:bb:cc:dd:ee:ff")
+
+    @Test
+    fun `wakes early once the listeners are open`() {
+        assertTrue(
+            EarlyWakePolicy.mayWakeBeforeCredentials(
+                listenersOpen = true, credentialsPresent = false,
+                userExited = false, sessionUp = false
+            )
+        )
+    }
+
+    @Test
+    fun `never wakes before the listeners are accepting`() {
+        assertFalse(
+            EarlyWakePolicy.mayWakeBeforeCredentials(
+                listenersOpen = false, credentialsPresent = false,
+                userExited = false, sessionUp = false
+            )
+        )
+    }
+
+    @Test
+    fun `credentials already there is the ordinary path, not the early one`() {
+        assertFalse(
+            EarlyWakePolicy.mayWakeBeforeCredentials(
+                listenersOpen = true, credentialsPresent = true,
+                userExited = false, sessionUp = false
+            )
+        )
+    }
+
+    @Test
+    fun `a user exit and a live session both hold the wake`() {
+        assertFalse(
+            EarlyWakePolicy.mayWakeBeforeCredentials(
+                listenersOpen = true, credentialsPresent = false,
+                userExited = true, sessionUp = false
+            )
+        )
+        assertFalse(
+            EarlyWakePolicy.mayWakeBeforeCredentials(
+                listenersOpen = true, credentialsPresent = false,
+                userExited = false, sessionUp = true
+            )
+        )
+    }
+
+    @Test
+    fun `credentials arriving under an early loop does not restart it`() {
+        assertFalse(EarlyWakePolicy.shouldRestartLoop(loopActive = true, previousKey = none, newKey = real))
+    }
+
+    @Test
+    fun `an unchanged key does not restart the loop`() {
+        assertFalse(EarlyWakePolicy.shouldRestartLoop(loopActive = true, previousKey = real, newKey = real))
+    }
+
+    @Test
+    fun `a genuinely new group restarts the loop`() {
+        val other = Triple("DIRECT-zz", "192.168.49.1", "11:22:33:44:55:66")
+        assertTrue(EarlyWakePolicy.shouldRestartLoop(loopActive = true, previousKey = real, newKey = other))
+    }
+
+    @Test
+    fun `no loop running always starts one`() {
+        assertTrue(EarlyWakePolicy.shouldRestartLoop(loopActive = false, previousKey = real, newKey = real))
+        assertTrue(EarlyWakePolicy.shouldRestartLoop(loopActive = false, previousKey = null, newKey = none))
+    }
+
+    @Test
+    fun `credentials going away restarts the loop`() {
+        assertTrue(EarlyWakePolicy.shouldRestartLoop(loopActive = true, previousKey = real, newKey = none))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/NativeDriverSelectionPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/connection/wifi/modes/nativeaa/NativeDriverSelectionPolicyTest.kt
@@ -611,4 +611,48 @@ class NativeDriverSelectionPolicyTest {
         assertFalse(NativeDriverSelectionPolicy.shouldRestateRefusal(-1L))
         assertFalse(NativeDriverSelectionPolicy.shouldRestateRefusal(Long.MIN_VALUE))
     }
+
+    // A watch that is connected must be scoped out before the counts reach the policy: the
+    // caller hands over phones only, and these pin what that buys.
+
+    @Test
+    fun `a connected watch scoped out keeps the one connected phone unambiguous`() {
+        assertFalse(NativeDriverSelectionPolicy.shouldShowSelector(Mode.AUTO, pairedCount = 2, connectedCount = 1))
+        assertTrue(NativeDriverSelectionPolicy.shouldShowSelector(Mode.AUTO, pairedCount = 2, connectedCount = 2))
+    }
+
+    @Test
+    fun `a connected device outside the phone list never wins over the phone`() {
+        val target = NativeDriverSelectionPolicy.resolveAutoConnectTarget(
+            preferredMac = "",
+            lastUsedMac = "",
+            connectedMacs = listOf("MAC_WATCH", "MAC_PHONE"),
+            pairedMacs = listOf("MAC_PHONE", "MAC_OTHER_PHONE")
+        )
+        assertEquals("MAC_PHONE", target)
+    }
+
+    @Test
+    fun `only a watch connected never returns the watch`() {
+        val target = NativeDriverSelectionPolicy.resolveAutoConnectTarget(
+            preferredMac = "",
+            lastUsedMac = "",
+            connectedMacs = listOf("MAC_WATCH"),
+            pairedMacs = listOf("MAC_PHONE", "MAC_OTHER_PHONE")
+        )
+        assertNull(target)
+    }
+
+    @Test
+    fun `a poke list naming only a watch is inert once the paired list is phones`() {
+        val lastUsed = NativeDriverSelectionPolicy.lastUsedMac("", setOf("MAC_WATCH"))
+        assertEquals("MAC_WATCH", lastUsed)
+        val target = NativeDriverSelectionPolicy.resolveAutoConnectTarget(
+            preferredMac = "",
+            lastUsedMac = lastUsed,
+            connectedMacs = emptyList(),
+            pairedMacs = listOf("MAC_PHONE", "MAC_OTHER_PHONE")
+        )
+        assertNull(target)
+    }
 }


### PR DESCRIPTION
Five commits on `main` (`12706e26`), 1489 unit tests. Tested on three devices over four hardware rounds: a UNISOC MT50 head unit (Android 14), a POCO X3 NFC and a Moto edge 30 neo, the two phones each serving as head unit for the other.

- **Recovery** (`97430ddf`, `16530fc9`): a `createGroup` the platform accepted and never formed is cancelled once it has aged instead of retrying into the 120 s BUSY wall, and re-asked with the band dropped first, then the name, then the app stops and says so; the stall is read off the empty group-info reads on `uptimeMillis`, and the refresh waits an accepted create out. A poke on a handshake manager that never started (mode armed with Bluetooth off) now starts it, and the one silent exit logs why. A handshake that found no credentials stops an early wake that started without them.
- **Identity** (`03776bf6`): below API 29 "New WiFi Direct network identity" purges this unit's stored profile, so the rename reaches the air on units where the app cannot name the group.
- **Speed** (`b5617bd5`): the credentials no longer wait up to fifteen seconds for an interface IP that is always `192.168.49.1`, group info is read immediately after the create, the station stand-down is a ceiling rather than a fixed delay, and the phone is woken while the group forms in one running loop that credential re-deliveries no longer restart. `AapService creating` to `SSL handshake complete` went from 14.5 s to about 10 s on the MT50.
- **Driver selection** (`289595df`, plus the Save fix in `16530fc9`): a driver candidate is a phone by its Audio Gateway record unless its device class rules it out, so a watch, a wireless AA dongle, a car radio and three head units with their own dialer are no longer offered, poked or auto-connected; the selector survives an activity relaunch while it opens, which on `main` kills the process on every launch for a user with two phones bonded; and five settings switches that wrote straight to preferences now stage a value and light Save.
