### PR TITLE
Some fixes to the floating button & added the connection statues feature and its toggle

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/main/FloatingButtonService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/FloatingButtonService.kt
@@ -21,12 +21,20 @@ import androidx.core.content.ContextCompat
 import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.R
 import com.andrerinas.openheadunit.utils.AppLog
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
 class FloatingButtonService : Service() {
 
     private var overlayView: View? = null
     private val mainHandler = Handler(Looper.getMainLooper())
+    private val serviceScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+    private var sessionJob: Job? = null
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -37,6 +45,13 @@ class FloatingButtonService : Service() {
                 startForeground(NOTIFICATION_ID, createNotification())
             } catch (e: Exception) {
                 AppLog.e("FloatingButtonService: startForeground failed: ${e.message}", e)
+            }
+        }
+
+        val commManager = App.provide(this).commManager
+        sessionJob = serviceScope.launch {
+            commManager.connectionState.collect { _ ->
+                mainHandler.post { showOrUpdateOverlay() }
             }
         }
     }
@@ -93,7 +108,16 @@ class FloatingButtonService : Service() {
 
         val xPx = ((settings.floatingButtonXPercent / 100f) * maxX).roundToInt()
         val yPx = ((settings.floatingButtonYPercent / 100f) * maxY).roundToInt()
-        val alpha = (settings.floatingButtonOpacityPercent / 100f).coerceIn(0.0f, 1.0f)
+
+        val commManager = App.provide(appContext).commManager
+        val isConnected = commManager.isConnected
+        val isConnectionStatusMode = settings.floatingButtonConnectionStatusMode
+        val configuredAlpha = (settings.floatingButtonOpacityPercent / 100f).coerceIn(0.0f, 1.0f)
+        val targetAlpha = if (isConnectionStatusMode && !isConnected) {
+            0.0f
+        } else {
+            configuredAlpha
+        }
 
         if (overlayView == null) {
             val button = ImageView(appContext).apply {
@@ -101,7 +125,7 @@ class FloatingButtonService : Service() {
                 scaleType = ImageView.ScaleType.FIT_CENTER
                 setBackgroundResource(R.drawable.bg_floating_button)
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                    elevation = if (alpha > 0f) 8f * density else 0f
+                    elevation = if (targetAlpha > 0f) 8f * density else 0f
                     outlineProvider = ViewOutlineProvider.BACKGROUND
                     clipToOutline = true
                 }
@@ -135,7 +159,7 @@ class FloatingButtonService : Service() {
                 }
             }
 
-            button.alpha = alpha
+            button.alpha = targetAlpha
 
             try {
                 windowManager.addView(button, layoutParams)
@@ -152,9 +176,9 @@ class FloatingButtonService : Service() {
             layoutParams.height = sizePx
             layoutParams.x = xPx
             layoutParams.y = yPx
-            button.alpha = alpha
+            button.animate().alpha(targetAlpha).setDuration(300).start()
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                button.elevation = if (alpha > 0f) 8f * density else 0f
+                button.elevation = if (targetAlpha > 0f) 8f * density else 0f
             }
 
             try {
@@ -181,6 +205,8 @@ class FloatingButtonService : Service() {
     }
 
     override fun onDestroy() {
+        sessionJob?.cancel()
+        serviceScope.cancel()
         super.onDestroy()
         removeOverlay()
     }

--- a/app/src/main/java/com/andrerinas/openheadunit/main/FloatingButtonService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/FloatingButtonService.kt
@@ -66,8 +66,17 @@ class FloatingButtonService : Service() {
     @SuppressLint("MissingPermission")
     private fun showOrUpdateOverlay() {
         val appContext = applicationContext
-        val windowManager = (appContext.getSystemService(WINDOW_SERVICE) as? WindowManager) ?: return
         val settings = App.provide(appContext).settings
+        val enabled = settings.enableFloatingButton
+        val permissionGranted = FloatingButtonManager.hasOverlayPermission(appContext)
+        val shouldShow = enabled && permissionGranted && !FloatingButtonManager.isAppForeground
+
+        if (!shouldShow) {
+            removeOverlay()
+            return
+        }
+
+        val windowManager = (appContext.getSystemService(WINDOW_SERVICE) as? WindowManager) ?: return
 
         val displayMetrics = DisplayMetrics()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
@@ -158,6 +167,7 @@ class FloatingButtonService : Service() {
     }
 
     private fun removeOverlay() {
+        mainHandler.removeCallbacksAndMessages(null)
         val view = overlayView ?: return
         try {
             val windowManager = applicationContext.getSystemService(WINDOW_SERVICE) as? WindowManager

--- a/app/src/main/java/com/andrerinas/openheadunit/main/FloatingButtonService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/FloatingButtonService.kt
@@ -31,7 +31,9 @@ import kotlin.math.roundToInt
 
 class FloatingButtonService : Service() {
 
-    private var overlayView: View? = null
+    private var overlayView: View?
+        get() = activeOverlayView
+        set(value) { activeOverlayView = value }
     private val mainHandler = Handler(Looper.getMainLooper())
     private val serviceScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private var sessionJob: Job? = null
@@ -225,6 +227,10 @@ class FloatingButtonService : Service() {
     companion object {
         const val ACTION_STOP = "com.andrerinas.openheadunit.ACTION_STOP_FLOATING_BUTTON"
         private const val NOTIFICATION_ID = 1002
+
+        @Volatile
+        @SuppressLint("StaticFieldLeak")
+        private var activeOverlayView: View? = null
 
         fun start(context: Context) {
             val intent = Intent(context, FloatingButtonService::class.java)

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -214,6 +214,7 @@ class SettingsFragment : Fragment() {
     private var pendingHotspotInterface: String? = null
 
     private var pendingEnableFloatingButton: Boolean? = null
+    private var pendingFloatingButtonConnectionStatusMode: Boolean? = null
     private var pendingFloatingButtonSizeDp: Int? = null
     private var pendingFloatingButtonOpacityPercent: Int? = null
     private var pendingFloatingButtonXPercent: Int? = null
@@ -352,6 +353,7 @@ class SettingsFragment : Fragment() {
         pendingAppLanguage = settings.appLanguage
 
         pendingEnableFloatingButton = settings.enableFloatingButton
+        pendingFloatingButtonConnectionStatusMode = settings.floatingButtonConnectionStatusMode
         pendingFloatingButtonSizeDp = settings.floatingButtonSizeDp
         pendingFloatingButtonOpacityPercent = settings.floatingButtonOpacityPercent
         pendingFloatingButtonXPercent = settings.floatingButtonXPercent
@@ -487,6 +489,7 @@ class SettingsFragment : Fragment() {
         pendingScreenOrientation = settings.screenOrientation
         pendingAppLanguage = settings.appLanguage
         pendingEnableFloatingButton = settings.enableFloatingButton
+        pendingFloatingButtonConnectionStatusMode = settings.floatingButtonConnectionStatusMode
         pendingFloatingButtonSizeDp = settings.floatingButtonSizeDp
         pendingFloatingButtonOpacityPercent = settings.floatingButtonOpacityPercent
         pendingFloatingButtonXPercent = settings.floatingButtonXPercent
@@ -717,6 +720,7 @@ class SettingsFragment : Fragment() {
 
         // Save the stretch to fill preference
         pendingEnableFloatingButton?.let { settings.enableFloatingButton = it }
+        pendingFloatingButtonConnectionStatusMode?.let { settings.floatingButtonConnectionStatusMode = it }
         pendingFloatingButtonSizeDp?.let { settings.floatingButtonSizeDp = it }
         pendingFloatingButtonOpacityPercent?.let { settings.floatingButtonOpacityPercent = it }
         pendingFloatingButtonXPercent?.let { settings.floatingButtonXPercent = it }
@@ -848,6 +852,7 @@ class SettingsFragment : Fragment() {
                         pendingScreenOrientation != settings.screenOrientation ||
                         pendingAppLanguage != settings.appLanguage ||
                         pendingEnableFloatingButton != settings.enableFloatingButton ||
+                        pendingFloatingButtonConnectionStatusMode != settings.floatingButtonConnectionStatusMode ||
                         pendingFloatingButtonSizeDp != settings.floatingButtonSizeDp ||
                         pendingFloatingButtonOpacityPercent != settings.floatingButtonOpacityPercent ||
                         pendingFloatingButtonXPercent != settings.floatingButtonXPercent ||
@@ -1720,6 +1725,17 @@ class SettingsFragment : Fragment() {
         ))
 
         if (isFloatingButtonEnabled) {
+            val connectionStatusMode = pendingFloatingButtonConnectionStatusMode ?: settings.floatingButtonConnectionStatusMode
+            items.add(SettingItem.ToggleSettingEntry(
+                stableId = "floatingButtonConnectionStatusMode",
+                nameResId = R.string.pref_floating_button_connection_status_title,
+                descriptionResId = R.string.pref_floating_button_connection_status_summary,
+                isChecked = connectionStatusMode,
+                onCheckedChanged = { isChecked ->
+                    pendingFloatingButtonConnectionStatusMode = isChecked
+                    checkChanges()
+                }
+            ))
             val size = pendingFloatingButtonSizeDp ?: settings.floatingButtonSizeDp
             items.add(SettingItem.SliderSettingEntry(
                 stableId = "floatingButtonSizeDp",

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -1757,7 +1757,7 @@ class SettingsFragment : Fragment() {
                 nameResId = R.string.pref_floating_button_opacity_title,
                 value = "${opacity}%",
                 sliderValue = opacity.toFloat(),
-                valueFrom = 10f,
+                valueFrom = 0f,
                 valueTo = 100f,
                 stepSize = 5f,
                 onValueChanged = { newVal ->

--- a/app/src/main/java/com/andrerinas/openheadunit/main/settings/SettingsAdapter.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/settings/SettingsAdapter.kt
@@ -284,6 +284,14 @@ class SettingsAdapter : ListAdapter<SettingItem, RecyclerView.ViewHolder>(Settin
                 override fun onProgressChanged(seekBar: android.widget.SeekBar?, progress: Int, fromUser: Boolean) {
                     if (fromUser) {
                         val newValue = setting.valueFrom + (progress.toFloat() / steps) * range
+                        val intVal = newValue.toInt()
+                        val suffix = when {
+                            setting.value.endsWith("%") -> "%"
+                            setting.value.endsWith("dp") -> "dp"
+                            setting.value.endsWith("s") -> "s"
+                            else -> ""
+                        }
+                        settingValue.text = "$intVal$suffix"
                         setting.onValueChanged(newValue)
                     }
                 }

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -115,6 +115,10 @@ class Settings(private val context: Context) {
         get() = prefs.getBoolean("enable-floating-button", false)
         set(value) { prefs.edit().putBoolean("enable-floating-button", value).apply() }
 
+    var floatingButtonConnectionStatusMode: Boolean
+        get() = prefs.getBoolean("floating-button-connection-status-mode", true)
+        set(value) { prefs.edit().putBoolean("floating-button-connection-status-mode", value).apply() }
+
     var floatingButtonXPercent: Int
         get() = prefs.getInt("floating-button-x-percent", 0)
         set(value) { prefs.edit().putInt("floating-button-x-percent", value.coerceIn(0, 100)).apply() }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -508,6 +508,8 @@
     <string name="category_more_features">More Features</string>
     <string name="pref_enable_floating_button_title">Floating Launcher Button</string>
     <string name="pref_enable_floating_button_summary">Displays a floating button over the OEM launcher and other apps to quickly return to Open Headunit</string>
+    <string name="pref_floating_button_connection_status_title" translatable="false">Connection Status Indicator</string>
+    <string name="pref_floating_button_connection_status_summary" translatable="false">Hide button when disconnected and fade in during active projection</string>
     <string name="pref_floating_button_size_title">Floating Button Size</string>
     <string name="pref_floating_button_opacity_title">Floating Button Opacity</string>
     <string name="pref_floating_button_x_title">Horizontal Position (X)</string>


### PR DESCRIPTION
fix(ui): prevent race condition where floating button overlay displays during active projection

- Re-check shouldShow (!isAppForeground) inside showOrUpdateOverlay before adding view to WindowManager.
- Cancel pending mainHandler posts in removeOverlay when service receives ACTION_STOP or is destroyed.

feat(ui): add Connection Status Indicator mode for floating launcher button

- Add floatingButtonConnectionStatusMode setting to Settings and SettingsFragment
- Observe commManager.connectionState in FloatingButtonService to dynamically fade in button during active projection and hide when disconnected
- Animate alpha transitions (300ms) and adjust elevation dynamically

fix(ui): update floating button opacity slider minimum to 0% and enable real-time slider text updates

- Change floatingButtonOpacityPercent slider minimum (valueFrom) in SettingsFragment from 10% to 0%
- Update SettingsAdapter onProgressChanged to update slider value text in real-time as user drags settings sliders

fix(ui): track overlay view statically in FloatingButtonService across service restarts

- Delegate overlayView getter/setter to @Volatile activeOverlayView in companion object
- Prevents WindowManager duplicate view addition exceptions during rapid background/foreground transitions